### PR TITLE
NFSE-5084: meson cleanup + nightly tests fix

### DIFF
--- a/.github/workflows/nightly_testing.yaml
+++ b/.github/workflows/nightly_testing.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         default: "master"
 
+env:
+  MESON_TESTTHREADS: 1
+
 jobs:
   nightly_ub:
     runs-on: ${{ matrix.os }}
@@ -50,7 +53,7 @@ jobs:
 
       - name: Run tests
         run: |
-          poetry run meson test -C builddir --suite=nightly-small --num-processes=1 --print-errorlogs --no-stdsplit
+          poetry run meson test -C builddir --suite=nightly-small --print-errorlogs --no-stdsplit
 
       - uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/nightly_testing.yaml
+++ b/.github/workflows/nightly_testing.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run tests
         run: |
-          poetry run meson test -C builddir --suite=nightly-small --print-errorlogs --no-stdsplit
+          poetry run meson test -C builddir --suite=nightly-small --num-processes=1 --print-errorlogs --no-stdsplit
 
       - uses: actions/upload-artifact@v2
         if: failure()

--- a/meson.build
+++ b/meson.build
@@ -140,13 +140,6 @@ add_project_arguments(
     language: 'c',
 )
 
-build_number_result = run_command(
-    'sh',
-    '-c',
-    '[ -n "$BUILD_NUMBER" ]'
-)
-in_ci = build_number_result.returncode() == 0
-
 libcurl_dep = dependency(
     'libcurl',
     version: '>=7.58.0',

--- a/tests/functional/smoke/meson.build
+++ b/tests/functional/smoke/meson.build
@@ -277,7 +277,7 @@ foreach t, params : tests
             t,
         ],
         timeout: 1800,
-        is_parallel: not in_ci,
+        is_parallel: true,
         workdir: meson.current_source_dir(),
         suite: ['functional'] + params.get('suites', []),
         depends: [

--- a/tests/functional/smoke/meson.build
+++ b/tests/functional/smoke/meson.build
@@ -277,7 +277,6 @@ foreach t, params : tests
             t,
         ],
         timeout: 1800,
-        is_parallel: true,
         workdir: meson.current_source_dir(),
         suite: ['functional'] + params.get('suites', []),
         depends: [

--- a/tests/stress/meson.build
+++ b/tests/stress/meson.build
@@ -108,10 +108,10 @@ programs = {
         },
         'nightly-tests': {
             'create_cursor_small': {
-                'args': '-b 64 -c 1500000 -d 1 -e 1000 -o 2 -v 256'.split(),
+                'args': '-b 64 -c 1000000 -d 1 -e 1000 -o 2 -v 256'.split(),
             },
             'cursor_with_sync_small': {
-                'args': '-b 64 -c 1500000 -d 5 -e 1000 -o 2 -v 512'.split(),
+                'args': '-b 64 -c 1000000 -d 5 -e 1000 -o 2 -v 512'.split(),
             },
             'cursor_with_transactions_small': {
                 'args': '-b 64 -c 1000000 -d 6 -e 1000 -o 2 -s 1000 -v 256'.split(),


### PR DESCRIPTION
## Description
Cleanup some unused vars in meson, force nightly tests to use 1 thread always, revert smoke to be parallel always

## Issue(s) Addressed
NFSE-5084

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
