### PR TITLE
Lazy binheap prepare

### DIFF
--- a/lib/c0/c0.c
+++ b/lib/c0/c0.c
@@ -275,6 +275,12 @@ c0_cursor_create(
 }
 
 void
+c0_cursor_prepare(struct c0_cursor *cur)
+{
+    c0sk_cursor_prepare(cur);
+}
+
+void
 c0_cursor_bind_txn(struct c0_cursor *c0cur, struct kvdb_ctxn *ctxn)
 {
     c0sk_cursor_bind_txn(c0cur, ctxn);

--- a/lib/c0/c0.c
+++ b/lib/c0/c0.c
@@ -336,10 +336,7 @@ c0_cursor_es_get(struct c0_cursor *c0cur)
 merr_t
 c0_cursor_update(struct c0_cursor *c0cur, u64 seqno, u32 *flags_out)
 {
-    merr_t err;
-
-    err = c0sk_cursor_update(c0cur, seqno, flags_out);
-    return ev(err);
+    return c0sk_cursor_update(c0cur, seqno, flags_out);
 }
 
 merr_t

--- a/lib/c0/c0_kvmultiset.c
+++ b/lib/c0/c0_kvmultiset.c
@@ -336,7 +336,7 @@ c0kvms_cursor_unget(struct element_source *es)
     return true;
 }
 
-static void
+void
 c0kvms_cursor_prepare(struct c0_kvmultiset_cursor *cur)
 {
     bin_heap2_prepare(cur->c0mc_bh, cur->c0mc_iterc, cur->c0mc_esrcv);
@@ -553,7 +553,6 @@ c0kvms_cursor_create(
         return err;
     }
 
-    c0kvms_cursor_prepare(cur);
     return 0;
 }
 

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -1466,10 +1466,7 @@ cn_cursor_create(
 merr_t
 cn_cursor_prepare(struct cn_cursor *cur)
 {
-    merr_t err;
-
-    err = cn_tree_cursor_prepare(cur);
-    return ev(err);
+    return cn_tree_cursor_prepare(cur);
 }
 
 merr_t

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -1464,6 +1464,15 @@ cn_cursor_create(
 }
 
 merr_t
+cn_cursor_prepare(struct cn_cursor *cur)
+{
+    merr_t err;
+
+    err = cn_tree_cursor_prepare(cur);
+    return ev(err);
+}
+
+merr_t
 cn_cursor_update(struct cn_cursor *cur, u64 seqno, bool *updated)
 {
     u64    dgen = atomic64_read(&cur->cn->cn_ingest_dgen);

--- a/lib/cn/cn_cursor.h
+++ b/lib/cn/cn_cursor.h
@@ -94,6 +94,10 @@ cn_cursor_create(
 
 /* MTF_MOCK */
 merr_t
+cn_cursor_prepare(struct cn_cursor *cur);
+
+/* MTF_MOCK */
+merr_t
 cn_cursor_update(struct cn_cursor *cursor, u64 seqno, bool *updated);
 
 /* MTF_MOCK */

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -2441,11 +2441,12 @@ cn_tree_cursor_read(struct cn_cursor *cur, struct kvs_cursor_element *elem, bool
         bin_heap2_pop(cur->bh, (void **)&popme);
 
         rc = cur_item_pfx_cmp(cur, &item);
-        assert(rc <= 0);
         if (rc < 0) {
             *eof = (cur->eof = 1);
             return 0;
         }
+
+        assert(rc <= 0);
 
         if (HSE_UNLIKELY(cur->filter && key_obj_cmp(&item.kobj, &filter_ko) > 0)) {
             *eof = (cur->eof = 1);

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -2050,10 +2050,6 @@ cn_tree_cursor_create(struct cn_cursor *cur, struct cn_tree *tree)
     if (ev(err))
         goto errout;
 
-    err = bin_heap2_prepare(cur->bh, cur->iterc, cur->esrcv);
-    if (ev(err))
-        goto errout;
-
     cursor_summary_add_dgen(cur->summary, cur->dgen);
     cur->summary->n_kvset = cur->iterc;
 
@@ -2066,6 +2062,20 @@ errout:
     vtc_free(view);
 
     return err;
+}
+
+merr_t
+cn_tree_cursor_prepare(struct cn_cursor *cur)
+{
+    merr_t err;
+
+    if (!cur->bh) {
+        assert(cur->eof);
+        return 0;
+    }
+
+    err = bin_heap2_prepare(cur->bh, cur->iterc, cur->esrcv);
+    return ev(err);
 }
 
 static merr_t
@@ -2396,15 +2406,13 @@ cn_tree_cursor_read(struct cn_cursor *cur, struct kvs_cursor_element *elem, bool
 {
     struct cn_kv_item   item, *popme;
     u64                 seq;
-    bool                end;
-    bool                is_tomb;
+    bool                found;
     const void *        vdata;
     uint                vlen;
     uint                complen;
     int                 rc;
     struct kv_iterator *kv_iter = 0;
     struct key_obj      filter_ko = { 0 };
-    uint                nkeys_before_pfx_dbg HSE_MAYBE_UNUSED;
 
     if (ev(cur->merr))
         return cur->merr;
@@ -2417,104 +2425,83 @@ cn_tree_cursor_read(struct cn_cursor *cur, struct kvs_cursor_element *elem, bool
     if (HSE_UNLIKELY(cur->filter))
         key2kobj(&filter_ko, cur->filter->kcf_maxkey, cur->filter->kcf_maxklen);
 
-    nkeys_before_pfx_dbg = 0;
-
     do {
+        enum kmd_vtype vtype;
+        u32            vbidx;
+        u32            vboff;
 
         if (!bin_heap2_peek(cur->bh, (void **)&popme)) {
             *eof = (cur->eof = 1);
             return 0;
         }
 
-        /* copy out bh item before bin_heap2_pop() overwrites its
-         * element (*popme).
+        /* Copy out bh item before bin_heap2_pop() overwrites its element (*popme).
          */
         item = *popme;
-        is_tomb = item.vctx.is_ptomb;
-
         bin_heap2_pop(cur->bh, (void **)&popme);
 
         rc = cur_item_pfx_cmp(cur, &item);
-        if (rc > 0) {
-            /* [HSE_REVISIT] cursor seek should seek to max(cursor_pfx, seek_key) to avoid
-             * this code path.
-             */
-            ++nkeys_before_pfx_dbg;
-            end = true;
-            continue;
-        } else if (rc < 0) {
+        assert(rc <= 0);
+        if (rc < 0) {
             *eof = (cur->eof = 1);
             return 0;
         }
 
-        if (HSE_UNLIKELY(cur->filter)) {
-            if (key_obj_cmp(&item.kobj, &filter_ko) > 0) {
-                *eof = (cur->eof = 1);
-                return 0;
-            }
+        if (HSE_UNLIKELY(cur->filter && key_obj_cmp(&item.kobj, &filter_ko) > 0)) {
+            *eof = (cur->eof = 1);
+            return 0;
         }
 
         kv_iter = kvset_cursor_es_h2r(item.src);
-        end = false;
+        found = true;
 
         do {
-            enum kmd_vtype vtype;
-            u32            vbidx;
-            u32            vboff;
-
-            if (!kvset_iter_next_vref(
-                    kv_iter, &item.vctx, &seq, &vtype, &vbidx,
-                    &vboff, &vdata, &vlen, &complen)) {
-                end = true;
+            if (!kvset_iter_next_vref(kv_iter, &item.vctx, &seq, &vtype, &vbidx,
+                                      &vboff, &vdata, &vlen, &complen)) {
+                found = false; /* Exhausted all values. */
                 break;
             }
-
-            cur->merr =
-                kvset_iter_next_val(kv_iter, &item.vctx, vtype, vbidx,
-                    vboff, &vdata, &vlen, &complen);
-            if (ev(cur->merr))
-                return cur->merr;
-
         } while (seq > cur->seqno);
-        if (end)
-            continue;
 
-        if (HSE_CORE_IS_PTOMB(vdata) &&
-            (!cur->pt_set || key_obj_cmp(&cur->pt_kobj, &item.kobj) != 0)) {
-            /* only store ptomb w/ highest seqno (less than cur's seqno)
-             * i.e. first occurrence of this ptomb
-             */
-            assert(cur->ct_pfx_len > 0);
-            cur->pt_set = 1;
-            cur->pt_kobj = item.kobj;
-            cur->pt_seq = seq;
+        if (!found)
+            continue; /* Key doesn't have a value in the cursor's view. */
 
-            /* [HSE_REVISIT]
-             * if ptomb, move all srcs > item->src past pfx only if
-             * ptomb was NOT from the spread region.
-             */
-        }
-
-        /* A kvset can have a matching key and ptomb such that the key
-         * is newer than ptomb. So drop dups only if regular tomb.
-         */
-        is_tomb = HSE_CORE_IS_TOMB(vdata) && !HSE_CORE_IS_PTOMB(vdata);
-        if (is_tomb)
-            drop_dups(cur, &item);
+        cur->merr = kvset_iter_next_val(kv_iter, &item.vctx, vtype, vbidx,
+                                        vboff, &vdata, &vlen, &complen);
+        if (ev(cur->merr))
+            return cur->merr;
 
         if (cur->pt_set) {
             if (key_obj_cmp_prefix(&cur->pt_kobj, &item.kobj) == 0) {
-                if (HSE_CORE_IS_PTOMB(vdata) || seq < cur->pt_seq)
-                    end = true;
+                if (seq < cur->pt_seq)
+                    found = false; /* Key is hidden by a ptomb. */
             } else {
                 cur->pt_set = 0;
                 cur->pt_seq = 0;
             }
         }
 
-    } while (end || is_tomb);
+        /* Only store ptomb w/ highest seqno (less than cur's seqno) i.e. first occurrence of
+         * this ptomb.
+         */
+        if (vtype == vtype_ptomb && !cur->pt_set) {
+            assert(cur->ct_pfx_len > 0);
 
-    assert(!HSE_CORE_IS_TOMB(vdata));
+            cur->pt_kobj = item.kobj;
+            cur->pt_seq = seq;
+            cur->pt_set = 1;
+        }
+
+        /* A kvset can have a matching key and ptomb such that the key
+         * is newer than ptomb. So drop dups only if regular tomb.
+         */
+        if (vtype == vtype_tomb)
+            drop_dups(cur, &item);
+
+        if (vtype == vtype_ptomb)
+            found = false;
+
+    } while (!found);
 
     /* set output */
     elem->kce_kobj = item.kobj;
@@ -2564,6 +2551,17 @@ cn_tree_cursor_seek(
     if (cur->eof)
         cur->eof = 0;
 
+    if (cur->reverse) {
+        if (HSE_UNLIKELY(keycmp(key, len, cur->pfx, HSE_KVS_KEY_LEN_MAX) > 0)) {
+            key = cur->pfx;
+            len = HSE_KVS_KEY_LEN_MAX;
+        }
+    } else {
+        if (HSE_UNLIKELY(keycmp(key, len, cur->pfx, cur->pfx_len) < 0)) {
+            key = cur->pfx;
+            len = cur->pfx_len;
+        }
+    }
     /* [HSE_REVISIT]: this is parallelizable */
     first = -1; /* first kvset that is not at EOF */
     for (i = cur->iterc - 1; i >= 0; --i) {

--- a/lib/cn/cn_tree_cursor.h
+++ b/lib/cn/cn_tree_cursor.h
@@ -21,6 +21,10 @@ cn_tree_cursor_create(struct cn_cursor *cur, struct cn_tree *tree);
 
 /* MTF_MOCK */
 merr_t
+cn_tree_cursor_prepare(struct cn_cursor *cur);
+
+/* MTF_MOCK */
+merr_t
 cn_tree_cursor_update(struct cn_cursor *cur, struct cn_tree *tree);
 
 /* MTF_MOCK */

--- a/lib/include/hse_ikvdb/c0.h
+++ b/lib/include/hse_ikvdb/c0.h
@@ -194,6 +194,10 @@ c0_cursor_create(
     struct cursor_summary *summary,
     struct c0_cursor **    c0cur);
 
+/* MTF_MOCK */
+void
+c0_cursor_prepare(struct c0_cursor *cur);
+
 /**
  * c0_cursor_bind_txn() - Assign ctxn to c0 cursor
  * @c0cur:      Instance of struct c0_cursor

--- a/lib/include/hse_ikvdb/c0_kvmultiset.h
+++ b/lib/include/hse_ikvdb/c0_kvmultiset.h
@@ -304,6 +304,9 @@ c0kvms_cursor_seek(
     u32                          pfx_len,
     u32                          ct_pfx_len);
 
+void
+c0kvms_cursor_prepare(struct c0_kvmultiset_cursor *cur);
+
 /**
  * c0kvms_cursor_update() - update this cursor
  * @cursor:   Handle for c0kvms cursor

--- a/lib/include/hse_ikvdb/c0sk.h
+++ b/lib/include/hse_ikvdb/c0sk.h
@@ -302,6 +302,9 @@ c0sk_cursor_update(
     u64                      seqno,
     u32 *                    flags_out);
 
+void
+c0sk_cursor_prepare(struct c0_cursor *cur);
+
 /**
  * c0sk_cursor_destroy() - destroy existing iterators over c0
  * @c0cur:      The existing cursor.

--- a/lib/include/hse_ikvdb/kvs.h
+++ b/lib/include/hse_ikvdb/kvs.h
@@ -195,9 +195,6 @@ merr_t
 kvs_cursor_init(struct hse_kvs_cursor *cursor, struct kvdb_ctxn *ctxn);
 
 merr_t
-kvs_cursor_prepare(struct hse_kvs_cursor *cursor);
-
-merr_t
 kvs_cursor_bind_txn(struct hse_kvs_cursor *handle, struct kvdb_ctxn *ctxn);
 
 void

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -2447,10 +2447,6 @@ ikvdb_kvs_cursor_create(
     if (!txn)
         kvdb_ctxn_set_wait_commits(ikvdb->ikdb_ctxn_set, tseqno);
 
-    err = kvs_cursor_prepare(cur);
-    if (ev(err))
-        goto out;
-
     perfc_inc(&kvdb_metrics_pc, PERFC_BA_KVDBMETRICS_CURCNT);
     cur->kc_create_time = tstart;
 

--- a/lib/kvs/kvs_cursor.c
+++ b/lib/kvs/kvs_cursor.c
@@ -707,11 +707,10 @@ kvs_cursor_bh_create(struct hse_kvs_cursor *cursor)
     struct kvs_cursor_impl *cur = cursor_h2r(cursor);
     bin_heap2_compare_fn *  cmp;
     merr_t err;
-    int cnt = 0;
 
-    cur->kci_esrcv[cnt++] = c0_cursor_es_make(cur->kci_c0cur);
-    cur->kci_esrcv[cnt++] = lc_cursor_es_make(cur->kci_lccur);
-    cur->kci_esrcv[cnt++] = cn_cursor_es_make(cur->kci_cncur);
+    cur->kci_esrcv[0] = c0_cursor_es_make(cur->kci_c0cur);
+    cur->kci_esrcv[1] = lc_cursor_es_make(cur->kci_lccur);
+    cur->kci_esrcv[2] = cn_cursor_es_make(cur->kci_cncur);
 
     cmp = cur->kci_reverse ? kvs_cursor_cmp_rev : kvs_cursor_cmp;
     if (cur->kci_bh)

--- a/tests/functional/kvpy/tombspan.py
+++ b/tests/functional/kvpy/tombspan.py
@@ -18,6 +18,78 @@ def check_keys(cursor: hse.KvsCursor, expected: List[bytes]):
     for x, y in zip(expected, actual):
         assert x == y
 
+def test_basic(kvdb: hse.Kvdb, kvs: hse.Kvs):
+    kvs.put(b"a", b"1")
+    kvs.put(b"b", b"2")
+    kvs.put(b"c", b"3")
+    kvs.put(b"d", b"4")
+    kvs.put(b"e", b"5")
+    kvs.put(b"f", b"6")
+    kvs.put(b"g", b"7")
+    kvs.put(b"h", b"8")
+
+    cursor = kvs.cursor()
+    check_keys(cursor, [b"a", b"b", b"c", b"d", b"e", b"f", b"g", b"h"])
+
+    kvs.delete(b"a")
+    kvs.delete(b"b")
+    kvs.delete(b"c")
+    kvs.delete(b"d")
+    kvs.delete(b"e")
+
+    cursor.update_view()
+    cursor.seek(b"a")
+    kv = cursor.read()
+    assert kv == (b"f", b"6")
+    cursor.seek(b"a")
+    kv = cursor.read()
+    assert kv == (b"f", b"6")
+
+    kvs.delete(b"f")
+    cursor.update_view()
+    cursor.seek(b"a")
+    kv = cursor.read()
+    assert kv == (b"g", b"7")
+    cursor.seek(b"a")
+    kv = cursor.read()
+    assert kv == (b"g", b"7")
+
+    kvs.put(b"c", b"33")
+    cursor.update_view()
+    cursor.seek(b"a")
+    kv = cursor.read()
+    assert kv == (b"c", b"33")
+
+    cursor.destroy()
+
+'''
+Perform the operations as done by mongo when it's running range delete after having moved chunks
+across shards
+'''
+def tombspan_test(kvdb: hse.Kvdb, kvs: hse.Kvs):
+    numkeys = 100 * 1000
+    half = int(numkeys / 2)
+    synccnt = numkeys / 20
+
+    key = "ab{:0>12}".format(99999)
+    kvs.put(key, "base")
+    for i in range(half, numkeys):
+        key = "ab{:0>12}".format(i)
+        kvs.delete(key)
+        if i % synccnt == 0:
+            kvdb.sync()
+
+    for i in range(half):
+        key = "ab{:0>12}".format(i)
+        kvs.put(key, "val")
+
+    k = "ab"
+    for i in range(half):
+        with kvs.cursor(filt="ab") as c:
+            c.seek(k)
+            k, v = c.read()
+            if not c.eof:
+                kvs.delete(k)
 
 hse.init(cli.CONFIG)
 
@@ -26,49 +98,11 @@ try:
         kvdb_ctx = lifecycle.KvdbContext()
         kvdb = stack.enter_context(kvdb_ctx)
         kvs_ctx = lifecycle.KvsContext(kvdb, "tmobspan")
-        kvs = stack.enter_context(kvs_ctx)
 
-        kvs.put(b"a", b"1")
-        kvs.put(b"b", b"2")
-        kvs.put(b"c", b"3")
-        kvs.put(b"d", b"4")
-        kvs.put(b"e", b"5")
-        kvs.put(b"f", b"6")
-        kvs.put(b"g", b"7")
-        kvs.put(b"h", b"8")
+        with kvs_ctx as kvs:
+            test_basic(kvdb, kvs)
 
-        cursor = kvs.cursor()
-        check_keys(cursor, [b"a", b"b", b"c", b"d", b"e", b"f", b"g", b"h"])
-
-        kvs.delete(b"a")
-        kvs.delete(b"b")
-        kvs.delete(b"c")
-        kvs.delete(b"d")
-        kvs.delete(b"e")
-
-        cursor.update_view()
-        cursor.seek(b"a")
-        kv = cursor.read()
-        assert kv == (b"f", b"6")
-        cursor.seek(b"a")
-        kv = cursor.read()
-        assert kv == (b"f", b"6")
-
-        kvs.delete(b"f")
-        cursor.update_view()
-        cursor.seek(b"a")
-        kv = cursor.read()
-        assert kv == (b"g", b"7")
-        cursor.seek(b"a")
-        kv = cursor.read()
-        assert kv == (b"g", b"7")
-
-        kvs.put(b"c", b"33")
-        cursor.update_view()
-        cursor.seek(b"a")
-        kv = cursor.read()
-        assert kv == (b"c", b"33")
-
-        cursor.destroy()
+        with kvs_ctx as kvs:
+            tombspan_test(kvdb, kvs)
 finally:
     hse.fini()

--- a/tests/functional/kvpy/tombspan.py
+++ b/tests/functional/kvpy/tombspan.py
@@ -19,46 +19,46 @@ def check_keys(cursor: hse.KvsCursor, expected: List[bytes]):
         assert x == y
 
 def test_basic(kvdb: hse.Kvdb, kvs: hse.Kvs):
-    kvs.put(b"a", b"1")
-    kvs.put(b"b", b"2")
-    kvs.put(b"c", b"3")
-    kvs.put(b"d", b"4")
-    kvs.put(b"e", b"5")
-    kvs.put(b"f", b"6")
-    kvs.put(b"g", b"7")
-    kvs.put(b"h", b"8")
+    kvs.put("a", "1")
+    kvs.put("b", "2")
+    kvs.put("c", "3")
+    kvs.put("d", "4")
+    kvs.put("e", "5")
+    kvs.put("f", "6")
+    kvs.put("g", "7")
+    kvs.put("h", "8")
 
     cursor = kvs.cursor()
-    check_keys(cursor, [b"a", b"b", b"c", b"d", b"e", b"f", b"g", b"h"])
+    check_keys(cursor, ["a", "b", "c", "d", "e", "f", "g", "h"])
 
-    kvs.delete(b"a")
-    kvs.delete(b"b")
-    kvs.delete(b"c")
-    kvs.delete(b"d")
-    kvs.delete(b"e")
+    kvs.delete("a")
+    kvs.delete("b")
+    kvs.delete("c")
+    kvs.delete("d")
+    kvs.delete("e")
 
     cursor.update_view()
-    cursor.seek(b"a")
+    cursor.seek("a")
     kv = cursor.read()
-    assert kv == (b"f", b"6")
-    cursor.seek(b"a")
+    assert kv == ("f", "6")
+    cursor.seek("a")
     kv = cursor.read()
-    assert kv == (b"f", b"6")
+    assert kv == ("f", "6")
 
-    kvs.delete(b"f")
+    kvs.delete("f")
     cursor.update_view()
-    cursor.seek(b"a")
+    cursor.seek("a")
     kv = cursor.read()
-    assert kv == (b"g", b"7")
-    cursor.seek(b"a")
+    assert kv == ("g", "7")
+    cursor.seek("a")
     kv = cursor.read()
-    assert kv == (b"g", b"7")
+    assert kv == ("g", "7")
 
-    kvs.put(b"c", b"33")
+    kvs.put("c", "33")
     cursor.update_view()
-    cursor.seek(b"a")
+    cursor.seek("a")
     kv = cursor.read()
-    assert kv == (b"c", b"33")
+    assert kv == ("c", "33")
 
     cursor.destroy()
 
@@ -71,21 +71,21 @@ def tombspan_test(kvdb: hse.Kvdb, kvs: hse.Kvs):
     half = int(numkeys / 2)
     synccnt = numkeys / 20
 
-    key = "ab{:0>12}".format(99999)
+    key = f"ab{99999:0>12}"
     kvs.put(key, "base")
     for i in range(half, numkeys):
-        key = "ab{:0>12}".format(i)
+        key = f"ab{i:0>12}"
         kvs.delete(key)
         if i % synccnt == 0:
             kvdb.sync()
 
     for i in range(half):
-        key = "ab{:0>12}".format(i)
+        key = f"ab{i:0>12}"
         kvs.put(key, "val")
 
-    k = "ab"
+    k = "a"
     for i in range(half):
-        with kvs.cursor(filt="ab") as c:
+        with kvs.cursor(filt="a") as c:
             c.seek(k)
             k, v = c.read()
             if not c.eof:

--- a/tests/mocks/repository/lib/mock_c0cn.c
+++ b/tests/mocks/repository/lib/mock_c0cn.c
@@ -661,6 +661,8 @@ static struct mapi_injection cn_inject_list[] = {
     { mapi_idx_cn_pc_mclass_get,     MAPI_RC_PTR, NULL },
     { mapi_idx_cn_get_ingest_perfc,  MAPI_RC_PTR, NULL },
 
+    { mapi_idx_cn_tree_cursor_prepare,  MAPI_RC_SCALAR, 0 },
+
     { -1 },
 };
 
@@ -725,6 +727,7 @@ mock_cn_unset()
 static struct mapi_injection c0_inject_list[] = {
     { mapi_idx_c0_cursor_update,    MAPI_RC_SCALAR, 0 },
     { mapi_idx_c0_cursor_bind_txn,  MAPI_RC_SCALAR, 0 },
+    { mapi_idx_c0_cursor_prepare,   MAPI_RC_SCALAR, 0 },
     { -1 },
 };
 

--- a/tests/unit/c0/c0sk_test.c
+++ b/tests/unit/c0/c0sk_test.c
@@ -1959,6 +1959,8 @@ MTF_DEFINE_UTEST_PREPOST(c0sk_test, c0_cursor_robust, no_fail_pre, no_fail_post)
         ASSERT_EQ(0, err);
         atomic64_inc(&seqno);
 
+        c0sk_cursor_prepare(cur[i]);
+
         /* this cursor will NOT see these keys */
 
         for (; j < n; ++j) {
@@ -1978,6 +1980,7 @@ MTF_DEFINE_UTEST_PREPOST(c0sk_test, c0_cursor_robust, no_fail_pre, no_fail_post)
                 c0sk_sync(c0sk, HSE_KVDB_SYNC_ASYNC);
         }
     }
+
 
     /*
      * we have 5 cursors with 5 different views,
@@ -2293,6 +2296,8 @@ MTF_DEFINE_UTEST_PREPOST(c0sk_test, c0_rcursor_robust, no_fail_pre, no_fail_post
         ASSERT_EQ(0, err);
         atomic64_inc(&seqno);
 
+        c0sk_cursor_prepare(cur[i]);
+
         /* this cursor will NOT see these keys */
 
         for (; j < n; ++j) {
@@ -2571,6 +2576,9 @@ MTF_DEFINE_UTEST_PREPOST(c0sk_test, c0_cursor_ptombs, no_fail_pre, no_fail_post)
             ASSERT_EQ(0, err);
 
             atomic64_inc(&seqno);
+
+            c0sk_cursor_prepare(cur);
+
         } else if (random() % 100 < 5) {
             atomic64_inc(&seqno);
         }

--- a/tests/unit/cn/cn_cursor_test.c
+++ b/tests/unit/cn/cn_cursor_test.c
@@ -179,6 +179,11 @@ verify(struct mtf_test_info *lcl_ti, struct cn_cursor *cur, struct nkv_tab *vtab
         if (eof)
             break;
 
+        /* Ignore tombstones from cursor read.
+         */
+        if (HSE_CORE_IS_TOMB(kvt.kvt_value.vt_data))
+            continue;
+
         /* validate reading correct keys and values */
         ip = kvt.kvt_key.kt_data;
         ASSERT_EQ(ntohl(*ip), key);
@@ -221,6 +226,8 @@ verify_cursor(
     err = cn_cursor_create(cn, seqno, false, pfx, pfx_len, &sum, &cur);
     ASSERT_EQ(err, 0);
     ASSERT_NE(cur, NULL);
+
+    cn_cursor_prepare(cur);
 
     verify(lcl_ti, cur, vtab, vc, 0);
 }
@@ -269,6 +276,8 @@ verify_seek_eof(
     err = cn_cursor_create(cn, seqno, false, pfx, pfx_len, &sum, &cur);
     ASSERT_EQ(err, 0);
     ASSERT_NE(cur, NULL);
+
+    cn_cursor_prepare(cur);
 
     /* read through entire set */
     verify(lcl_ti, cur, vtab, vc, 1);

--- a/tests/unit/kvs/kvs_cursor_test.c
+++ b/tests/unit/kvs/kvs_cursor_test.c
@@ -109,9 +109,6 @@ create_cursor(
     err = kvs_cursor_init(cur, NULL);
     ASSERT_EQ(0, err);
 
-    err = kvs_cursor_prepare(cur);
-    ASSERT_EQ(0, err);
-
     *cur_out = cur;
 }
 


### PR DESCRIPTION
Signed-off-by: Gaurav Ramdasi <10132364+gsramdasi@users.noreply.github.com>

## Description
This patch contains 2 changes to cursors:
- The prepare operation in c0 and cn (NOT lc) is now done by cursor read instead of cursor create. This avoids the tombspan problem in the create path and also avoids wasted effort in the case when a cursor is seek-ed before ever being read.
- A cn cursor passes up (to the kvs cursor layer) tombstones as well. Dropping tombstones is now left to the kvs cursor layer.

Note that this change does not extend to LC since LC has a requirement that before exiting a cursor operation's rcu read section, the cursor must be positioned on a key such that the key has at least one value in the cursor's view.
To ensure this the prepare operation (which involves reads) is left in the cursor create's rcu read section.

## Issue(s) Addressed
NFSE-5074

## Verified checks?
Have the checks completed?
- [X] meson test -C build --setup=ci
- [X] All commits are signed off
