### PR TITLE
Remove media class constants in mclass_policy source

### DIFF
--- a/lib/cn/cn_perfc.c
+++ b/lib/cn/cn_perfc.c
@@ -93,7 +93,7 @@ NE_CHECK(cn_perfc_capped, PERFC_EN_CNCAPPED, "cn_perfc_capped table/enum mismatc
 NE_CHECK(cn_perfc_mclass, PERFC_EN_CNMCLASS, "cn_perfc_mclass table/enum mismatch");
 
 static_assert(
-    NELEM(cn_perfc_mclass) == HSE_MPOLICY_AGE_CNT * HSE_MPOLICY_DTYPE_CNT * HSE_MPOLICY_MEDIA_CNT,
+    NELEM(cn_perfc_mclass) == HSE_MPOLICY_AGE_CNT * HSE_MPOLICY_DTYPE_CNT * MP_MED_COUNT,
     "cn_perfc_mclass entries mismatched");
 
 /* clang-format on */

--- a/lib/cn/kblock_builder.c
+++ b/lib/cn/kblock_builder.c
@@ -965,7 +965,7 @@ kblock_finish(struct kblock_builder *bld, struct wbb *ptree)
         }
 
         err = mpool_mblock_alloc(bld->ds, mclass, &blkid, &mbprop);
-    } while (err && ++allocs < HSE_MPOLICY_MEDIA_CNT);
+    } while (err && ++allocs < MP_MED_COUNT);
 
     if (ev(err))
         goto errout;

--- a/lib/cn/vblock_builder.c
+++ b/lib/cn/vblock_builder.c
@@ -70,7 +70,7 @@ _vblock_start(struct vblock_builder *bld)
         }
 
         err = mpool_mblock_alloc(bld->ds, mclass, &blkid, &mbprop);
-    } while (err && ++allocs < HSE_MPOLICY_MEDIA_CNT);
+    } while (err && ++allocs < MP_MED_COUNT);
 
     if (ev(err))
         return err;

--- a/lib/include/hse_ikvdb/mclass_policy.h
+++ b/lib/include/hse_ikvdb/mclass_policy.h
@@ -6,6 +6,7 @@
 #ifndef HSE_MCLASS_POLICY_H
 #define HSE_MCLASS_POLICY_H
 
+#include <mpool/mpool.h>
 #include <hse_util/compiler.h>
 #include <hse_util/hse_err.h>
 
@@ -24,13 +25,6 @@ enum hse_mclass_policy_dtype {
     HSE_MPOLICY_DTYPE_CNT,
 };
 
-enum hse_mclass_policy_media {
-    HSE_MPOLICY_MEDIA_STAGING,
-    HSE_MPOLICY_MEDIA_CAPACITY,
-    HSE_MPOLICY_MEDIA_CNT,
-    HSE_MPOLICY_MEDIA_INVALID = HSE_MPOLICY_MEDIA_CNT,
-};
-
 /* Max mclass policy name length */
 #define HSE_MPOLICY_NAME_LEN_MAX 32
 
@@ -39,7 +33,7 @@ enum hse_mclass_policy_media {
 
 struct mclass_policy {
     char mc_name[HSE_MPOLICY_NAME_LEN_MAX];
-    u8   mc_table[HSE_MPOLICY_AGE_CNT][HSE_MPOLICY_DTYPE_CNT][HSE_MPOLICY_MEDIA_CNT];
+    u8   mc_table[HSE_MPOLICY_AGE_CNT][HSE_MPOLICY_DTYPE_CNT][MP_MED_COUNT];
 };
 
 /**

--- a/lib/kvdb/kvdb_rparams.c
+++ b/lib/kvdb/kvdb_rparams.c
@@ -109,82 +109,66 @@ mclass_policies_default_builder(const struct param_spec *ps, void *data)
     /* Setup capacity_only */
     policy = &mclass_policies[0];
     strlcpy(policy->mc_name, "capacity_only", sizeof("capacity_only"));
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][0] =
-        HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][1] =
-        HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] =
-        HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][1] =
-        HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][1] = HSE_MPOLICY_MEDIA_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
 
     /* Setup staging_only */
     policy = &mclass_policies[1];
     strlcpy(policy->mc_name, "staging_only", sizeof("staging_only"));
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][0] = HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][0] = HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][0] =
-        HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][1] =
-        HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] =
-        HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][1] =
-        HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][0] = HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] = HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][1] = HSE_MPOLICY_MEDIA_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
 
     /* Setup staging_max_capacity */
     policy = &mclass_policies[2];
     strlcpy(policy->mc_name, "staging_max_capacity", sizeof("staging_max_capacity"));
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][0] = HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][0] = HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][0] =
-        HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][1] =
-        HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] =
-        HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][1] =
-        HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][0] = HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][1] = HSE_MPOLICY_MEDIA_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
 
     /* Setup staging_min_capacity */
     policy = &mclass_policies[3];
     strlcpy(policy->mc_name, "staging_min_capacity", sizeof("staging_min_capacity"));
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][0] = HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][0] = HSE_MPOLICY_MEDIA_STAGING;
-    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][0] =
-        HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][1] =
-        HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] =
-        HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][1] =
-        HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][1] = HSE_MPOLICY_MEDIA_INVALID;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][1] = HSE_MPOLICY_MEDIA_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_STAGING;
+    policy->mc_table[HSE_MPOLICY_AGE_ROOT][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_KEY][1] = MP_MED_INVALID;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_CAPACITY;
+    policy->mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][1] = MP_MED_INVALID;
 
     /* Set default policy for rest of the policies
      * {
@@ -215,11 +199,11 @@ mclass_policies_default_builder(const struct param_spec *ps, void *data)
         for (int age = 0; age < (int)HSE_MPOLICY_AGE_CNT; age++) {
             for (int dtype = 0; dtype < (int)HSE_MPOLICY_DTYPE_CNT; dtype++) {
                 if (age != (int)HSE_MPOLICY_AGE_ROOT && dtype == (int)HSE_MPOLICY_DTYPE_VALUE) {
-                    mclass_policies[i].mc_table[age][dtype][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-                    mclass_policies[i].mc_table[age][dtype][1] = HSE_MPOLICY_MEDIA_INVALID;
+                    mclass_policies[i].mc_table[age][dtype][0] = MP_MED_CAPACITY;
+                    mclass_policies[i].mc_table[age][dtype][1] = MP_MED_INVALID;
                 } else {
-                    mclass_policies[i].mc_table[age][dtype][0] = HSE_MPOLICY_MEDIA_STAGING;
-                    mclass_policies[i].mc_table[age][dtype][1] = HSE_MPOLICY_MEDIA_INVALID;
+                    mclass_policies[i].mc_table[age][dtype][0] = MP_MED_STAGING;
+                    mclass_policies[i].mc_table[age][dtype][1] = MP_MED_INVALID;
                 }
             }
         }
@@ -235,7 +219,7 @@ mclass_policies_converter(const struct param_spec *ps, const cJSON *node, void *
     assert(ps);
     assert(node);
     assert(data);
-    assert(mclass_policy_get_num_fields() == 3);
+    assert(mclass_policy_get_num_fields() == 2);
 
     if (!cJSON_IsArray(node))
         return false;
@@ -245,8 +229,6 @@ mclass_policies_converter(const struct param_spec *ps, const cJSON *node, void *
     const unsigned int              agegroup_map_sz = mclass_policy_get_num_map_entries(0);
     const struct mclass_policy_map *dtype_map = mclass_policy_get_map(1);
     const unsigned int              dtype_map_sz = mclass_policy_get_num_map_entries(1);
-    const struct mclass_policy_map *mclasses_map = mclass_policy_get_map(2);
-    const unsigned int              mclasses_map_sz = mclass_policy_get_num_map_entries(2);
 
     int i = mclass_policy_get_num_default_policies();
     for (cJSON *policy_json = node->child; policy_json; policy_json = policy_json->next, i++) {
@@ -285,9 +267,10 @@ mclass_policies_converter(const struct param_spec *ps, const cJSON *node, void *
 
         const char *policy_name = cJSON_GetStringValue(policy_name_json);
         if (strlen(policy_name) >= HSE_MPOLICY_NAME_LEN_MAX) {
-            log_err("Length of media class policy name '%s' is greater than %d",
-                    policy_name,
-                    HSE_MPOLICY_NAME_LEN_MAX - 1);
+            log_err(
+                "Length of media class policy name '%s' is greater than %d",
+                policy_name,
+                HSE_MPOLICY_NAME_LEN_MAX - 1);
             return false;
         }
 
@@ -308,8 +291,10 @@ mclass_policies_converter(const struct param_spec *ps, const cJSON *node, void *
                 }
             }
             if (agegroup == -1) {
-                log_err("Invalid media class policy age group: %s, must be one of sync, root, internal, or leaf",
-                        agegroup_json->string);
+                log_err(
+                    "Invalid media class policy age group: %s, must be one of sync, root, "
+                    "internal, or leaf",
+                    agegroup_json->string);
                 return false;
             }
 
@@ -328,15 +313,18 @@ mclass_policies_converter(const struct param_spec *ps, const cJSON *node, void *
                     }
                 }
                 if (dtype == -1) {
-                    log_err("Invalid media class policy data type: %s, must be one of key or value",
-                            dtype_json->string);
+                    log_err(
+                        "Invalid media class policy data type: %s, must be one of key or value",
+                        dtype_json->string);
                     return false;
                 }
 
                 const int sz = cJSON_GetArraySize(dtype_json);
-                if (sz > HSE_MPOLICY_MEDIA_CNT) {
-                    log_err("Too many items in media class policy data type array (max = %d)",
-                            HSE_MPOLICY_MEDIA_CNT);
+                if (sz > MP_MED_COUNT) {
+                    log_err(
+                        "Too many items in media class policy data "
+                        "type array (max = %d)",
+                        MP_MED_COUNT);
                     return false;
                 }
 
@@ -347,18 +335,19 @@ mclass_policies_converter(const struct param_spec *ps, const cJSON *node, void *
                         return false;
                     }
 
-                    int media = -1;
-                    for (int k = 0; k < mclasses_map_sz; k++) {
+                    enum mpool_mclass media = MP_MED_INVALID;
+                    for (int k = 0; k < NELEM(mpool_mclass_to_string); k++) {
                         ctx = cJSON_GetStringValue(media_json);
-                        if (!strcmp(ctx, mclasses_map[k].mc_kname)) {
-                            media = mclasses_map[k].mc_enum;
+                        if (!strcmp(ctx, mpool_mclass_to_string[k])) {
+                            media = (enum mpool_mclass)k;
                             break;
                         }
                     }
-                    if (media == -1) {
-                        log_err("Unknown media class in media class policy "
-                                "data type array: %s, must be one of capacity or staging",
-                                ctx);
+                    if (media == MP_MED_INVALID) {
+                        log_err(
+                            "Unknown media class in media class policy "
+                            "data type array: %s, must be one of capacity or staging",
+                            ctx);
                         return false;
                     }
 

--- a/lib/kvdb/mclass_policy.c
+++ b/lib/kvdb/mclass_policy.c
@@ -40,19 +40,12 @@ static const struct mclass_policy_map dtypes[] = {
     { HSE_MPOLICY_DTYPE_VALUE, "values" },
 };
 
-static const struct mclass_policy_map mclasses[] = {
-    {
-        HSE_MPOLICY_MEDIA_STAGING,
-        "staging",
-    },
-    { HSE_MPOLICY_MEDIA_CAPACITY, "capacity" },
+static const struct mclass_policy_map *mclass_policy_fields[] = { agegroups, dtypes };
+
+static const unsigned int mclass_policy_nentries[] = {
+    NELEM(agegroups),
+    NELEM(dtypes),
 };
-
-static const struct mclass_policy_map *mclass_policy_fields[] = { agegroups, dtypes, mclasses };
-
-static const unsigned int mclass_policy_nentries[] = { NELEM(agegroups),
-                                                       NELEM(dtypes),
-                                                       NELEM(mclasses) };
 
 unsigned int
 mclass_policy_get_num_fields()
@@ -82,20 +75,14 @@ mclass_policy_get_num_map_entries(int index)
 enum mpool_mclass
 mclass_policy_get_type(struct mclass_policy *policy, u8 age, u8 dtype, u8 retries)
 {
-    enum hse_mclass_policy_media mtype = HSE_MPOLICY_MEDIA_INVALID;
+    enum mpool_mclass mtype = MP_MED_INVALID;
 
     assert(age < HSE_MPOLICY_AGE_CNT);
     assert(dtype < HSE_MPOLICY_DTYPE_CNT);
-    assert(retries < HSE_MPOLICY_MEDIA_CNT);
+    assert(retries < MP_MED_COUNT);
 
-    if (age < HSE_MPOLICY_AGE_CNT && dtype < HSE_MPOLICY_DTYPE_CNT &&
-        retries < HSE_MPOLICY_MEDIA_CNT)
+    if (age < HSE_MPOLICY_AGE_CNT && dtype < HSE_MPOLICY_DTYPE_CNT && retries < MP_MED_COUNT)
         mtype = policy->mc_table[age][dtype][retries];
 
-    if (mtype == HSE_MPOLICY_MEDIA_STAGING)
-        return MP_MED_STAGING;
-    else if (mtype == HSE_MPOLICY_MEDIA_CAPACITY)
-        return MP_MED_CAPACITY;
-
-    return MP_MED_INVALID;
+    return mtype;
 }

--- a/tests/unit/cn/kblock_builder_test.c
+++ b/tests/unit/cn/kblock_builder_test.c
@@ -218,11 +218,11 @@ initial_setup(struct mtf_test_info *lcl_ti)
 
     for (i = 0; i < HSE_MPOLICY_AGE_CNT; i++)
         for (j = 0; j < HSE_MPOLICY_DTYPE_CNT; j++)
-            for (k = 0; k < HSE_MPOLICY_MEDIA_CNT; k++) {
+            for (k = 0; k < MP_MED_COUNT; k++) {
                 if (k == 0)
-                    mocked_mpolicy.mc_table[i][j][k] = HSE_MPOLICY_MEDIA_CAPACITY;
+                    mocked_mpolicy.mc_table[i][j][k] = MP_MED_CAPACITY;
                 else
-                    mocked_mpolicy.mc_table[i][j][k] = HSE_MPOLICY_MEDIA_INVALID;
+                    mocked_mpolicy.mc_table[i][j][k] = MP_MED_INVALID;
             }
 
     return 0;

--- a/tests/unit/cn/vblock_builder_test.c
+++ b/tests/unit/cn/vblock_builder_test.c
@@ -94,11 +94,11 @@ initial_setup(struct mtf_test_info *lcl_ti)
 
     for (i = 0; i < HSE_MPOLICY_AGE_CNT; i++)
         for (j = 0; j < HSE_MPOLICY_DTYPE_CNT; j++)
-            for (k = 0; k < HSE_MPOLICY_MEDIA_CNT; k++) {
+            for (k = 0; k < MP_MED_COUNT; k++) {
                 if (k == 0)
-                    mocked_mpolicy.mc_table[i][j][k] = HSE_MPOLICY_MEDIA_CAPACITY;
+                    mocked_mpolicy.mc_table[i][j][k] = MP_MED_CAPACITY;
                 else
-                    mocked_mpolicy.mc_table[i][j][k] = HSE_MPOLICY_MEDIA_INVALID;
+                    mocked_mpolicy.mc_table[i][j][k] = MP_MED_INVALID;
             }
 
     return 0;

--- a/tests/unit/kvdb/mclass_policy_test.c
+++ b/tests/unit/kvdb/mclass_policy_test.c
@@ -34,16 +34,16 @@ MTF_DEFINE_UTEST_PRE(mclass_policy_test, mclass_policy_default, general_pre)
     strcpy(dpolicies[0].mc_name, "capacity_only");
     for (i = 0; i < HSE_MPOLICY_AGE_CNT; i++)
         for (j = 0; j < HSE_MPOLICY_DTYPE_CNT; j++) {
-            dpolicies[0].mc_table[i][j][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-            dpolicies[0].mc_table[i][j][1] = HSE_MPOLICY_MEDIA_INVALID;
+            dpolicies[0].mc_table[i][j][0] = MP_MED_CAPACITY;
+            dpolicies[0].mc_table[i][j][1] = MP_MED_INVALID;
         }
 
     /* Staging only media class policy, use staging for all combinations  */
     strcpy(dpolicies[1].mc_name, "staging_only");
     for (i = 0; i < HSE_MPOLICY_AGE_CNT; i++)
         for (j = 0; j < HSE_MPOLICY_DTYPE_CNT; j++) {
-            dpolicies[1].mc_table[i][j][0] = HSE_MPOLICY_MEDIA_STAGING;
-            dpolicies[1].mc_table[i][j][1] = HSE_MPOLICY_MEDIA_INVALID;
+            dpolicies[1].mc_table[i][j][0] = MP_MED_STAGING;
+            dpolicies[1].mc_table[i][j][1] = MP_MED_INVALID;
         }
 
     /*
@@ -52,13 +52,11 @@ MTF_DEFINE_UTEST_PRE(mclass_policy_test, mclass_policy_default, general_pre)
     strcpy(dpolicies[2].mc_name, "staging_max_capacity");
     for (i = 0; i < HSE_MPOLICY_AGE_CNT; i++)
         for (j = 0; j < HSE_MPOLICY_DTYPE_CNT; j++) {
-            dpolicies[2].mc_table[i][j][0] = HSE_MPOLICY_MEDIA_STAGING;
-            dpolicies[2].mc_table[i][j][1] = HSE_MPOLICY_MEDIA_INVALID;
+            dpolicies[2].mc_table[i][j][0] = MP_MED_STAGING;
+            dpolicies[2].mc_table[i][j][1] = MP_MED_INVALID;
         }
-    dpolicies[2].mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] =
-        HSE_MPOLICY_MEDIA_CAPACITY;
-    dpolicies[2].mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] =
-        HSE_MPOLICY_MEDIA_CAPACITY;
+    dpolicies[2].mc_table[HSE_MPOLICY_AGE_INTERNAL][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_CAPACITY;
+    dpolicies[2].mc_table[HSE_MPOLICY_AGE_LEAF][HSE_MPOLICY_DTYPE_VALUE][0] = MP_MED_CAPACITY;
 
     /*
      * staging_min_capacity - only root nodes use staging.
@@ -66,14 +64,14 @@ MTF_DEFINE_UTEST_PRE(mclass_policy_test, mclass_policy_default, general_pre)
     strcpy(dpolicies[3].mc_name, "staging_min_capacity");
     for (i = 0; i < HSE_MPOLICY_AGE_INTERNAL; i++)
         for (j = 0; j < HSE_MPOLICY_DTYPE_CNT; j++) {
-            dpolicies[3].mc_table[i][j][0] = HSE_MPOLICY_MEDIA_STAGING;
-            dpolicies[3].mc_table[i][j][1] = HSE_MPOLICY_MEDIA_INVALID;
+            dpolicies[3].mc_table[i][j][0] = MP_MED_STAGING;
+            dpolicies[3].mc_table[i][j][1] = MP_MED_INVALID;
         }
 
     for (i = HSE_MPOLICY_AGE_INTERNAL; i < HSE_MPOLICY_AGE_CNT; i++)
         for (j = 0; j < HSE_MPOLICY_DTYPE_CNT; j++) {
-            dpolicies[3].mc_table[i][j][0] = HSE_MPOLICY_MEDIA_CAPACITY;
-            dpolicies[3].mc_table[i][j][1] = HSE_MPOLICY_MEDIA_INVALID;
+            dpolicies[3].mc_table[i][j][0] = MP_MED_CAPACITY;
+            dpolicies[3].mc_table[i][j][1] = MP_MED_INVALID;
         }
 
     err = argv_deserialize_to_kvdb_rparams(NELEM(paramv), paramv, &params);
@@ -82,9 +80,9 @@ MTF_DEFINE_UTEST_PRE(mclass_policy_test, mclass_policy_default, general_pre)
     /* Validate that the parsed policies match the hardcoded matrices for the default policies. */
     for (i = 0; i < HSE_MPOLICY_AGE_CNT; i++)
         for (j = 0; j < HSE_MPOLICY_DTYPE_CNT; j++)
-            for (k = 0; k < HSE_MPOLICY_MEDIA_CNT; k++)
+            for (k = 0; k < MP_MED_COUNT; k++)
                 for (l = 0; l < 4; l++) {
-                    enum hse_mclass_policy_media hse_mtype;
+                    enum mpool_mclass            hse_mtype;
                     enum mpool_mclass            mpool_mtype;
 
                     hse_mtype = params.mclass_policies[l].mc_table[i][j][k];
@@ -93,9 +91,9 @@ MTF_DEFINE_UTEST_PRE(mclass_policy_test, mclass_policy_default, general_pre)
                     ASSERT_EQ(strcmp(params.mclass_policies[l].mc_name, dpolicies[l].mc_name), 0);
 
                     mpool_mtype = mclass_policy_get_type(&params.mclass_policies[l], i, j, k);
-                    if (hse_mtype == HSE_MPOLICY_MEDIA_INVALID)
+                    if (hse_mtype == MP_MED_INVALID)
                         ASSERT_EQ(mpool_mtype, MP_MED_INVALID);
-                    else if (hse_mtype == HSE_MPOLICY_MEDIA_STAGING)
+                    else if (hse_mtype == MP_MED_STAGING)
                         ASSERT_EQ(mpool_mtype, MP_MED_STAGING);
                     else
                         ASSERT_EQ(mpool_mtype, MP_MED_CAPACITY);
@@ -112,8 +110,8 @@ MTF_DEFINE_UTEST_PRE(mclass_policy_test, mclass_policy_default, general_pre)
 
     for (i = 0; i < HSE_MPOLICY_AGE_CNT; i++)
         for (j = 0; j < HSE_MPOLICY_DTYPE_CNT; j++)
-            for (k = 0; k < HSE_MPOLICY_MEDIA_CNT; k++) {
-                enum hse_mclass_policy_media hse_mtype;
+            for (k = 0; k < MP_MED_COUNT; k++) {
+                enum mpool_mclass            hse_mtype;
                 enum mpool_mclass            mpool_mtype;
 
                 hse_mtype = params.mclass_policies[4].mc_table[i][j][k];
@@ -123,16 +121,16 @@ MTF_DEFINE_UTEST_PRE(mclass_policy_test, mclass_policy_default, general_pre)
                     ASSERT_EQ(hse_mtype, dpolicies[2].mc_table[i][j][k]);
                 } else if (k == 0) {
                     /* <internal, leaf> first preference is capacity */
-                    ASSERT_EQ(hse_mtype, HSE_MPOLICY_MEDIA_CAPACITY);
+                    ASSERT_EQ(hse_mtype, MP_MED_CAPACITY);
                 } else {
                     /* <internal, leaf> no second preference */
-                    ASSERT_EQ(hse_mtype, HSE_MPOLICY_MEDIA_INVALID);
+                    ASSERT_EQ(hse_mtype, MP_MED_INVALID);
                 }
 
                 mpool_mtype = mclass_policy_get_type(&params.mclass_policies[4], i, j, k);
-                if (hse_mtype == HSE_MPOLICY_MEDIA_INVALID)
+                if (hse_mtype == MP_MED_INVALID)
                     ASSERT_EQ(mpool_mtype, MP_MED_INVALID);
-                else if (hse_mtype == HSE_MPOLICY_MEDIA_STAGING)
+                else if (hse_mtype == MP_MED_STAGING)
                     ASSERT_EQ(mpool_mtype, MP_MED_STAGING);
                 else
                     ASSERT_EQ(mpool_mtype, MP_MED_CAPACITY);


### PR DESCRIPTION
These were essentially mirrors of their mpool counterparts. No sense in
having duplicate information.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
