### PR TITLE
Move vma_size_max to a constant in cN

### DIFF
--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -60,6 +60,8 @@
 #include "bloom_reader.h"
 #include "cn_perfc.h"
 
+#define VMA_SIZE_MAX 30
+
 struct tbkt;
 struct mclass_policy;
 
@@ -1608,7 +1610,7 @@ cn_vma_mblock_max(struct cn *cn, enum mpool_mclass mclass)
 {
     u64 vma_size_max, mblocksz;
 
-    vma_size_max = 1ul << cn->cn_mpool_props.mp_vma_size_max;
+    vma_size_max = 1ul << VMA_SIZE_MAX;
     mblocksz = cn_mpool_dev_zone_alloc_unit_default(cn, mclass);
 
     assert(mblocksz > 0);

--- a/lib/mpool/include/mpool/mpool_structs.h
+++ b/lib/mpool/include/mpool/mpool_structs.h
@@ -80,11 +80,9 @@ struct mpool_dparams {
 /**
  * struct mpool_props -
  *
- * @mp_vma_size_max:    max VMA map size (log2)
  * @mp_mblocksz:        mblock size by media class (MiB)
  */
 struct mpool_props {
-    uint32_t mp_vma_size_max;
     uint32_t mp_mblocksz[MP_MED_COUNT];
 };
 

--- a/lib/mpool/src/mpool.c
+++ b/lib/mpool/src/mpool.c
@@ -412,8 +412,6 @@ mpool_props_get(struct mpool *mp, struct mpool_props *props)
         props->mp_mblocksz[i] = mcp.mc_mblocksz;
     }
 
-    props->mp_vma_size_max = 30;
-
     return 0;
 }
 

--- a/tests/mocks/repository/lib/mock_mpool.c
+++ b/tests/mocks/repository/lib/mock_mpool.c
@@ -177,7 +177,6 @@ _mpool_mblock_delete(struct mpool *mp, uint64_t id)
 merr_t
 _mpool_props_get(struct mpool *mp, struct mpool_props *props)
 {
-    props->mp_vma_size_max = 30;
     props->mp_mblocksz[MP_MED_CAPACITY] = 32 << 20;
 
     return 0;

--- a/tests/unit/mpool/mpool_test.c
+++ b/tests/unit/mpool/mpool_test.c
@@ -62,7 +62,6 @@ MTF_DEFINE_UTEST_PREPOST(mpool_test, mpool_ocd_test, mpool_test_pre, mpool_test_
     err = mpool_props_get(mp, &mprops);
     ASSERT_EQ(0, merr_errno(err));
     ASSERT_EQ(32, mprops.mp_mblocksz[MP_MED_CAPACITY]);
-    ASSERT_EQ(30, mprops.mp_vma_size_max);
 
     err = mpool_stats_get(NULL, &stats);
     ASSERT_EQ(EINVAL, merr_errno(err));


### PR DESCRIPTION
It was always a constant of 30, so it was unnecessary to keep it as an
mpool property.

Removing it from the property struct is fairly useful in the introspection PR. Don't think it needs to wait.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
