### PR TITLE
Add infrastructure getting a parameter generically

### DIFF
--- a/lib/config/param.c
+++ b/lib/config/param.c
@@ -579,8 +579,8 @@ param_default_validator(const struct param_spec *ps, const void *value)
     return false;
 }
 
-#define STORAGE_CONVERTER(X)                                                                      \
-    bool param_convert_to_bytes_from_##X(                                                         \
+#define STORAGE_CONVERTER(_units)                                                                 \
+    bool param_convert_to_bytes_from_##_units(                                                    \
         const struct param_spec *ps, const cJSON *node, void *value)                              \
     {                                                                                             \
         assert(ps);                                                                               \
@@ -597,7 +597,7 @@ param_default_validator(const struct param_spec *ps, const void *value)
         assert(rc == 0);                                                                          \
                                                                                                   \
         double tmp = cJSON_GetNumberValue(node);                                                  \
-        tmp = tmp * X;                                                                            \
+        tmp = tmp * (_units);                                                                     \
         if (fetestexcept(FE_OVERFLOW)) {                                                          \
             CLOG_ERR("Value of %s is too large", ps->ps_name);                                    \
             feclearexcept(FE_OVERFLOW);                                                           \
@@ -711,51 +711,51 @@ STORAGE_CONVERTER(TB)
 
 #undef STORAGE_CONVERTER
 
-#define STORAGE_STRINGIFY(X)                                                        \
-    merr_t param_stringify_bytes_to_##X(                                            \
-        const struct param_spec *const ps,                                          \
-        const void *const              value,                                       \
-        char *const                    buf,                                         \
-        const size_t                   buf_sz,                                      \
-        size_t *                       needed_sz)                                   \
-    {                                                                               \
-        int n = 0;                                                                  \
-                                                                                    \
-        switch (ps->ps_type) {                                                      \
-            case PARAM_TYPE_I8:                                                     \
-                n = snprintf(buf, buf_sz, "%ld", *(int8_t *)value / (int64_t)X);    \
-                break;                                                              \
-            case PARAM_TYPE_I16:                                                    \
-                n = snprintf(buf, buf_sz, "%ld", *(int16_t *)value / (int64_t)X);   \
-                break;                                                              \
-            case PARAM_TYPE_I32:                                                    \
-                n = snprintf(buf, buf_sz, "%ld", *(int32_t *)value / (int64_t)X);   \
-                break;                                                              \
-            case PARAM_TYPE_I64:                                                    \
-                n = snprintf(buf, buf_sz, "%ld", *(int64_t *)value / (int64_t)X);   \
-                break;                                                              \
-            case PARAM_TYPE_U8:                                                     \
-                n = snprintf(buf, buf_sz, "%lu", *(uint8_t *)value / (uint64_t)X);  \
-                break;                                                              \
-            case PARAM_TYPE_U16:                                                    \
-                n = snprintf(buf, buf_sz, "%lu", *(uint16_t *)value / (uint64_t)X); \
-                break;                                                              \
-            case PARAM_TYPE_U32:                                                    \
-                n = snprintf(buf, buf_sz, "%lu", *(uint32_t *)value / (uint64_t)X); \
-                break;                                                              \
-            case PARAM_TYPE_U64:                                                    \
-                n = snprintf(buf, buf_sz, "%lu", *(uint64_t *)value / (uint64_t)X); \
-                break;                                                              \
-            default:                                                                \
-                abort();                                                            \
-        }                                                                           \
-                                                                                    \
-        if (n < 0)                                                                  \
-            return merr(EBADMSG);                                                   \
-        if (needed_sz)                                                              \
-            *needed_sz = n;                                                         \
-                                                                                    \
-        return 0;                                                                   \
+#define STORAGE_STRINGIFY(_units)                                                          \
+    merr_t param_stringify_bytes_to_##_units(                                              \
+        const struct param_spec *const ps,                                                 \
+        const void *const              value,                                              \
+        char *const                    buf,                                                \
+        const size_t                   buf_sz,                                             \
+        size_t *                       needed_sz)                                          \
+    {                                                                                      \
+        int n = 0;                                                                         \
+                                                                                           \
+        switch (ps->ps_type) {                                                             \
+            case PARAM_TYPE_I8:                                                            \
+                n = snprintf(buf, buf_sz, "%ld", *(int8_t *)value / (int64_t)(_units));    \
+                break;                                                                     \
+            case PARAM_TYPE_I16:                                                           \
+                n = snprintf(buf, buf_sz, "%ld", *(int16_t *)value / (int64_t)(_units));   \
+                break;                                                                     \
+            case PARAM_TYPE_I32:                                                           \
+                n = snprintf(buf, buf_sz, "%ld", *(int32_t *)value / (int64_t)(_units));   \
+                break;                                                                     \
+            case PARAM_TYPE_I64:                                                           \
+                n = snprintf(buf, buf_sz, "%ld", *(int64_t *)value / (int64_t)(_units));   \
+                break;                                                                     \
+            case PARAM_TYPE_U8:                                                            \
+                n = snprintf(buf, buf_sz, "%lu", *(uint8_t *)value / (uint64_t)(_units));  \
+                break;                                                                     \
+            case PARAM_TYPE_U16:                                                           \
+                n = snprintf(buf, buf_sz, "%lu", *(uint16_t *)value / (uint64_t)(_units)); \
+                break;                                                                     \
+            case PARAM_TYPE_U32:                                                           \
+                n = snprintf(buf, buf_sz, "%lu", *(uint32_t *)value / (uint64_t)(_units)); \
+                break;                                                                     \
+            case PARAM_TYPE_U64:                                                           \
+                n = snprintf(buf, buf_sz, "%lu", *(uint64_t *)value / (uint64_t)(_units)); \
+                break;                                                                     \
+            default:                                                                       \
+                abort();                                                                   \
+        }                                                                                  \
+                                                                                           \
+        if (n < 0)                                                                         \
+            return merr(EBADMSG);                                                          \
+        if (needed_sz)                                                                     \
+            *needed_sz = n;                                                                \
+                                                                                           \
+        return 0;                                                                          \
     }
 
 STORAGE_STRINGIFY(KB)
@@ -764,3 +764,34 @@ STORAGE_STRINGIFY(GB)
 STORAGE_STRINGIFY(TB)
 
 #undef STORAGE_STRINGIFY
+
+merr_t
+param_get(
+    const struct params *const     params,
+    const struct param_spec *const pspecs,
+    const size_t                   pspecs_sz,
+    const char *const              param,
+    char *const                    buf,
+    const size_t                   buf_sz,
+    size_t *const                  needed_sz)
+{
+    const struct param_spec *ps = NULL;
+
+    if (!params || !params->p_params.as_generic || !pspecs || !param || !buf)
+        return merr(EINVAL);
+
+    for (size_t i = 0; i < pspecs_sz; i++) {
+        if (!strcmp(pspecs[i].ps_name, param)) {
+            ps = &pspecs[i];
+            break;
+        }
+    }
+
+    if (!ps)
+        return merr(EINVAL);
+
+    assert(ps->ps_stringify);
+
+    return ps->ps_stringify(
+        ps, (char *)params->p_params.as_generic + ps->ps_offset, buf, buf_sz, needed_sz);
+}

--- a/lib/include/hse_ikvdb/param.h
+++ b/lib/include/hse_ikvdb/param.h
@@ -43,12 +43,12 @@ struct params {
     } p_type;
     union {
         /* Do not assign to as_generic, for internal use only */
-        void *const                as_generic;
-        struct kvdb_cparams *const as_kvdb_cp;
-        struct kvdb_rparams *const as_kvdb_rp;
-        struct kvs_cparams *const  as_kvs_cp;
-        struct kvs_rparams *const  as_kvs_rp;
-        struct hse_gparams *const  as_hse_gp;
+        const void *               as_generic;
+        const struct kvdb_cparams *as_kvdb_cp;
+        const struct kvdb_rparams *as_kvdb_rp;
+        const struct kvs_cparams * as_kvs_cp;
+        const struct kvs_rparams * as_kvs_rp;
+        const struct hse_gparams * as_hse_gp;
     } p_params;
 };
 
@@ -186,6 +186,16 @@ merr_t
 param_stringify_bytes_to_TB(
     const struct param_spec *ps,
     const void *             value,
+    char *                   buf,
+    size_t                   buf_sz,
+    size_t *                 needed_sz);
+
+merr_t
+param_get(
+    const struct params *    params,
+    const struct param_spec *pspecs,
+    size_t                   pspecs_sz,
+    const char *             param,
     char *                   buf,
     size_t                   buf_sz,
     size_t *                 needed_sz);

--- a/lib/kvs/kvs_rparams.c
+++ b/lib/kvs/kvs_rparams.c
@@ -65,8 +65,7 @@ validate_cn_node_size_hi(const struct param_spec *ps, const struct params *const
     return true;
 }
 
-static bool HSE_NONNULL(1, 2, 3)
-compression_value_algorithm_converter(
+static bool HSE_NONNULL(1, 2, 3) compression_value_algorithm_converter(
     const struct param_spec *const ps,
     const cJSON *const             node,
     void *const                    data)

--- a/tests/unit/config/param_test.c
+++ b/tests/unit/config/param_test.c
@@ -81,7 +81,7 @@ array_default_builder(const struct param_spec *const ps, void *const data)
 bool
 array_relation_validate(const struct param_spec *const ps, const struct params *p)
 {
-    struct test_params *params = p->p_params.as_generic;
+    const struct test_params *params = p->p_params.as_generic;
 
     return params->test11[0].field1 < params->test9 && params->test11[1].field1 < params->test8;
 }
@@ -900,6 +900,39 @@ MTF_DEFINE_UTEST_PRE(param_test, roundup_pow2, test_pre)
 
     ASSERT_EQ(0, merr_errno(err));
     ASSERT_EQ(2048, params.test16);
+}
+
+MTF_DEFINE_UTEST_PRE(param_test, get, test_pre)
+{
+	merr_t err;
+	char   buf[128];
+	size_t needed_sz;
+
+	const struct params p = { .p_params = { .as_generic = &params }, .p_type = PARAMS_GEN };
+
+	err = param_get(&p, pspecs, NELEM(pspecs), "test1", buf, sizeof(buf), &needed_sz);
+	ASSERT_EQ(0, merr_errno(err));
+	ASSERT_STREQ("true", buf);
+	ASSERT_EQ(4, needed_sz);
+
+	err = param_get(&p, pspecs, NELEM(pspecs), "test1", buf, sizeof(buf), NULL);
+	ASSERT_EQ(0, merr_errno(err));
+	ASSERT_STREQ("true", buf);
+
+	err = param_get(&p, pspecs, NELEM(pspecs), "does.not.exist", buf, sizeof(buf), NULL);
+	ASSERT_EQ(EINVAL, merr_errno(err));
+
+	err = param_get(NULL, pspecs, NELEM(pspecs), "test1", buf, sizeof(buf), NULL);
+	ASSERT_EQ(EINVAL, merr_errno(err));
+
+	err = param_get(&p, NULL, NELEM(pspecs), "test1", buf, sizeof(buf), NULL);
+	ASSERT_EQ(EINVAL, merr_errno(err));
+
+	err = param_get(&p, pspecs, NELEM(pspecs), NULL, buf, sizeof(buf), NULL);
+	ASSERT_EQ(EINVAL, merr_errno(err));
+
+	err = param_get(&p, pspecs, NELEM(pspecs), "test1", NULL, sizeof(buf), NULL);
+	ASSERT_EQ(EINVAL, merr_errno(err));
 }
 
 MTF_END_UTEST_COLLECTION(param_test)


### PR DESCRIPTION
All our various parameter types are essentially a thin wrapper over
generic infrastructure. Adding param_get() expands that infrastructure
in order to reduce the amount of work.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
