### PR TITLE
NFSE-5087 Remove kblock/vblock size params

### DIFF
--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -1578,7 +1578,7 @@ cn_make(struct mpool *ds, const struct kvs_cparams *cp, struct kvdb_health *heal
 u64
 cn_mpool_dev_zone_alloc_unit_default(struct cn *cn, enum hse_mclass mclass)
 {
-    return cn->cn_mpool_props.mclass[mclass].mc_mblocksz << 20;
+    return cn->cn_mpool_props.mclass[mclass].mc_mblocksz;
 }
 
 u64

--- a/lib/cn/cndb.c
+++ b/lib/cn/cndb.c
@@ -137,7 +137,6 @@ cndb_alloc(struct mpool *mp, u64 *captgt, u64 *oid1_out, u64 *oid2_out)
     merr_t                    err;
     size_t                    capacity;
     int                       i;
-    struct mpool_mclass_props props;
 
     if (captgt && *captgt)
         capacity = *captgt;
@@ -145,8 +144,7 @@ cndb_alloc(struct mpool *mp, u64 *captgt, u64 *oid1_out, u64 *oid2_out)
         capacity = CNDB_CAPTGT_DEFAULT;
 
     for (i = HSE_MCLASS_COUNT - 1; i >= HSE_MCLASS_BASE; i--) {
-        err = mpool_mclass_props_get(mp, i, &props);
-        if (!err)
+        if (mpool_mclass_is_configured(mp, i))
             break;
     }
     assert(i >= HSE_MCLASS_BASE);

--- a/lib/cn/kblock_builder.h
+++ b/lib/cn/kblock_builder.h
@@ -132,7 +132,7 @@ kbb_finish(struct kblock_builder *bld, struct blk_list *kblks, u64 seqno_min, u6
 size_t
 kbb_estimate_alen(struct cn *cn, size_t wlen, enum hse_mclass mclass);
 
-void
+merr_t
 kbb_set_agegroup(struct kblock_builder *bld, enum hse_mclass_policy_age age);
 
 enum hse_mclass_policy_age

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -251,8 +251,6 @@ kv_spill(struct cn_compaction_work *w)
      * readahead buffer).
      */
     direct_read_len = w->cw_rp->cn_compact_vblk_ra;
-    if (direct_read_len < 32 * 1024)
-        direct_read_len = 32 * 1024;
     direct_read_len -= PAGE_SIZE;
 
     tstart = perfc_ison(w->cw_pc, PERFC_DI_CNCOMP_VGET) ? 1 : 0;

--- a/lib/cn/vblock_builder.h
+++ b/lib/cn/vblock_builder.h
@@ -114,7 +114,7 @@ vbb_vblock_hdr_len(void);
 merr_t
 vbb_blk_list_merge(struct vblock_builder *dst, struct vblock_builder *src, struct blk_list *vblks);
 
-void
+merr_t
 vbb_set_agegroup(struct vblock_builder *bld, enum hse_mclass_policy_age age);
 
 enum hse_mclass_policy_age

--- a/lib/cn/vblock_builder_internal.h
+++ b/lib/cn/vblock_builder_internal.h
@@ -1,10 +1,19 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_KVS_CN_VBLOCK_BUILDER_INT_H
 #define HSE_KVS_CN_VBLOCK_BUILDER_INT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <hse_ikvdb/blk_list.h>
+#include <hse_ikvdb/mclass_policy.h>
+
+#include <hse_util/hse_err.h>
 
 #define WBUF_LEN_MAX (1024 * 1024)
 #define VBLOCK_HDR_LEN 4096
@@ -25,6 +34,7 @@ struct cn_merge_stats;
  *             minus the size of the vblock byte header.
  * @destruct:  if true, vlbock builder is ready to be destroyed
  * @opt_wrsz:  optimal write size for incremental mblock writes
+ * @mblocksz:  mblock size of specified media class
  *
  * WBUF_LEN_MAX is the allocated size of the write buffer.  Each mblock write
  * will be at most WBUF_LEN_MAX bytes.  Member @wbuf_len is the actual write
@@ -40,7 +50,7 @@ struct cn_merge_stats;
  * When a new value is given to the vblock builder
  * -----------------------------------------------
  *
- *   Let @vlen be the lenght of the new value
+ *   Let @vlen be the length of the new value
  *
  *   If current vblock has not been allocated, start a new vblock as follows:
  *     - allocate vblock
@@ -70,16 +80,16 @@ struct vblock_builder {
     struct cn_merge_stats *    mstats;
     struct blk_list            vblk_list;
     enum hse_mclass_policy_age agegroup;
-    u64                        vsize;
-    u64                        blkid;
-    uint                       max_size;
-    uint                       vblk_off;
+    uint64_t                   vsize;
+    uint64_t                   blkid;
+    uint32_t                   max_size;
+    off_t                      vblk_off;
     void *                     wbuf;
-    uint                       wbuf_off;
-    uint                       wbuf_len;
-    u64                        vgroup;
+    off_t                      wbuf_off;
+    unsigned int               wbuf_len;
+    uint64_t                   vgroup;
     bool                       destruct;
-    u32                        opt_wrsz;
+    uint32_t                   opt_wrsz;
 };
 
 static inline bool
@@ -88,13 +98,13 @@ _vblock_has_room(struct vblock_builder *bld, size_t vlen)
     return bld->vblk_off + vlen <= bld->max_size;
 }
 
-static inline uint
+static inline uint32_t
 _vblock_unused_media_space(struct vblock_builder *bld)
 {
     return bld->max_size - bld->vblk_off;
 }
 
 merr_t
-_vblock_finish_ext(struct vblock_builder *bld, u8 slot, bool final);
+_vblock_finish_ext(struct vblock_builder *bld, uint8_t slot, bool final);
 
 #endif

--- a/lib/include/hse_ikvdb/kvs_rparams.h
+++ b/lib/include/hse_ikvdb/kvs_rparams.h
@@ -72,8 +72,6 @@ struct kvs_rparams {
     uint64_t cn_bloom_preload;
 
     uint64_t cn_kcachesz;
-    uint64_t kblock_size;
-    uint64_t vblock_size;
 
     uint64_t capped_evict_ttl;
 

--- a/lib/kvs/kvs_rparams.c
+++ b/lib/kvs/kvs_rparams.c
@@ -18,6 +18,7 @@
 #include <hse_util/storage.h>
 
 #include <hse_ikvdb/mclass_policy.h>
+#include <hse_ikvdb/ikvdb.h>
 #include <hse_ikvdb/param.h>
 #include <hse_ikvdb/kvs_rparams.h>
 #include <hse_ikvdb/limits.h>
@@ -265,12 +266,12 @@ static const struct param_spec pspecs[] = {
         .ps_stringify = param_default_stringify,
         .ps_jsonify = param_default_jsonify,
         .ps_default_value = {
-            .as_uscalar = 256 * 1024,
+            .as_uscalar = 256 << KB_SHIFT,
         },
         .ps_bounds = {
             .as_uscalar = {
-                .ps_min = 0,
-                .ps_max = UINT64_MAX,
+                .ps_min = 32 << KB_SHIFT,
+                .ps_max = 2 << MB_SHIFT,
             },
         },
     },
@@ -307,12 +308,12 @@ static const struct param_spec pspecs[] = {
         .ps_stringify = param_default_stringify,
         .ps_jsonify = param_default_jsonify,
         .ps_default_value = {
-            .as_uscalar = 512 * 1024,
+            .as_uscalar = 512 << KB_SHIFT,
         },
         .ps_bounds = {
             .as_uscalar = {
-                .ps_min = 0,
-                .ps_max = UINT64_MAX,
+                .ps_min = 32 << KB_SHIFT,
+                .ps_max = 2 << MB_SHIFT,
             },
         },
     },
@@ -761,48 +762,6 @@ static const struct param_spec pspecs[] = {
             .as_uscalar = {
                 .ps_min = 0,
                 .ps_max = UINT64_MAX,
-            },
-        },
-    },
-    {
-        .ps_name = "kblock_size_mb",
-        .ps_description = "preferred kblock size (in MiB)",
-        .ps_flags = PARAM_FLAG_EXPERIMENTAL,
-        .ps_type = PARAM_TYPE_U64,
-        .ps_offset = offsetof(struct kvs_rparams, kblock_size),
-        .ps_size = PARAM_SZ(struct kvs_rparams, kblock_size),
-        .ps_convert = param_convert_to_bytes_from_MB,
-        .ps_validate = param_default_validator,
-        .ps_stringify = param_stringify_bytes_to_MB,
-        .ps_jsonify = param_jsonify_bytes_to_MB,
-        .ps_default_value = {
-            .as_uscalar = 32 * MB,
-        },
-        .ps_bounds = {
-            .as_uscalar = {
-                .ps_min = KBLOCK_MIN_SIZE,
-                .ps_max = KBLOCK_MAX_SIZE,
-            },
-        },
-    },
-    {
-        .ps_name = "vblock_size_mb",
-        .ps_description = "",
-        .ps_flags = PARAM_FLAG_EXPERIMENTAL,
-        .ps_type = PARAM_TYPE_U64,
-        .ps_offset = offsetof(struct kvs_rparams, vblock_size),
-        .ps_size = PARAM_SZ(struct kvs_rparams, vblock_size),
-        .ps_convert = param_convert_to_bytes_from_MB,
-        .ps_validate = param_default_validator,
-        .ps_stringify = param_stringify_bytes_to_MB,
-        .ps_jsonify = param_jsonify_bytes_to_MB,
-        .ps_default_value = {
-            .as_uscalar = 32 * MB,
-        },
-        .ps_bounds = {
-            .as_uscalar = {
-                .ps_min = VBLOCK_MIN_SIZE,
-                .ps_max = VBLOCK_MAX_SIZE,
             },
         },
     },

--- a/lib/mpool/include/mpool/mpool.h
+++ b/lib/mpool/include/mpool/mpool.h
@@ -149,6 +149,17 @@ mpool_mclass_ftw(
     const char           *prefix,
     struct mpool_file_cb *cb);
 
+/** @brief Check if a media class is configured.
+ *
+ * @param mp: Mpool.
+ * @param mclass: Media class.
+ *
+ * @returns true if configured, false if not.
+ */
+/* MTF_MOCK */
+bool
+mpool_mclass_is_configured(struct mpool *mp, enum hse_mclass mclass);
+
 /**
  * mpool_props_get() - get mpool properties
  *

--- a/lib/mpool/src/mclass.c
+++ b/lib/mpool/src/mclass.c
@@ -407,7 +407,7 @@ void
 mclass_props_get(struct media_class *const mc, struct mpool_mclass_props *const props)
 {
     props->mc_fmaxsz = mblock_fset_fmaxsz_get(mc->mbfsp);
-    props->mc_mblocksz = mc->mblocksz >> MB_SHIFT;
+    props->mc_mblocksz = mc->mblocksz;
     props->mc_filecnt = mblock_fset_filecnt_get(mc->mbfsp);
     strlcpy(props->mc_path, mc->upath, sizeof(props->mc_path));
 }

--- a/lib/mpool/src/mpool.c
+++ b/lib/mpool/src/mpool.c
@@ -515,6 +515,12 @@ mpool_mclass_ftw(
     return mclass_ftw(mc, prefix, cb);
 }
 
+bool
+mpool_mclass_is_configured(struct mpool *const mp, const enum hse_mclass mclass)
+{
+    return !!mpool_mclass_handle(mp, mclass);
+}
+
 void
 mpool_cparams_defaults(struct mpool_cparams *cparams)
 {

--- a/lib/wal/wal.c
+++ b/lib/wal/wal.c
@@ -501,11 +501,9 @@ wal_create(struct mpool *mp, uint64_t *mdcid1, uint64_t *mdcid2)
     struct wal_mdc *          mdc;
     merr_t                    err;
     int                       i;
-    struct mpool_mclass_props props;
 
     for (i = HSE_MCLASS_COUNT - 1; i >= HSE_MCLASS_BASE; i--) {
-        err = mpool_mclass_props_get(mp, i, &props);
-        if (!err)
+        if (mpool_mclass_is_configured(mp, i))
             break;
     }
     assert(i >= HSE_MCLASS_BASE);

--- a/scripts/build/utpp
+++ b/scripts/build/utpp
@@ -191,7 +191,7 @@ function emit_header(name, set_name, ku, prefix, args)
             printf("\t\trc = (void *)(mtfm_%s_%s_get())(__VA_ARGS__); \\\n",
                    set_name, name) > TARGET_FILE;
             printf("\trc; \\\n") > TARGET_FILE;
-        } else if (prefix ~ /bool|int|uint|unsigned|long|ulong|merr_t|size_t|ssize_t|enum|s8|s16|s32|s64|u8|u16|u32|u64|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t/) {
+        } else if (prefix ~ /bool|int|uint|unsigned|unsigned int|long|ulong|merr_t|size_t|ssize_t|enum|s8|s16|s32|s64|u8|u16|u32|u64|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t/) {
             printf("\tuint64_t rc = 0; \\\n") > TARGET_FILE;
             printf("\tif (!mapi_enabled || !mapi_inject_check(%s%s, &rc)) \\\n",
                    "mapi_idx_", name) > TARGET_FILE;

--- a/tests/unit/cn/kblock_builder_test.c
+++ b/tests/unit/cn/kblock_builder_test.c
@@ -8,7 +8,6 @@
 
 #include <hse_util/hse_err.h>
 #include <hse_util/logging.h>
-#include <hse_util/storage.h>
 
 #include <hse/limits.h>
 
@@ -28,8 +27,6 @@
 
 const struct kvs_rparams mocked_rp_default = {
     .cn_bloom_create = 1,
-    .kblock_size = 32 * MB,
-    .vblock_size = 32 *MB,
 };
 
 const struct kvs_cparams mocked_cp_default = {
@@ -250,7 +247,8 @@ MTF_DEFINE_UTEST_PRE(test, t_kbb_create1, test_setup)
     ASSERT_EQ(err, 0);
 
     for (i = 0; i < HSE_MPOLICY_AGE_CNT; i++) {
-        kbb_set_agegroup(kbb, i);
+        err = kbb_set_agegroup(kbb, i);
+        ASSERT_EQ(0, merr_errno(err));
         ASSERT_EQ(kbb_get_agegroup(kbb), i);
     }
 

--- a/tests/unit/cn/vblock_builder_test.c
+++ b/tests/unit/cn/vblock_builder_test.c
@@ -119,7 +119,8 @@ MTF_DEFINE_UTEST_PRE(test, t_vbb_create1, test_setup)
     ASSERT_EQ(err, 0);
 
     for (i = 0; i < HSE_MPOLICY_AGE_CNT; i++) {
-        vbb_set_agegroup(vbb, i);
+        err = vbb_set_agegroup(vbb, i);
+        ASSERT_EQ(0, merr_errno(err));
         ASSERT_EQ(vbb_get_agegroup(vbb), i);
     }
 
@@ -468,7 +469,7 @@ fill_exact(struct mtf_test_info *lcl_ti, struct vblock_builder *vbb, uint space,
 {
     merr_t err = 0;
     uint   vlen_max = HSE_KVS_VALUE_LEN_MAX;
-    uint   avail = kvsrp.vblock_size - PAGE_SIZE - space;
+    uint   avail = MPOOL_MBLOCK_SIZE_DEFAULT - PAGE_SIZE - space;
     uint   vlen;
 
     while (avail > 0) {
@@ -491,7 +492,7 @@ run_test_case(struct mtf_test_info *lcl_ti, enum test_case tc, size_t n_vblocks)
 {
     struct vblock_builder *vbb = 0;
 
-    const size_t mblock_size = kvsrp.vblock_size;
+    const size_t mblock_size = MPOOL_MBLOCK_SIZE_DEFAULT;
     const size_t vblock_hdr_size = PAGE_SIZE;
     const size_t avail_mblock_size = mblock_size - vblock_hdr_size;
     const size_t vlen = 50 * 1000;

--- a/tests/unit/kvdb/kvdb_rest_test.c
+++ b/tests/unit/kvdb/kvdb_rest_test.c
@@ -145,6 +145,7 @@ struct mapi_injection inject_list[] = {
     { mapi_idx_mpool_mdc_rewind, MAPI_RC_SCALAR, 0 },
     { mapi_idx_mpool_mdc_read, MAPI_RC_SCALAR, 0 },
     { mapi_idx_mpool_mclass_props_get, MAPI_RC_SCALAR, ENOENT },
+    { mapi_idx_mpool_mclass_is_configured, MAPI_RC_SCALAR, true },
 
     { mapi_idx_cn_get_tree, MAPI_RC_SCALAR, 0 },
 
@@ -206,7 +207,6 @@ test_pre(struct mtf_test_info *lcl_ti)
     ASSERT_EQ_RET(0, err, merr_errno(err));
     err = ikvdb_kvs_create(store, KVS3, &kvs_cp);
 
-    mapi_inject(mapi_idx_mpool_mclass_props_get, 0);
     err = ikvdb_kvs_open(store, KVS1, &kvs_rp, 0, &kvs1);
     ASSERT_EQ_RET(0, err, merr_errno(err));
 
@@ -229,7 +229,6 @@ test_post(struct mtf_test_info *ti)
     store = 0;
 
     MOCK_UNSET(platform, _hse_meminfo);
-    mapi_inject_unset(mapi_idx_mpool_mclass_props_get);
 
     mock_kvdb_meta_unset();
 

--- a/tests/unit/kvs/kvs_rparams_test.c
+++ b/tests/unit/kvs/kvs_rparams_test.c
@@ -207,9 +207,9 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_compact_vblk_ra, test_pre)
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
-    ASSERT_EQ(256 * 1024, params.cn_compact_vblk_ra);
-    ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(256 << KB_SHIFT, params.cn_compact_vblk_ra);
+    ASSERT_EQ(32 << KB_SHIFT, ps->ps_bounds.as_uscalar.ps_min);
+    ASSERT_EQ(2 << MB_SHIFT, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_compact_vra, test_pre)
@@ -245,9 +245,9 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_compact_kblk_ra, test_pre)
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
-    ASSERT_EQ(512 * 1024, params.cn_compact_kblk_ra);
-    ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(512 << KB_SHIFT, params.cn_compact_kblk_ra);
+    ASSERT_EQ(32 << KB_SHIFT, ps->ps_bounds.as_uscalar.ps_min);
+    ASSERT_EQ(2 << MB_SHIFT, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_capped_ttl, test_pre)
@@ -675,54 +675,6 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_kcachesz, test_pre)
     ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
-MTF_DEFINE_UTEST_PRE(kvs_rparams_test, kblock_size, test_pre)
-{
-    merr_t                   err;
-    const struct param_spec *ps = ps_get("kblock_size_mb");
-
-    ASSERT_NE(NULL, ps);
-    ASSERT_NE(NULL, ps->ps_description);
-    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
-    ASSERT_EQ(offsetof(struct kvs_rparams, kblock_size), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
-    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_convert_to_bytes_from_MB);
-    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
-    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_stringify_bytes_to_MB);
-    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_jsonify_bytes_to_MB);
-    ASSERT_EQ(32 * MB, params.kblock_size);
-    ASSERT_EQ(KBLOCK_MIN_SIZE, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(KBLOCK_MAX_SIZE, ps->ps_bounds.as_uscalar.ps_max);
-
-    err = check("kblock_size_mb=32", true, NULL);
-    ASSERT_EQ(0, merr_errno(err));
-    ASSERT_EQ(32 * MB, params.kblock_size);
-}
-
-MTF_DEFINE_UTEST_PRE(kvs_rparams_test, vblock_size, test_pre)
-{
-    merr_t                   err;
-    const struct param_spec *ps = ps_get("vblock_size_mb");
-
-    ASSERT_NE(NULL, ps);
-    ASSERT_NE(NULL, ps->ps_description);
-    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
-    ASSERT_EQ(offsetof(struct kvs_rparams, vblock_size), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
-    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_convert_to_bytes_from_MB);
-    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
-    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_stringify_bytes_to_MB);
-    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_jsonify_bytes_to_MB);
-    ASSERT_EQ(32 * MB, params.vblock_size);
-    ASSERT_EQ(VBLOCK_MIN_SIZE, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(VBLOCK_MAX_SIZE, ps->ps_bounds.as_uscalar.ps_max);
-
-    err = check("kblock_size_mb=32", true, NULL);
-    ASSERT_EQ(0, merr_errno(err));
-    ASSERT_EQ(32 * MB, params.kblock_size);
-}
-
 MTF_DEFINE_UTEST_PRE(kvs_rparams_test, capped_evict_ttl, test_pre)
 {
     const struct param_spec *ps = ps_get("capped_evict_ttl");
@@ -870,16 +822,16 @@ MTF_DEFINE_UTEST(kvs_rparams_test, set)
 
     const struct kvs_rparams p = kvs_rparams_defaults();
 
-    err = kvs_rparams_set(&p, "cn_compact_kblk_ra", "64");
+    err = kvs_rparams_set(&p, "cn_compact_kblk_ra", "32768");
     ASSERT_EQ(0, merr_errno(err));
-    ASSERT_EQ(64, p.cn_compact_kblk_ra);
+    ASSERT_EQ(32768, p.cn_compact_kblk_ra);
 
     err = kvs_rparams_set(&p, NULL, "64");
     ASSERT_EQ(EINVAL, merr_errno(err));
 
     err = kvs_rparams_set(&p, "cn_compact_kblk_ra", NULL);
     ASSERT_EQ(EINVAL, merr_errno(err));
-    ASSERT_EQ(64, p.cn_compact_kblk_ra);
+    ASSERT_EQ(32768, p.cn_compact_kblk_ra);
 
     err = kvs_rparams_set(&p, "does.not.exist", "5");
     ASSERT_EQ(EINVAL, merr_errno(err));
@@ -887,12 +839,12 @@ MTF_DEFINE_UTEST(kvs_rparams_test, set)
     /* Fail to parse */
     err = kvs_rparams_set(&p, "cn_compact_kblk_ra", "invalid");
     ASSERT_EQ(EINVAL, merr_errno(err));
-    ASSERT_EQ(64, p.cn_compact_kblk_ra);
+    ASSERT_EQ(32768, p.cn_compact_kblk_ra);
 
     /* Fail to convert */
     err = kvs_rparams_set(&p, "cn_compact_kblk_ra", "\"convert\"");
     ASSERT_EQ(EINVAL, merr_errno(err));
-    ASSERT_EQ(64, p.cn_compact_kblk_ra);
+    ASSERT_EQ(32768, p.cn_compact_kblk_ra);
 
     /* Fail to validate */
     /* No writable parameter which would have a way to not be validated. cJSON

--- a/tests/unit/mpool/mpool_test.c
+++ b/tests/unit/mpool/mpool_test.c
@@ -61,7 +61,7 @@ MTF_DEFINE_UTEST_PREPOST(mpool_test, mpool_ocd_test, mpool_test_pre, mpool_test_
 
     err = mpool_props_get(mp, &mprops);
     ASSERT_EQ(0, merr_errno(err));
-    ASSERT_EQ(32, mprops.mclass[HSE_MCLASS_CAPACITY].mc_mblocksz);
+    ASSERT_EQ(MPOOL_MBLOCK_SIZE_DEFAULT, mprops.mclass[HSE_MCLASS_CAPACITY].mc_mblocksz);
 
     err = mpool_info_get(NULL, &info);
     ASSERT_EQ(EINVAL, merr_errno(err));
@@ -189,7 +189,7 @@ MTF_DEFINE_UTEST_PREPOST(mpool_test, mclass_test, mpool_test_pre, mpool_test_pos
 
     err = mpool_mclass_props_get(mp, HSE_MCLASS_CAPACITY, &props);
     ASSERT_EQ(0, merr_errno(err));
-    ASSERT_EQ(32, props.mc_mblocksz);
+    ASSERT_EQ(MPOOL_MBLOCK_SIZE_DEFAULT, props.mc_mblocksz);
 
     err = mpool_mclass_info_get(NULL, HSE_MCLASS_CAPACITY, &info);
     ASSERT_EQ(EINVAL, merr_errno(err));
@@ -267,6 +267,34 @@ MTF_DEFINE_UTEST_PREPOST(mpool_test, mclass_test, mpool_test_pre, mpool_test_pos
 
     err = mpool_close(mp);
     ASSERT_EQ(0, err);
+
+    mpool_destroy(home, &tdparams);
+}
+
+MTF_DEFINE_UTEST_PREPOST(mpool_test, is_configured, mpool_test_pre, mpool_test_post)
+{
+    merr_t        err;
+    struct mpool *mp;
+
+    err = mpool_create(home, &tcparams);
+    ASSERT_EQ(0, err);
+
+    err = mpool_open(home, &trparams, O_RDWR, &mp);
+    ASSERT_EQ(0, err);
+
+    for (int i = HSE_MCLASS_BASE; i < HSE_MCLASS_COUNT; i++) {
+        if (i == HSE_MCLASS_BASE) {
+            ASSERT_TRUE(mpool_mclass_is_configured(mp, i));
+        } else {
+            ASSERT_FALSE(mpool_mclass_is_configured(mp, i));
+        }
+    }
+
+    ASSERT_FALSE(mpool_mclass_is_configured(NULL, HSE_MCLASS_BASE));
+    ASSERT_FALSE(mpool_mclass_is_configured(mp, HSE_MCLASS_COUNT));
+
+    err = mpool_close(mp);
+    ASSERT_EQ(0, merr_errno(err));
 
     mpool_destroy(home, &tdparams);
 }


### PR DESCRIPTION
These are no longer needed and will instead just piggyback on the mblock
size.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Issue(s) Addressed
<!-- Issue number -->

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
