### PR TITLE
Add map for mclass to string constant

### DIFF
--- a/lib/kvdb/kvdb_rparams.c
+++ b/lib/kvdb/kvdb_rparams.c
@@ -22,6 +22,7 @@
 #include <hse_util/storage.h>
 #include <hse_util/compiler.h>
 #include <hse_util/string.h>
+#include <hse_util/invariant.h>
 #include <hse_ikvdb/csched.h>
 
 /**
@@ -406,21 +407,16 @@ dur_mclass_converter(
     const cJSON *const             node,
     void *const                    data)
 {
-    static const char *mclasses[MP_MED_COUNT] = {
-        MP_MED_NAME_CAPACITY, MP_MED_NAME_STAGING
-    };
-
-    assert(ps);
-    assert(node);
-    assert(data);
+    INVARIANT(ps);
+    INVARIANT(node);
+    INVARIANT(data);
 
     if (!cJSON_IsString(node))
         return false;
 
     const char *value = cJSON_GetStringValue(node);
-
-    for (size_t i = 0; i < NELEM(mclasses); i++) {
-        if (!strcmp(mclasses[i], value)) {
+    for (size_t i = 0; i < NELEM(mpool_mclass_to_string); i++) {
+        if (!strcmp(mpool_mclass_to_string[i], value)) {
             *(enum mpool_mclass *)data = i;
             return true;
         }

--- a/lib/mpool/include/mpool/mpool.h
+++ b/lib/mpool/include/mpool/mpool.h
@@ -22,6 +22,8 @@ struct mpool_file;       /* opaque mpool file handle */
  * Mpool Administrative APIs...
  */
 
+extern const char *const mpool_mclass_to_string[MP_MED_COUNT];
+
 /**
  * mpool_create() - Create an mpool
  *

--- a/lib/mpool/src/mpool.c
+++ b/lib/mpool/src/mpool.c
@@ -32,6 +32,11 @@ struct mpool {
     const char          home[]; /* flexible array */
 };
 
+const char *const mpool_mclass_to_string[MP_MED_COUNT] = {
+    [MP_MED_CAPACITY] = MP_MED_NAME_CAPACITY,
+    [MP_MED_STAGING] = MP_MED_NAME_STAGING,
+};
+
 static merr_t
 mpool_to_mclass_params(
     enum mpool_mclass           mc,


### PR DESCRIPTION
Just useful for turning a media class into a string.

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
