### PR TITLE
Protect against double forward slash

### DIFF
--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -172,9 +172,22 @@ hse_kvdb_create(const char *kvdb_home, size_t paramc, const char *const *const p
     char                pidfile_path[PATH_MAX];
     struct pidfh *      pfh = NULL;
     struct pidfile      content = {};
+    size_t              n;
 
     if (HSE_UNLIKELY(!kvdb_home)) {
         log_err("A KVDB home must be provided");
+        return merr_to_hse_err(EINVAL);
+    }
+
+    n = strnlen(kvdb_home, PATH_MAX);
+
+    if (HSE_UNLIKELY(n == PATH_MAX)) {
+        log_err("KVDB home path length cannot be longer than PATH_MAX");
+        return merr_to_hse_err(ENAMETOOLONG);
+    }
+
+    if (HSE_UNLIKELY(n == 0)) {
+        log_err("KVDB home must be a non-zero length path");
         return merr_to_hse_err(EINVAL);
     }
 
@@ -234,9 +247,22 @@ hse_kvdb_drop(const char *kvdb_home)
     char          pidfile_path[PATH_MAX];
     struct pidfh *pfh = NULL;
     merr_t        err;
+    size_t        n;
 
     if (HSE_UNLIKELY(!kvdb_home)) {
         log_err("A KVDB home must be provided");
+        return merr_to_hse_err(EINVAL);
+    }
+
+    n = strnlen(kvdb_home, PATH_MAX);
+
+    if (HSE_UNLIKELY(n == PATH_MAX)) {
+        log_err("KVDB home path length cannot be longer than PATH_MAX");
+        return merr_to_hse_err(ENAMETOOLONG);
+    }
+
+    if (HSE_UNLIKELY(n == 0)) {
+        log_err("KVDB home must be a non-zero length path");
         return merr_to_hse_err(EINVAL);
     }
 
@@ -273,15 +299,15 @@ hse_kvdb_open(
     const char *const *const paramv,
     struct hse_kvdb **       handle)
 {
-    merr_t                  err;
-    struct ikvdb *          ikvdb = NULL;
-    struct kvdb_rparams     params = kvdb_rparams_defaults();
-    u64                     tstart;
-    char                    pidfile_path[PATH_MAX];
-    struct config *         conf = NULL;
-    struct pidfh *          pfh = NULL;
-    struct pidfile          content = {};
-    size_t HSE_MAYBE_UNUSED n;
+    merr_t              err;
+    struct ikvdb *      ikvdb = NULL;
+    struct kvdb_rparams params = kvdb_rparams_defaults();
+    u64                 tstart;
+    char                pidfile_path[PATH_MAX];
+    struct config *     conf = NULL;
+    struct pidfh *      pfh = NULL;
+    struct pidfile      content = {};
+    size_t              n;
 
     if (HSE_UNLIKELY(!kvdb_home)) {
         log_err("A KVDB home must be provided");
@@ -290,6 +316,18 @@ hse_kvdb_open(
 
     if (HSE_UNLIKELY(!handle))
         return merr_to_hse_err(merr(EINVAL));
+
+    n = strnlen(kvdb_home, PATH_MAX);
+
+    if (HSE_UNLIKELY(n == PATH_MAX)) {
+        log_err("KVDB home path length cannot be longer than PATH_MAX");
+        return merr_to_hse_err(ENAMETOOLONG);
+    }
+
+    if (HSE_UNLIKELY(n == 0)) {
+        log_err("KVDB home must be a non-zero length path");
+        return merr_to_hse_err(EINVAL);
+    }
 
     tstart = perfc_lat_start(&kvdb_pkvdbl_pc);
     perfc_inc(&kvdb_pc, PERFC_RA_KVDBOP_KVDB_OPEN);

--- a/lib/kvdb/kvdb_home.c
+++ b/lib/kvdb/kvdb_home.c
@@ -36,8 +36,7 @@ path_copy(const char *home, const char *path, char *buf, const size_t buf_sz)
         return 0;
     }
 
-    n = snprintf(
-        buf, buf_sz, "%s%s%s", home, home[strnlen(home, PATH_MAX) - 1] == '/' ? "" : "/", path);
+    n = snprintf(buf, buf_sz, "%s%s%s", home, home[strlen(home)] == '/' ? "" : "/", path);
     if (n >= buf_sz)
         return merr(ENAMETOOLONG);
     if (n < 0)

--- a/lib/kvdb/kvdb_home.c
+++ b/lib/kvdb/kvdb_home.c
@@ -36,7 +36,8 @@ path_copy(const char *home, const char *path, char *buf, const size_t buf_sz)
         return 0;
     }
 
-    n = snprintf(buf, buf_sz, "%s/%s", home, path);
+    n = snprintf(
+        buf, buf_sz, "%s%s%s", home, home[strnlen(home, PATH_MAX) - 1] == '/' ? "" : "/", path);
     if (n >= buf_sz)
         return merr(ENAMETOOLONG);
     if (n < 0)


### PR DESCRIPTION
In the event the kvdb home ends in a forward slash, don't add an extra one. Makes the kvdb.meta file a little cleaner.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
