### PR TITLE
Include hse_util/hse_err.h where it is used

### DIFF
--- a/lib/util/include/hse_util/rest_api.h
+++ b/lib/util/include/hse_util/rest_api.h
@@ -1,12 +1,14 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_PLATFORM_REST_API_H
 #define HSE_PLATFORM_REST_API_H
 
 #include <microhttpd.h>
+
+#include <hse_util/hse_err.h>
 
 #define REST_VERSION_MAJOR 0
 #define REST_VERSION_MINOR 1


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>

## Description
Missing include in certain places.

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
