### PR TITLE
Force doxygen to error on warnings

### DIFF
--- a/docs/doxygen/doxyfile.in
+++ b/docs/doxygen/doxyfile.in
@@ -816,7 +816,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = @DOXYGEN_WARN_AS_ERROR@
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/docs/doxygen/meson.build
+++ b/docs/doxygen/meson.build
@@ -21,6 +21,7 @@ conf_data = configuration_data({
     'DOXYGEN_CSS': cssfile,
     'DOXYGEN_EXAMPLES': examples,
     'DOXYGEN_OUTPUT': join_paths(meson.current_build_dir(), 'api'),
+    'DOXYGEN_WARN_AS_ERROR': get_option('werror') ? 'YES' : 'NO',
 })
 
 doxyfile = configure_file(


### PR DESCRIPTION
## Description
Any warnings produced by doxygen should error out if -Dwerror=true is set.

## Verified checks?
Have the checks completed?
- [X] meson test -C build --setup=ci
- [X] All commits are signed off
