### PR TITLE
Cleanup kvs.h header

### DIFF
--- a/lib/include/hse_ikvdb/kvs.h
+++ b/lib/include/hse_ikvdb/kvs.h
@@ -32,7 +32,6 @@ struct ikvdb;
 struct ikvdb_impl;
 struct mpool;
 struct kvs_cparams;
-struct kvs_rparams;
 struct lc;
 struct cn;
 struct cn_kvdb;


### PR DESCRIPTION
Removes the forward declaration because the full struct must be visible since it is a member.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
