### PR TITLE
Return a const string from kvdb_kvs_name()

### DIFF
--- a/lib/include/hse_ikvdb/kvs.h
+++ b/lib/include/hse_ikvdb/kvs.h
@@ -229,7 +229,7 @@ u64
 kvdb_kvs_cnid(struct kvdb_kvs *kk);
 
 /* MTF_MOCK */
-char *
+const char *
 kvdb_kvs_name(struct kvdb_kvs *kk);
 
 /* MTF_MOCK */

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -1527,7 +1527,7 @@ kvdb_kvs_cnid(struct kvdb_kvs *kk)
     return kk->kk_cnid;
 }
 
-char *
+const char *
 kvdb_kvs_name(struct kvdb_kvs *kk)
 {
     return kk->kk_name;


### PR DESCRIPTION
## Description
Hand out a const reference to the kvs name.

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
