### PR TITLE
Use cJSON_GetErrorPtr() to return more descriptive errors

### DIFF
--- a/lib/config/argv.c
+++ b/lib/config/argv.c
@@ -88,8 +88,12 @@ argv_deserialize_to_params(
             free(buf);
 
             if (!node) {
-                CLOG_ERR("Failed to parse %s %s: %s", params_logging_context(params), ps->ps_name, param);
-                err = merr(EINVAL);
+                if (cJSON_GetErrorPtr()) {
+                    CLOG_ERR("Failed to parse %s %s: %s", params_logging_context(params), ps->ps_name, param);
+                    err = merr(EINVAL);
+                } else {
+                    err = merr(ENOMEM);
+                }
                 goto out;
             }
         }

--- a/lib/config/config.c
+++ b/lib/config/config.c
@@ -394,8 +394,12 @@ config_create(const char *path, cJSON **conf)
 
     *conf = cJSON_ParseWithLength(config, st.st_size + 1);
     if (!*conf) {
-        CLOG_ERR("Failed to parse file as valid JSON (%s)", path);
-        err = merr(EINVAL);
+        if (cJSON_GetErrorPtr()) {
+            CLOG_ERR("Failed to parse file as valid JSON (%s): %s", path, cJSON_GetErrorPtr());
+            err = merr(EINVAL);
+        } else {
+            err = merr(ENOMEM);
+        }
         goto out;
     }
 

--- a/lib/kvdb/kvdb_meta.c
+++ b/lib/kvdb/kvdb_meta.c
@@ -471,7 +471,11 @@ kvdb_meta_deserialize(struct kvdb_meta *const meta, const char *const kvdb_home)
 
     root = cJSON_ParseWithLength(meta_data, st.st_size + 1);
     if (!root) {
-        err = merr(EPROTO);
+        if (cJSON_GetErrorPtr()) {
+            err = merr(EPROTO);
+        } else {
+            err = merr(EINVAL);
+        }
         goto out;
     }
 

--- a/lib/pidfile/lib/pidfile.c
+++ b/lib/pidfile/lib/pidfile.c
@@ -133,7 +133,11 @@ pidfile_deserialize(const char *home, struct pidfile *content)
 
     root = cJSON_ParseWithLength(str, st.st_size);
     if (!root) {
-        rc = EINVAL;
+        if (cJSON_GetErrorPtr()) {
+            rc = EPROTO;
+        } else {
+            rc = ENOMEM;
+        }
         goto out;
     }
     pid = cJSON_GetObjectItemCaseSensitive(root, "pid");


### PR DESCRIPTION
cJSON can tell you what failed to parse. This can help differentiate
between ENOMEM and EINVAL/EPROTO.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
