### PR TITLE
Remove weak attribute from mtf_test_failure()

### DIFF
--- a/tests/framework/include/mtf/conditions.h
+++ b/tests/framework/include/mtf/conditions.h
@@ -8,11 +8,8 @@
 
 #include <stdlib.h>
 
-#include <hse_util/compiler.h>
-
 #include "common.h"
 
-HSE_WEAK
 void
 mtf_test_failure(void);
 


### PR DESCRIPTION
When the weak attribute exists, a test failure causes the program to
segfault instead of abort due to an undefined symbol. Why is it
undefined? The world may never know. It is clearly defined in
libhse-test-framework.a, but not in the final test executables.

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
