### PR TITLE
NFSE-5086-use-correct-atomics-2

### DIFF
--- a/include/hse/hse.h
+++ b/include/hse/hse.h
@@ -55,22 +55,7 @@
 extern "C" {
 #endif
 
-#ifdef __has_attribute
-#  if __has_attribute(visibility)
-#    define HSE_EXPORT __attribute__((__visibility__("default")))
-#  else
-#    define HSE_EXPORT
-#  endif
-#else
-#  define HSE_EXPORT
-#endif
-
-#ifdef HSE_EXPORT_EXPERIMENTAL
-#undef HSE_EXPORT_EXPERIMENTAL
-#define HSE_EXPORT_EXPERIMENTAL HSE_EXPORT
-#else
-#define HSE_EXPORT_EXPERIMENTAL
-#endif
+#pragma GCC visibility push(default)
 
 /** @addtogroup ERRORS
  * @{
@@ -87,7 +72,7 @@ extern "C" {
  *
  * @returns Error's errno equivalent.
  */
-HSE_EXPORT int
+int
 hse_err_to_errno(hse_err_t err);
 
 /** @brief Return an hse_err_t value's string representation.
@@ -107,7 +92,7 @@ hse_err_to_errno(hse_err_t err);
  * would have been written to the final string if enough space had been
  * available.
  */
-HSE_EXPORT size_t
+size_t
 hse_strerror(hse_err_t err, char *buf, size_t buf_len);
 
 /** @brief Return an hse_err_t value's error context.
@@ -120,7 +105,7 @@ hse_strerror(hse_err_t err, char *buf, size_t buf_len);
  *
  * @returns The error's context.
  */
-HSE_EXPORT enum hse_err_ctx
+enum hse_err_ctx
 hse_err_to_ctx(hse_err_t err);
 
 /**@} ERRORS */
@@ -142,7 +127,7 @@ hse_err_to_ctx(hse_err_t err);
  *
  * @returns Error status.
  */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_init(const char *config, size_t paramc, const char *const *paramv);
 
 /** @brief Shutdown the HSE subsystem.
@@ -155,7 +140,7 @@ hse_init(const char *config, size_t paramc, const char *const *paramv);
  *
  * @note This function is not thread safe.
  */
-HSE_EXPORT void
+void
 hse_fini(void);
 
 /** @} SUBSYS */
@@ -178,7 +163,7 @@ hse_fini(void);
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_close(struct hse_kvdb *kvdb);
 
 #ifdef HSE_EXPERIMENTAL
@@ -206,7 +191,7 @@ hse_kvdb_close(struct hse_kvdb *kvdb);
  *
  * @returns Error status.
  */
-HSE_EXPORT_EXPERIMENTAL hse_err_t
+hse_err_t
 hse_kvdb_compact(struct hse_kvdb *kvdb, unsigned int flags);
 
 /** @brief Get status of an ongoing compaction activity.
@@ -224,7 +209,7 @@ hse_kvdb_compact(struct hse_kvdb *kvdb, unsigned int flags);
  *
  * @returns Error status.
  */
-HSE_EXPORT_EXPERIMENTAL hse_err_t
+hse_err_t
 hse_kvdb_compact_status_get(struct hse_kvdb *kvdb, struct hse_kvdb_compact_status *status);
 
 #endif
@@ -242,7 +227,7 @@ hse_kvdb_compact_status_get(struct hse_kvdb *kvdb, struct hse_kvdb_compact_statu
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_create(const char *kvdb_home, size_t paramc, const char *const *paramv);
 
 /** @brief Drop a KVDB.
@@ -257,7 +242,7 @@ hse_kvdb_create(const char *kvdb_home, size_t paramc, const char *const *paramv)
  *
  * @returns Error status.
  */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_drop(const char *kvdb_home);
 
 /** @brief Get the names of the KVSs within the given KVDB.
@@ -293,7 +278,7 @@ hse_kvdb_drop(const char *kvdb_home);
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_kvs_names_get(struct hse_kvdb *kvdb, size_t *namec, char ***namev);
 
 /** @brief Free the names collection obtained through hse_kvdb_kvs_names_get().
@@ -303,7 +288,7 @@ hse_kvdb_kvs_names_get(struct hse_kvdb *kvdb, size_t *namec, char ***namev);
  * @param kvdb: KVDB handle from hse_kvdb_open().
  * @param namev: Vector of KVS names that hse_kvdb_kvs_names_get() output.
  */
-HSE_EXPORT void
+void
 hse_kvdb_kvs_names_free(struct hse_kvdb *kvdb, char **namev);
 
 /** @brief Open a KVDB.
@@ -322,7 +307,7 @@ hse_kvdb_kvs_names_free(struct hse_kvdb *kvdb, char **namev);
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_open(
     const char *       kvdb_home,
     size_t             paramc,
@@ -343,7 +328,7 @@ hse_kvdb_open(
  *
  * @returns Error status.
  */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_storage_add(const char *kvdb_home, size_t paramc, const char *const *paramv);
 
 #ifdef HSE_EXPERIMENTAL
@@ -362,7 +347,7 @@ hse_kvdb_storage_add(const char *kvdb_home, size_t paramc, const char *const *pa
  *
  * @returns Error status.
  */
-HSE_EXPORT_EXPERIMENTAL hse_err_t
+hse_err_t
 hse_kvdb_storage_info_get(struct hse_kvdb *kvdb, struct hse_kvdb_storage_info *info);
 
 #endif
@@ -383,7 +368,7 @@ hse_kvdb_storage_info_get(struct hse_kvdb *kvdb, struct hse_kvdb_storage_info *i
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_sync(struct hse_kvdb *kvdb, unsigned int flags);
 
 /**@} KVDB */
@@ -403,7 +388,7 @@ hse_kvdb_sync(struct hse_kvdb *kvdb, unsigned int flags);
  *
  * @returns Error status.
  */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_kvs_close(struct hse_kvs *kvs);
 
 /** @brief Create a KVS within the referenced KVDB.
@@ -425,7 +410,7 @@ hse_kvdb_kvs_close(struct hse_kvs *kvs);
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_kvs_create(
     struct hse_kvdb *  kvdb,
     const char *       kvs_name,
@@ -447,7 +432,7 @@ hse_kvdb_kvs_create(
  *
  * @returns Error status.
  */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_kvs_drop(struct hse_kvdb *kvdb, const char *kvs_name);
 
 /** @brief Open a KVS in a KVDB.
@@ -467,7 +452,7 @@ hse_kvdb_kvs_drop(struct hse_kvdb *kvdb, const char *kvs_name);
  *
  * @returns Error status.
  */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_kvs_open(
     struct hse_kvdb *  handle,
     const char *       kvs_name,
@@ -498,7 +483,7 @@ hse_kvdb_kvs_open(
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_delete(
     struct hse_kvs *     kvs,
     unsigned int         flags,
@@ -538,7 +523,7 @@ hse_kvs_delete(
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_get(
     struct hse_kvs *     kvs,
     unsigned int         flags,
@@ -583,7 +568,7 @@ hse_kvs_get(
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_prefix_delete(
     struct hse_kvs *     kvs,
     unsigned int         flags,
@@ -627,7 +612,7 @@ hse_kvs_prefix_delete(
  *
  * @returns Error status.
  */
-HSE_EXPORT_EXPERIMENTAL hse_err_t
+hse_err_t
 hse_kvs_prefix_probe(
     struct hse_kvs *            kvs,
     unsigned int                flags,
@@ -686,7 +671,7 @@ hse_kvs_prefix_probe(
  * @returns Error status
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_put(
     struct hse_kvs *     kvs,
     unsigned int         flags,
@@ -770,7 +755,7 @@ hse_kvs_put(
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_txn_abort(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
 
 /** @brief Allocate transaction object.
@@ -787,7 +772,7 @@ hse_kvdb_txn_abort(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * @returns The allocated transaction structure.
  */
 /* MTF_MOCK */
-HSE_EXPORT struct hse_kvdb_txn *
+struct hse_kvdb_txn *
 hse_kvdb_txn_alloc(struct hse_kvdb *kvdb);
 
 /** @brief Initiate transaction.
@@ -806,7 +791,7 @@ hse_kvdb_txn_alloc(struct hse_kvdb *kvdb);
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_txn_begin(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
 
 /** @brief Commit all the mutations of the referenced transaction.
@@ -825,7 +810,7 @@ hse_kvdb_txn_begin(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * @returns Error status
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvdb_txn_commit(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
 
 /** @brief Free transaction object.
@@ -845,7 +830,7 @@ hse_kvdb_txn_commit(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * @remark @p txn must not be NULL.
  */
 /* MTF_MOCK */
-HSE_EXPORT void
+void
 hse_kvdb_txn_free(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
 
 /** @brief Retrieve the state of the referenced transaction.
@@ -861,7 +846,7 @@ hse_kvdb_txn_free(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * @returns Transaction's state.
  */
 /* MTF_MOCK */
-HSE_EXPORT enum hse_kvdb_txn_state
+enum hse_kvdb_txn_state
 hse_kvdb_txn_state_get(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
 
 /**@} TRANSACTIONS */
@@ -934,7 +919,7 @@ hse_kvdb_txn_state_get(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * @returns Error status
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_cursor_create(
     struct hse_kvs *        kvs,
     unsigned int            flags,
@@ -957,7 +942,7 @@ hse_kvs_cursor_create(
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_cursor_destroy(struct hse_kvs_cursor *cursor);
 
 /** @brief Iteratively access the elements pointed to by the cursor.
@@ -990,7 +975,7 @@ hse_kvs_cursor_destroy(struct hse_kvs_cursor *cursor);
  * @returns Error status
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_cursor_read(
     struct hse_kvs_cursor *cursor,
     unsigned int           flags,
@@ -1025,7 +1010,7 @@ hse_kvs_cursor_read(
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_cursor_seek(
     struct hse_kvs_cursor *cursor,
     unsigned int           flags,
@@ -1065,7 +1050,7 @@ hse_kvs_cursor_seek(
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_cursor_seek_range(
     struct hse_kvs_cursor *cursor,
     unsigned int           flags,
@@ -1094,24 +1079,15 @@ hse_kvs_cursor_seek_range(
  * @returns Error status.
  */
 /* MTF_MOCK */
-HSE_EXPORT hse_err_t
+hse_err_t
 hse_kvs_cursor_update_view(struct hse_kvs_cursor *cursor, unsigned int flags);
 
 /**@} CURSORS */
 
-#undef HSE_EXPORT_EXPERIMENTAL
-#undef HSE_EXPORT
+#pragma GCC visibility pop
 
 #if HSE_MOCKING
-/* This is a complete hack because of the way mocks are generated. HSE_EXPORT
- * gets pulled as part of the function declaration when creating the function
- * pointers types for each mocked function.
- */
-#define HSE_EXPORT
-#define HSE_EXPORT_EXPERIMENTAL
 #include "hse_ut.h"
-#undef HSE_EXPORT_EXPERIMENTAL
-#undef HSE_EXPORT
 #endif /* HSE_MOCKING */
 
 #ifdef __cplusplus

--- a/include/hse/hse.h
+++ b/include/hse/hse.h
@@ -57,7 +57,7 @@ extern "C" {
 
 #ifdef __has_attribute
 #  if __has_attribute(visibility)
-#    define HSE_EXPORT __attribute__((visibility("default")))
+#    define HSE_EXPORT __attribute__((__visibility__("default")))
 #  else
 #    define HSE_EXPORT
 #  endif

--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -1138,9 +1138,5 @@ hse_err_to_ctx(const hse_err_t err)
 
 /* Includes necessary files for mocking */
 #if HSE_MOCKING
-#define HSE_EXPORT
-#define HSE_EXPORT_EXPERIMENTAL
 #include "hse_ut_impl.i"
-#undef HSE_EXPORT_EXPERIMENTAL
-#undef HSE_EXPORT
 #endif /* HSE_MOCKING */

--- a/lib/c0/c0snr_set.c
+++ b/lib/c0/c0snr_set.c
@@ -58,7 +58,7 @@ struct c0snr_set_entry;
  * @cse_kvms_gen:       last active kvms gen to use this c0snr
  */
 struct c0snr_set_entry {
-    atomic_t               cse_refcnt;
+    atomic_int             cse_refcnt;
     volatile bool          cse_ctxn;
     struct c0snr_set_list *cse_list;
     u64                    cse_kvms_gen;

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -205,7 +205,7 @@ cn_get_sched(struct cn *cn)
     return cn->csched;
 }
 
-atomic_t *
+atomic_int *
 cn_get_cancel(struct cn *cn)
 {
     return &cn->cn_maint_cancel;

--- a/lib/cn/cn_internal.h
+++ b/lib/cn/cn_internal.h
@@ -36,9 +36,9 @@ struct cn {
 
     atomic_ulong cn_ingest_dgen;
 
-    atomic_t cn_refcnt;
-    bool     cn_closing;
-    bool     cn_replay;
+    atomic_int cn_refcnt;
+    bool       cn_closing;
+    bool       cn_replay;
 
     /* for asynchronous mblock I/O */
     struct workqueue_struct *cn_io_wq;
@@ -59,7 +59,7 @@ struct cn {
     /* for maintenance work */
     struct workqueue_struct *cn_maint_wq;
     struct work_struct       cn_maintenance_work;
-    atomic_t                 cn_maint_cancel;
+    atomic_int               cn_maint_cancel;
     bool                     cn_maintenance_stop;
 
     struct kvs_rparams *  rp;

--- a/lib/cn/cn_perfc.c
+++ b/lib/cn/cn_perfc.c
@@ -14,8 +14,6 @@
 #include "cn_internal.h"
 #include "cn_perfc_internal.h"
 
-#define STATIC
-
 /* clang-format off */
 
 struct perfc_name cn_perfc_get[] _dt_section = {
@@ -120,7 +118,6 @@ cn_perfc_mclass_get_idx(uint agegroup, uint dtype, uint mclass)
 }
 
 
-STATIC
 void
 cn_perfc_bkts_create(struct perfc_name *pcn, int edgec, u64 *edgev, uint sample_pct)
 {
@@ -137,7 +134,6 @@ cn_perfc_bkts_create(struct perfc_name *pcn, int edgec, u64 *edgev, uint sample_
     pcn->pcn_ivl = ivl;
 }
 
-STATIC
 void
 cn_perfc_bkts_destroy(struct perfc_name *pcn)
 {

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -180,7 +180,7 @@ struct cn_compaction_work {
     merr_t                   cw_err;
     struct workqueue_struct *cw_io_workq;
     struct perfc_set *       cw_pc;
-    atomic_t *               cw_cancel_request;
+    atomic_int              *cw_cancel_request;
     struct mpool *           cw_ds;
     struct kvs_rparams *     cw_rp;
     struct kvs_cparams *     cw_cp;
@@ -200,11 +200,11 @@ struct cn_compaction_work {
     bool                     cw_have_token;
     bool                     cw_rspill_conc;
     struct list_head         cw_rspill_link;
-    atomic_t                 cw_rspill_done;
-    atomic_t                 cw_rspill_commit_in_progress;
+    atomic_int               cw_rspill_done;
+    atomic_int               cw_rspill_commit_in_progress;
     u64                      cw_dgen_hi;
     u64                      cw_dgen_lo;
-    atomic_t *               cw_bonus;
+    atomic_int              *cw_bonus;
 
     /* For scheduler */
     struct sts_job        cw_job;

--- a/lib/cn/cn_tree_internal.h
+++ b/lib/cn/cn_tree_internal.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_KVDB_CN_CN_TREE_INTERNAL_H
@@ -176,7 +176,7 @@ struct cn_tree_node {
     u64              tn_biggest_kvset; /* key count */
     bool             tn_rspills_wedged;
     u8               tn_childc;
-    atomic_t         tn_compacting;
+    atomic_int       tn_compacting;
 
     union {
         struct sp3_node sp3n;

--- a/lib/cn/cndb_internal.h
+++ b/lib/cn/cndb_internal.h
@@ -177,7 +177,7 @@ struct cndb {
     u16                       cndb_version;
     bool                      cndb_read_only;
     bool                      cndb_compacted;
-    atomic64_t                cndb_txid;
+    atomic_ulong              cndb_txid;
     u64                       cndb_captgt;
     u64                       cndb_high_water;
     u64                       cndb_oid1;

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -259,8 +259,8 @@ struct sp3 {
     uint lpct_throttle;
 
     /* Throttle sensors */
-    u64        rspill_dt_prev;
-    atomic64_t rspill_dt;
+    u64         rspill_dt_prev;
+    atomic_long rspill_dt;
 
 
     u64 qos_prv_log;
@@ -278,7 +278,7 @@ struct sp3 {
     /* Accessed by monitor and infrequently by open/close threads */
     struct mutex     new_tlist_lock HSE_L1D_ALIGNED;
     struct list_head new_tlist;
-    atomic_t         destruct;
+    atomic_int       destruct;
 
     /* Accessed by monitor, open/close, ingest and jobs threads */
     struct mutex     mutex HSE_L1D_ALIGNED;

--- a/lib/cn/csched_sp3.h
+++ b/lib/cn/csched_sp3.h
@@ -46,10 +46,10 @@ struct sp3_node {
 struct sp3_tree {
     struct list_head spt_tlink;
     uint             spt_job_cnt;
-    atomic_t         spt_enabled;
-    atomic_t         spt_ingest_count;
-    atomic64_t       spt_ingest_alen;
-    atomic64_t       spt_ingest_wlen;
+    atomic_int       spt_enabled;
+    atomic_int       spt_ingest_count;
+    atomic_ulong     spt_ingest_alen;
+    atomic_ulong     spt_ingest_wlen;
 };
 
 #if HSE_MOCKING

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -27,7 +27,7 @@
 #define SP3_BONUS_MAX_IDLE 1
 #define SP3_BONUS_MAX_SCAT 2
 
-static atomic_t sp3_bonus;
+static atomic_int sp3_bonus;
 
 static bool
 sp3_node_is_idle(struct cn_tree_node *tn)
@@ -369,7 +369,7 @@ sp3_work_leaf_len(
     struct kvset_list_entry **mark,
     enum cn_action *          action,
     enum cn_comp_rule *       rule,
-    atomic_t **               bonusp)
+    atomic_int              **bonusp)
 {
     struct cn_tree_node *    tn;
     struct list_head *       head;
@@ -542,7 +542,7 @@ sp3_work_leaf_scatter(
     struct kvset_list_entry **mark,
     enum cn_action *          action,
     enum cn_comp_rule *       rule,
-    atomic_t **               bonusp)
+    atomic_int              **bonusp)
 {
     struct list_head *       head;
     struct cn_tree_node *    tn;
@@ -656,7 +656,7 @@ sp3_work(
     enum cn_action           action = CN_ACTION_NONE;
     enum cn_comp_rule        rule = CN_CR_NONE;
     struct kvset_list_entry *mark = NULL;
-    atomic_t *               bonus = NULL;
+    atomic_int              *bonus = NULL;
 
     *qnum_out = 0;
     tn = spn2tn(spn);

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -101,15 +101,15 @@ struct kvset {
     u16         ks_maxklen; /* length of largest key */
     u16         ks_minklen; /* length of smallest key */
 
-    atomic_t ks_ref HSE_L1D_ALIGNED; /* reference count */
-    u32      ks_deleted;             /* DEL_NONE, DEL_KEEPV, DEL_ALL */
-    atomic_t ks_delete_error;
-    atomic_t ks_mbset_callbacks;
-    bool     ks_mbset_cb_pending;
-    u64      ks_seqno_min;
-    size_t   ks_kvset_sz;
-    u64      ks_ctime;
-    u64      ks_tag;
+    atomic_int ks_ref HSE_L1D_ALIGNED; /* reference count */
+    u32        ks_deleted;             /* DEL_NONE, DEL_KEEPV, DEL_ALL */
+    atomic_int ks_delete_error;
+    atomic_int ks_mbset_callbacks;
+    bool       ks_mbset_cb_pending;
+    u64        ks_seqno_min;
+    size_t     ks_kvset_sz;
+    u64        ks_ctime;
+    u64        ks_tag;
 
     struct kvset_kblk ks_kblks[] HSE_L1D_ALIGNED;
 };

--- a/lib/cn/mbset.h
+++ b/lib/cn/mbset.h
@@ -57,7 +57,7 @@ struct mbset {
     uint                      mbs_mapc;
     uint                      mbs_idc;
     struct mpool *            mbs_ds;
-    atomic_t                  mbs_ref;
+    atomic_int                mbs_ref;
     mbset_callback *          mbs_callback;
     void *                    mbs_callback_rock;
     void *                    mbs_udata;

--- a/lib/cn/vblock_reader.h
+++ b/lib/cn/vblock_reader.h
@@ -56,8 +56,8 @@ struct vblock_desc {
     u32                  vbd_off;      /* byte offset of vblock data */
     u32                  vbd_len;      /* byte length of vblock data */
     u64                  vbd_vgroup;   /* vblock group ID (dgen_hi) */
-    atomic_t             vbd_vgidx;    /* vblock group index */
-    atomic_t             vbd_refcnt;   /* vbr_madvise_async() refcnt */
+    atomic_int           vbd_vgidx;    /* vblock group index */
+    atomic_int           vbd_refcnt;   /* vbr_madvise_async() refcnt */
 };
 
 /**

--- a/lib/include/hse_ikvdb/cn.h
+++ b/lib/include/hse_ikvdb/cn.h
@@ -186,7 +186,7 @@ struct csched *
 cn_get_sched(struct cn *cn);
 
 /* MTF_MOCK */
-atomic_t *
+atomic_int *
 cn_get_cancel(struct cn *cn);
 
 /* MTF_MOCK */

--- a/lib/include/hse_ikvdb/cn_kvdb.h
+++ b/lib/include/hse_ikvdb/cn_kvdb.h
@@ -19,10 +19,10 @@
  * @cnd_vblk_size: sum of on-media sizes of all cn vblocks in kvdb (bytes)
  */
 struct cn_kvdb {
-    atomic64_t cnd_kblk_cnt;
-    atomic64_t cnd_vblk_cnt;
-    atomic64_t cnd_kblk_size;
-    atomic64_t cnd_vblk_size;
+    atomic_ulong cnd_kblk_cnt;
+    atomic_ulong cnd_vblk_cnt;
+    atomic_ulong cnd_kblk_size;
+    atomic_ulong cnd_vblk_size;
 };
 
 /* MTF_MOCK */

--- a/lib/include/hse_ikvdb/kvdb_ctxn.h
+++ b/lib/include/hse_ikvdb/kvdb_ctxn.h
@@ -51,8 +51,8 @@ struct kvdb_ctxn {
  */
 struct kvdb_ctxn_bind {
     struct kvdb_ctxn *b_ctxn;
-    atomic64_t        b_gen;
-    atomic64_t        b_ref;
+    atomic_ulong      b_gen;
+    atomic_int        b_ref;
     bool              b_update;
     bool              b_preserve;
 };

--- a/lib/include/hse_ikvdb/throttle.h
+++ b/lib/include/hse_ikvdb/throttle.h
@@ -87,7 +87,7 @@ enum {
  * implementation of 'struct throttle'.
  */
 struct throttle_sensor {
-    atomic_t ts_sensor;
+    atomic_int ts_sensor;
 } HSE_L1D_ALIGNED;
 
 static inline void
@@ -150,12 +150,11 @@ struct throttle_mavg {
  * @thr_max_tries:      max number of trials
  * @thr_rp:
  * @thr_perfc:
- * @thr_data:           raw nanosleep performance metrics
  * @thr_sensorv:        vector of throttle sensors
  */
 struct throttle {
-    atomic_t             thr_pct;
-    atomic64_t           thr_next;
+    atomic_int           thr_pct;
+    atomic_ulong         thr_next;
     uint                 thr_delay;
     spinlock_t           thr_lock;
 
@@ -183,8 +182,6 @@ struct throttle {
     struct kvdb_rparams *thr_rp;
     struct perfc_set     thr_sensor_perfc;
     struct perfc_set     thr_sleep_perfc;
-
-    atomic64_t thr_data HSE_L1D_ALIGNED;
 
     struct throttle_sensor thr_sensorv[THROTTLE_SENSOR_CNT];
 };

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -76,8 +76,11 @@
 
 /* clang-format off */
 
-static_assert((sizeof(uintptr_t) == sizeof(u64)),
+static_assert((sizeof(uintptr_t) == sizeof(uint64_t)),
               "libhse relies on pointers being 64-bits in size");
+
+static_assert((sizeof(atomic_ulong) == sizeof(uint64_t)),
+              "libhse require atomic_ulong to be exactly 64-bits");
 
 struct perfc_name ctxn_perfc_op[] _dt_section = {
     NE(PERFC_BA_CTXNOP_ACTIVE,    1, "Count of active txns",       "c_ctxn_active"),

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -98,7 +98,7 @@ NE_CHECK(ctxn_perfc_op, PERFC_EN_CTXNOP, "ctxn_perfc_op table/enum mismatch");
 thread_local char tls_vbuf[256 * 1024] HSE_ALIGNED(PAGE_SIZE);
 const size_t      tls_vbufsz = sizeof(tls_vbuf);
 
-static atomic_t kvdb_alias = 0;
+static atomic_int kvdb_alias;
 
 #define ikvdb_h2r(_ikvdb_handle) \
     container_of(_ikvdb_handle, struct ikvdb_impl, ikdb_handle)
@@ -118,8 +118,8 @@ struct kvdb_ctxn_bkt {
     struct kvdb_ctxn *kcb_ctxnv[(HSE_ACP_LINESIZE / 8) - 1];
 };
 
-static thread_local uint     tls_txn_idx;
-static              atomic_t ikvdb_txn_idx;
+static thread_local uint tls_txn_idx;
+static atomic_uint ikvdb_txn_idx;
 
 /**
  * struct ikvdb_impl - private representation of a kvdb

--- a/lib/kvdb/kvdb_ctxn.c
+++ b/lib/kvdb/kvdb_ctxn.c
@@ -65,7 +65,7 @@ struct kvdb_ctxn_set_impl {
 
     struct mutex             ktn_list_mutex HSE_ACP_ALIGNED;
     struct list_head         ktn_pending;
-    atomic_t                 ktn_reading;
+    atomic_int               ktn_reading;
     bool                     ktn_queued;
 
     struct cds_list_head     ktn_alloc_list HSE_ALIGNED(CAA_CACHE_LINE_SIZE);
@@ -141,7 +141,7 @@ kvdb_ctxn_set_thread(struct work_struct *work)
 
     ktn = container_of(work, struct kvdb_ctxn_set_impl, ktn_dwork.work);
 
-    atomic_set(&ktn->ktn_reading, 1);
+    atomic_store(&ktn->ktn_reading, 1);
 
     /* Abort all active transactions that have expired. */
     now = get_time_ns();
@@ -160,7 +160,7 @@ kvdb_ctxn_set_thread(struct work_struct *work)
     list_for_each_entry(ctxn, &alist, ctxn_abort_link)
         kvdb_ctxn_abort(&ctxn->ctxn_inner_handle);
 
-    atomic_set(&ktn->ktn_reading, 0);
+    atomic_store(&ktn->ktn_reading, 0);
 
     INIT_LIST_HEAD(&freelist);
 

--- a/lib/kvdb/kvdb_kvs.h
+++ b/lib/kvdb/kvdb_kvs.h
@@ -42,7 +42,7 @@ struct kvdb_kvs {
     u64                     kk_cnid;
     struct kvs_cparams     *kk_cparams;
     u32                     kk_flags;
-    atomic_t                kk_refcnt;
+    atomic_int              kk_refcnt;
 
     char kk_name[HSE_KVS_NAME_LEN_MAX];
 };

--- a/lib/kvdb/sched_sts.c
+++ b/lib/kvdb/sched_sts.c
@@ -45,7 +45,7 @@
 /* A worker thread */
 struct sts_worker {
     struct sts *sts;
-    atomic_t    initializing;
+    atomic_int  initializing;
     uint        wqnum;
     char        wname[16];
 } HSE_L1D_ALIGNED;
@@ -56,7 +56,7 @@ sts_worker_main(void *rock);
 /* Scheduler queue */
 struct sts_queue {
     struct list_head jobs;
-    atomic_t         idle_workers;
+    atomic_int       idle_workers;
     struct perfc_set qpc;
     struct sts *     sts;
 } HSE_L1D_ALIGNED;
@@ -71,16 +71,16 @@ struct sts {
     struct kvdb_rparams *rp;
     const char *         name;
     uint                 qc;
-    atomic_t             state;
-    atomic_t             worker_id_counter;
-    atomic_t             spawned_workers;
-    atomic_t             ready_workers;
+    atomic_int           state;
+    atomic_int           worker_id_counter;
+    atomic_int           spawned_workers;
+    atomic_int           ready_workers;
 
     /* Current number of workers.
      * Index self->qc is for shared workers.
      * Index i, i < self->qc, is for workers dedicated to queue i.
      */
-    atomic_t wcnt_current[STS_QUEUES_MAX + 1];
+    atomic_int wcnt_current[STS_QUEUES_MAX + 1];
 
     uint rr_next;
 
@@ -582,7 +582,7 @@ sts_worker_main(void *rock)
     pthread_t          tid;
     int                state;
     bool               idle;
-    atomic_t *         idle_count;
+    atomic_int        *idle_count;
 
     tid = pthread_self();
     idle = false;

--- a/lib/kvs/kvs.c
+++ b/lib/kvs/kvs.c
@@ -69,8 +69,6 @@ struct mpool;
 
 /*-  Key Value Store  -------------------------------------------------------*/
 
-static atomic_t kvs_init_ref;
-
 static merr_t
 kvs_create(struct ikvs **kvs, struct kvs_rparams *rp);
 
@@ -651,23 +649,11 @@ kvs_perfc_fini(void)
 merr_t
 kvs_init(void)
 {
-    merr_t err;
-
-    if (atomic_inc_return(&kvs_init_ref) > 1)
-        return 0;
-
-    err = kvs_curcache_init();
-    if (ev(err))
-        atomic_dec(&kvs_init_ref);
-
-    return err;
+    return kvs_curcache_init();
 }
 
 void
 kvs_fini(void)
 {
-    if (atomic_dec_return(&kvs_init_ref) > 0)
-        return;
-
     kvs_curcache_fini();
 }

--- a/lib/kvs/kvs_cursor.c
+++ b/lib/kvs/kvs_cursor.c
@@ -187,7 +187,7 @@ static uint                 ikvs_curcachec    HSE_READ_MOSTLY;
 static uint                 ikvs_colormax     HSE_READ_MOSTLY;
 
 struct timer_list           ikvs_curcache_timer;
-atomic_t                    ikvs_curcache_pruning;
+atomic_int                  ikvs_curcache_pruning;
 
 /*-  Cursor Support  --------------------------------------------------*/
 
@@ -273,7 +273,7 @@ ikvs_curcache_td2bkt(void)
     static thread_local size_t tls_offset;
 
     if (HSE_UNLIKELY(!tls_offset)) {
-        static atomic_t g_cc_idx;
+        static atomic_uint g_cc_idx;
 
         tls_offset = ikvs_curcache_idx2bktoff(atomic_inc_return(&g_cc_idx));
     }

--- a/lib/lc/lc.c
+++ b/lib/lc/lc.c
@@ -105,7 +105,7 @@ static struct kmem_cache *lc_cursor_cache;
  */
 struct ingest_batch {
     u64                  ib_seqno;
-    atomic64_t           ib_refcnt;
+    atomic_int           ib_refcnt;
     struct ingest_batch *ib_next;
 };
 
@@ -139,7 +139,7 @@ struct lc_impl {
     struct lc    lc_handle;
     struct mutex lc_mutex;
     uint         lc_nsrc;
-    atomic_t     lc_closing;
+    atomic_int   lc_closing;
 
     struct bonsai_root *     lc_broot[LC_SOURCE_CNT_MAX];
     struct lc_gc             lc_gc;
@@ -151,7 +151,7 @@ struct lc_impl {
 
     struct rmlock        lc_ib_rmlock;
     struct ingest_batch *lc_ib_head;
-    atomic_t             lc_ib_len;
+    atomic_int           lc_ib_len;
 };
 
 #define lc_h2r(HANDLE) container_of(HANDLE, struct lc_impl, lc_handle)

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -16,9 +16,9 @@ build_config_h_data = configuration_data({
     'SUPPORTS_ATTR_ALIGNED': cc.has_function_attribute('aligned'),
     'SUPPORTS_ATTR_SECTION': cc.compiles(
         '''
-        int x __attribute__((section(".read_mostly"))) = 0;
+        int x __attribute__((__section__(".read_mostly"))) = 0;
         ''',
-        name: '__attribute__((section(".read_mostly")))',
+        name: '__attribute__((__section__(".read_mostly")))',
     ),
     'SUPPORTS_ATTR_UNUSED': cc.has_function_attribute('unused'),
     'SUPPORTS_ATTR_USED': cc.has_function_attribute('used'),
@@ -29,13 +29,13 @@ build_config_h_data = configuration_data({
     'SUPPORTS_ATTR_WEAK': cc.has_function_attribute('weak'),
     'SUPPORTS_ATTR_SENTINEL': cc.compiles(
         '''
-        int __attribute__((sentinel))
+        int __attribute__((__sentinel__))
         test_func(const char *fmt, ...)
         {
             return 0;
         }
         ''',
-        name: '__attribute__((sentinel))',
+        name: '__attribute__((__sentinel__))',
     ),
     'SUPPORTS_ATTR_NONNULL': cc.has_function_attribute('nonnull'),
     'WITH_COVERAGE': get_option('b_coverage'),

--- a/lib/mpool/src/mblock_file.c
+++ b/lib/mpool/src/mblock_file.c
@@ -89,7 +89,7 @@ struct mblock_file {
     int            fileid;
     int            fd;
 
-    atomic_t *wlenv;
+    atomic_int *wlenv;
 
     struct mutex uniq_lock HSE_L1D_ALIGNED;
     uint32_t     uniq;
@@ -102,8 +102,8 @@ struct mblock_file {
     int                 mmapc;
     struct mblock_mmap *mmapv;
 
-    atomic64_t wlen HSE_L1D_ALIGNED;
-    atomic_t   mbcnt;
+    atomic_long wlen HSE_L1D_ALIGNED;
+    atomic_int  mbcnt;
 };
 
 /* clang-format on */
@@ -1002,7 +1002,7 @@ mblock_file_read(
     off_t     roff, eoff;
     size_t    len = 0, mblocksz, wlen;
     merr_t    err;
-    atomic_t *wlenp;
+    atomic_int *wlenp;
 
     if (!mbfp || !iov)
         return merr(EINVAL);
@@ -1046,7 +1046,7 @@ mblock_file_write(struct mblock_file *mbfp, uint64_t mbid, const struct iovec *i
     size_t    len = 0, mblocksz;
     off_t     woff, eoff, off;
     merr_t    err;
-    atomic_t *wlenp;
+    atomic_int *wlenp;
 
     if (!mbfp || !iov)
         return merr(EINVAL);

--- a/lib/mpool/src/mblock_fset.c
+++ b/lib/mpool/src/mblock_fset.c
@@ -51,7 +51,7 @@ struct mblock_fset {
     struct media_class  *mc;
     struct kmem_cache   *rmcache[MBLOCK_FSET_RMCACHE_CNT];
 
-    atomic64_t           fidx;
+    atomic_int           fidx;
     size_t               fszmax;
     struct mblock_file **filev;
     int                  fcnt;

--- a/lib/mpool/src/mblock_fset.c
+++ b/lib/mpool/src/mblock_fset.c
@@ -51,7 +51,7 @@ struct mblock_fset {
     struct media_class  *mc;
     struct kmem_cache   *rmcache[MBLOCK_FSET_RMCACHE_CNT];
 
-    atomic_int           fidx;
+    atomic_ulong         fidx;
     size_t               fszmax;
     struct mblock_file **filev;
     int                  fcnt;

--- a/lib/util/include/hse_util/atomic.h
+++ b/lib/util/include/hse_util/atomic.h
@@ -10,15 +10,6 @@
 
 /* clang-format off */
 
-/* The following typedefs are remnants of a legacy implementation of this
- * API and are deprecated. New code should use one of the atomic types
- * from stdatomic.h, and existing code should be updated to use the
- * correct atomic type.
- */
-typedef atomic_int      atomic_t;
-typedef atomic_long     atomic64_t;
-
-
 /* Relaxed semantics:
  *
  * No synchronization nor ordering guarantees.

--- a/lib/util/include/hse_util/compiler.h
+++ b/lib/util/include/hse_util/compiler.h
@@ -25,7 +25,7 @@
 
 /* Optimization barrier */
 /* The "volatile" is due to gcc bugs */
-#define barrier()               asm volatile("" : : : "memory")
+#define barrier()               __asm__ __volatile__("" : : : "memory")
 
 #define HSE_LIKELY(_expr)       __builtin_expect(!!(_expr), 1)
 #define HSE_UNLIKELY(_expr)     __builtin_expect(!!(_expr), 0)

--- a/lib/util/src/arch.c
+++ b/lib/util/src/arch.c
@@ -117,7 +117,7 @@ hse_getcpu(uint *node)
     }
 #else
     if (hse_getcpu_tls.cnt++ % 1024 == 0) {
-        static atomic_t hse_getcpu_gvcpu;
+        static atomic_uint hse_getcpu_gvcpu;
 
         /* Generate periodically changing fake vCPU and node IDs for architectures
          * not known to support a vDSO based getcpu().

--- a/lib/util/src/rcu.c
+++ b/lib/util/src/rcu.c
@@ -18,11 +18,10 @@
  */
 
 #include <hse_util/atomic.h>
-#include <hse_util/delay.h>
 
 struct rcu_barrier_data {
     struct rcu_head rbd_rcu;
-    atomic_t        rbd_count;
+    atomic_int      rbd_count;
 };
 
 static void
@@ -32,7 +31,7 @@ rcu_barrier_cb(struct rcu_head *rh)
 
     rbd = caa_container_of(rh, struct rcu_barrier_data, rbd_rcu);
 
-    atomic_inc(&rbd->rbd_count);
+    atomic_inc_rel(&rbd->rbd_count);
 }
 
 __attribute__((__weak__)) void
@@ -44,8 +43,8 @@ rcu_barrier_bp(void)
 
     rcu_defer_barrier();
 
-    while (atomic_read(&rbd.rbd_count) == 0)
-        msleep(100);
+    while (atomic_read_acq(&rbd.rbd_count) == 0)
+        usleep(1000);
 
     synchronize_rcu();
 }

--- a/lib/util/src/rest_api.c
+++ b/lib/util/src/rest_api.c
@@ -59,7 +59,7 @@ struct url_desc {
     rest_get_t *        get_handler;
     rest_put_t *        put_handler;
     enum rest_url_flags url_flags;
-    atomic_t            refcnt;
+    atomic_int          refcnt;
 };
 
 struct thread_arg {
@@ -69,7 +69,7 @@ struct thread_arg {
     struct kv_iter     iter;
     struct conn_info * ci;
     int                op;
-    atomic_t           busy;
+    atomic_int         busy;
 };
 
 /**
@@ -91,7 +91,7 @@ struct session {
     struct thread_arg    targ;
     int                  enqueued;
     struct conn_info     ci;
-    atomic_t             refcnt;
+    atomic_int           refcnt;
     struct session **    slot;
     void *               magic;
     char                 buf[4096];

--- a/lib/util/src/slab.c
+++ b/lib/util/src/slab.c
@@ -283,7 +283,7 @@ struct kmem_cache {
 static struct {
     struct kmem_cache       *kmc_pagecache;
     struct workqueue_struct *kmc_wq;
-    atomic_t                 kmc_huge_used;
+    atomic_int               kmc_huge_used;
     uint                     kmc_huge_max;
 
     struct mutex     kmc_lock HSE_L1D_ALIGNED;

--- a/lib/wal/wal.c
+++ b/lib/wal/wal.c
@@ -39,10 +39,10 @@ struct wal {
     uint8_t                 wal_thr_hwm;
     uint8_t                 wal_thr_lwm;
 
-    atomic64_t              wal_rid HSE_L1D_ALIGNED;
-    atomic64_t              wal_ingestseq;
-    atomic64_t              wal_ingestgen;
-    atomic64_t              wal_txhorizon;
+    atomic_ulong            wal_rid HSE_L1D_ALIGNED;
+    atomic_ulong            wal_ingestseq;
+    atomic_ulong            wal_ingestgen;
+    atomic_ulong            wal_txhorizon;
 
     struct mutex     sync_mutex HSE_L1D_ALIGNED;
     struct list_head sync_waiters;
@@ -52,8 +52,8 @@ struct wal {
     bool         sync_pending;
     struct cv    timer_cv;
 
-    atomic64_t error HSE_L1D_ALIGNED;
-    atomic_t   closing;
+    atomic_long error HSE_L1D_ALIGNED;
+    atomic_int closing;
     bool       clean;
     bool       read_only;
     bool       timer_tid_valid;

--- a/lib/wal/wal_buffer.h
+++ b/lib/wal/wal_buffer.h
@@ -15,7 +15,7 @@ struct wal_bufset *
 wal_bufset_open(
     struct wal_fileset *wfset,
     size_t              bufsz,
-    atomic64_t         *ingestgen,
+    atomic_ulong       *ingestgen,
     struct wal_iocb    *iocb);
 
 void

--- a/lib/wal/wal_io.c
+++ b/lib/wal/wal_io.c
@@ -38,16 +38,16 @@ struct wal_io {
     bool             io_stop;
     struct cv        io_cv;
 
-    atomic64_t          io_pend HSE_L1D_ALIGNED;
-    atomic64_t          io_comp;
-    atomic64_t          io_gen;
-    atomic64_t         *io_doff;
-    atomic_t            io_stopped;
+    atomic_long         io_pend HSE_L1D_ALIGNED;
+    atomic_long         io_comp;
+    atomic_ulong        io_gen;
+    atomic_ulong       *io_doff;
+    atomic_int          io_stopped;
 
     struct wal_fileset *io_wfset;
     struct wal_file    *io_wfile;
     struct wal_iocb    *io_cb;
-    atomic64_t          io_err;
+    atomic_long         io_err;
     uint32_t            io_index;
     struct work_struct  io_work;
 };
@@ -205,7 +205,7 @@ struct wal_io *
 wal_io_create(
     struct wal_fileset *wfset,
     uint32_t            index,
-    atomic64_t         *doff,
+    atomic_ulong       *doff,
     struct wal_iocb    *iocb)
 {
     struct wal_io *io;

--- a/lib/wal/wal_io.h
+++ b/lib/wal/wal_io.h
@@ -23,7 +23,7 @@ struct wal_io *
 wal_io_create(
     struct wal_fileset *wfset,
     uint32_t            index,
-    atomic64_t         *doff,
+    atomic_ulong       *doff,
     struct wal_iocb    *iocb);
 
 void

--- a/lib/wal/wal_omf.c
+++ b/lib/wal/wal_omf.c
@@ -18,7 +18,7 @@ wal_rechdr_pack(enum wal_rec_type rtype, uint64_t rid, size_t tlen, uint64_t gen
 {
     struct wal_rechdr_omf *rhomf = outbuf;
 
-    atomic_set((atomic64_t *)&rhomf->rh_off, 0);
+    atomic_set((atomic_ulong *)&rhomf->rh_off, 0);
     omf_set_rh_flags(rhomf, WAL_FLAGS_MORG);
     omf_set_rh_gen(rhomf, gen);
     omf_set_rh_type(rhomf, rtype);
@@ -80,7 +80,7 @@ wal_rec_finish(struct wal_record *rec, uint64_t seqno, uint64_t gen)
     omf_set_r_seqno(romf, seqno);
     wal_rechdr_crc_pack(recbuf, rec->len);
 
-    atomic_set((atomic64_t *)&rhomf->rh_off, cpu_to_omf64(rec->offset));
+    atomic_set((atomic_ulong *)&rhomf->rh_off, cpu_to_omf64(rec->offset));
 }
 
 /* Record unpack routines */
@@ -305,7 +305,7 @@ wal_txn_rechdr_finish(void *recbuf, size_t len, uint64_t offset)
     struct wal_rechdr_omf *rhomf = recbuf;
 
     wal_rechdr_crc_pack(recbuf, len);
-    atomic_set((atomic64_t *)&rhomf->rh_off, cpu_to_omf64(offset));
+    atomic_set((atomic_ulong *)&rhomf->rh_off, cpu_to_omf64(offset));
 }
 
 void

--- a/lib/wal/wal_replay.c
+++ b/lib/wal/wal_replay.c
@@ -51,9 +51,9 @@ struct wal_replay {
     struct rb_root              r_txcid_root;
     uint64_t                    r_maxcid;
 
-    atomic_t                    r_leader;
-    atomic_t                    r_vdone;
-    atomic64_t                  r_verr;
+    atomic_int                  r_leader;
+    atomic_int                  r_vdone;
+    atomic_long                 r_verr;
 
     struct wal                 *r_wal HSE_L1D_ALIGNED;
     struct ikvdb_kvs_hdl       *r_ikvsh;

--- a/tests/mocks/lib/api.c
+++ b/tests/mocks/lib/api.c
@@ -26,7 +26,7 @@ struct mocked_api {
     u64      stop2;
     union rc rc2;
 
-    atomic64_t calls HSE_L1D_ALIGNED;
+    atomic_ulong calls HSE_L1D_ALIGNED;
 };
 
 /*

--- a/tests/mocks/repository/lib/mock_c0cn.c
+++ b/tests/mocks/repository/lib/mock_c0cn.c
@@ -107,13 +107,13 @@ struct mock_cn {
     char            tripwire[PAGE_SIZE * 7]; /* must be first field */
     struct c0_data *data;
     struct cndb *   cndb;
-    atomic_t        refcnt;
+    atomic_int      refcnt;
 
     spinlock_t             cc_lock;
     struct mock_cn_cursor *cc_head;
 } HSE_ALIGNED(PAGE_SIZE);
 
-static atomic_t mocked_c0_open_count;
+static atomic_int mocked_c0_open_count;
 static struct kvs_rparams mocked_kvs_rparams;
 static struct kvs_cparams mocked_kvs_cparams;
 

--- a/tests/unit/c0/c0sk_test.c
+++ b/tests/unit/c0/c0sk_test.c
@@ -36,7 +36,7 @@ struct csched *              csched;
 
 #define MAX_TXNS (32)
 
-atomic_t ctxn_locks[MAX_TXNS];
+atomic_int ctxn_locks[MAX_TXNS];
 uintptr_t c0snr[MAX_TXNS];
 
 struct kvdb_rparams kvdb_rp;

--- a/tests/unit/cn/kcompact_test.c
+++ b/tests/unit/cn/kcompact_test.c
@@ -69,7 +69,7 @@ init_work(
     bool *                     drop_tomb,
     uint                       kvset_cnt,
     struct kv_iterator **      inputv,
-    atomic_t *                 cancel,
+    atomic_int                *cancel,
     struct kvset_mblocks *     outv,
     struct kvset_vblk_map *    vbmap)
 {
@@ -255,7 +255,7 @@ MTF_DEFINE_UTEST_PRE(kcompact_test, four_into_one, pre)
     struct kvset_vblk_map     vbm = { 0 };
     struct nkv_tab            nkv;
     bool                      drop_tombv[1] = { false };
-    atomic_t                  c;
+    atomic_int                c;
     u64                       dgen = 0;
     int                       i;
     merr_t                    err;
@@ -316,7 +316,7 @@ MTF_DEFINE_UTEST_PRE(kcompact_test, all_gone, pre)
     struct kv_iterator *      itv[5] = { 0 };
     struct nkv_tab            nkv;
     bool                      drop_tombv[1] = { false };
-    atomic_t                  c;
+    atomic_int                c;
     u64                       dgen = 0;
     int                       i;
     merr_t                    err;
@@ -381,7 +381,7 @@ MTF_DEFINE_UTEST_PREPOST(kcompact_test, all_gone_mixed, mixed_pre, mixed_post)
     struct kv_iterator *      itv[5] = { 0 };
     struct nkv_tab            nkv;
     bool                      drop_tombv[1] = { false };
-    atomic_t                  c;
+    atomic_int                c;
     u64                       dgen = 0;
     int                       i;
     merr_t                    err;
@@ -446,7 +446,7 @@ MTF_DEFINE_UTEST_PREPOST(kcompact_test, four_into_one_mixed, mixed_pre, mixed_po
     struct kvset_vblk_map     vbm = { 0 };
     struct nkv_tab            nkv;
     bool                      drop_tombv[1] = { false };
-    atomic_t                  c;
+    atomic_int                c;
     u64                       dgen = 0;
     int                       i;
     merr_t                    err;
@@ -504,7 +504,7 @@ run_kcompact(struct mtf_test_info *lcl_ti, int expect)
     struct kv_iterator *      itv[5] = { 0 };
     struct nkv_tab            nkv;
     bool                      drop_tombv[1] = { false };
-    atomic_t                  c;
+    atomic_int                c;
     u64                       dgen = 0;
     int                       i;
     merr_t                    err;

--- a/tests/unit/cn/merge_test.c
+++ b/tests/unit/cn/merge_test.c
@@ -1092,7 +1092,7 @@ init_work(
     uint                       shift,
     uint                       pfx_len,
     struct perfc_set *         pc,
-    atomic_t *                 cancel,
+    atomic_int                *cancel,
     uint                       num_outputs,
     bool *                     drop_tomb,
     struct kvset_mblocks *     outputs,
@@ -1178,7 +1178,7 @@ run_testcase(struct mtf_test_info *lcl_ti, int mode, const char *info)
     u32                       iterc;
     struct kv_iterator **     iterv;
     u32                       i;
-    atomic_t                  cancel;
+    atomic_int                cancel;
     struct cn_compaction_work w;
 
     if (tp.verbose >= VERBOSE_PER_FILE2)

--- a/tests/unit/kvdb/ikvdb_test.c
+++ b/tests/unit/kvdb/ikvdb_test.c
@@ -1661,7 +1661,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, kvdb_sync_test, test_pre, test_post)
 
 struct thread_info {
     struct ikvdb *  h;
-    atomic_t *      num_opens;
+    atomic_int     *num_opens;
     struct hse_kvs *kvs_h;
     pthread_t       tid;
 };
@@ -1684,7 +1684,7 @@ parallel_kvs_open(void *arg)
 MTF_DEFINE_UTEST_PREPOST(ikvdb_test, kvdb_parallel_kvs_opens, test_pre, test_post)
 {
     const int           num_threads = get_nprocs() * 2;
-    atomic_t            num_opens;
+    atomic_int          num_opens;
     int                 i;
     merr_t              err;
     struct ikvdb *      h;
@@ -1827,7 +1827,6 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, ikvdb_test_various, test_pre, test_post)
 {
     char   invalid[HSE_KVS_NAME_LEN_MAX * 2];
     merr_t err;
-    int    i;
 
     err = validate_kvs_name("foo");
     ASSERT_EQ(err, 0);
@@ -1843,12 +1842,6 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, ikvdb_test_various, test_pre, test_post)
     snprintf(invalid, sizeof(invalid), "%*c", (int)sizeof(invalid) - 1, 'x');
     err = validate_kvs_name(invalid);
     ASSERT_NE(err, 0);
-
-    for (i = 0; i < 1000; ++i)
-        kvs_init();
-
-    for (i = 0; i < 1000; ++i)
-        kvs_fini();
 }
 
 MTF_DEFINE_UTEST(ikvdb_test, ikvdb_hash_test)

--- a/tests/unit/kvdb/kvdb_ctxn_test.c
+++ b/tests/unit/kvdb/kvdb_ctxn_test.c
@@ -1361,7 +1361,7 @@ struct parallel_ctxn_arg {
     struct kvdb_ctxn *ctxn;
     int               thrd_num;
     int               txn_num;
-    atomic_t *        owner_thread;
+    atomic_int       *owner_thread;
 };
 
 #if 0
@@ -1372,7 +1372,7 @@ parallel_ctxn_helper(void *arg)
     struct kvdb_ctxn *        ctxn = p->ctxn;
     int                       thrd_num = p->thrd_num;
     int                       txn_num = p->txn_num;
-    atomic_t *                owner_thread = p->owner_thread;
+    atomic_int               *owner_thread = p->owner_thread;
     merr_t                    err = 0;
 //    int                       i;
 //    struct kvs_ktuple         kt;
@@ -1429,7 +1429,7 @@ MTF_DEFINE_UTEST_PREPOST(kvdb_ctxn_test, multiple_ctxn_commit, mapi_pre, mapi_po
     struct kvdb_keylock    *klock;
     struct c0              *c0 = NULL; /* c0 is mocked */
     struct kvdb_ctxn       *handles[num_txns];
-    atomic_t                owner_thread[32] = {};
+    atomic_int             *owner_thread[32] = {};
     const u64               initial_value = 117UL;
     atomic_ulong            kvdb_seq, tseqno;
 

--- a/tests/unit/kvdb/kvdb_keylock_test.c
+++ b/tests/unit/kvdb/kvdb_keylock_test.c
@@ -18,7 +18,7 @@
 
 #define MOCK_SET(group, func) mtfm_##group##func##_set(func)
 
-atomic64_t kvdb_seq;
+atomic_ulong kvdb_seq;
 
 int
 mapi_pre(struct mtf_test_info *ti)
@@ -228,7 +228,7 @@ struct parallel_lock_arg {
     struct kvdb_ctxn_locks *locks_handle;
     pthread_barrier_t *     lock_barrier;
     int                     num_hash;
-    atomic_t *              owner_thread;
+    atomic_int             *owner_thread;
     int                     num;
 };
 
@@ -241,7 +241,7 @@ parallel_lock_helper(void *arg)
     pthread_barrier_t *       barrier = p->lock_barrier;
     int                       num_hash = p->num_hash;
     int                       num = p->num;
-    atomic_t *                owner_thread = p->owner_thread;
+    atomic_int               *owner_thread = p->owner_thread;
     merr_t                    err = 0;
     int                       i;
     u64                       hash = 0x12345678UL << 32;
@@ -291,7 +291,7 @@ MTF_DEFINE_UTEST_PREPOST(kvdb_keylock_test, keylock_lock_multiple_ctxn, mapi_pre
     struct parallel_lock_arg argstruct[num_threads];
     struct kvdb_keylock *    klock_handle;
     struct kvdb_ctxn_locks * locks_handle[num_threads];
-    atomic_t                 owner_thread[10000] = {};
+    atomic_int               owner_thread[10000] = {};
     merr_t                   err;
     int                      i, rc;
 

--- a/tests/unit/kvdb/sched_sts_test.c
+++ b/tests/unit/kvdb/sched_sts_test.c
@@ -77,7 +77,7 @@ struct job {
     struct sts_job sts_job;
     int            debug;
     pthread_t      tid;
-    atomic_t *     var;
+    atomic_int    *var;
     int            var_wait;
     int            var_add;
     uint           delay_msec;
@@ -92,7 +92,7 @@ struct job {
 #define REPEAT_FOREVER ((u64)-1)
 
 static merr_t
-atomic_read_timeout(atomic_t *var, int value, u64 timeout_usec)
+atomic_read_timeout(atomic_int *var, int value, u64 timeout_usec)
 {
     u64 stop = get_time_ns() + timeout_usec * 1000;
 
@@ -110,7 +110,7 @@ jhandler(struct sts_job *sj)
     struct job *job = container_of(sj, struct job, sts_job);
     u64         count = 0;
     u64         t0 = 0, t1 = 0;
-    atomic_t *  add_var = 0;
+    atomic_int *add_var = NULL;
     int         add_value = 0;
 
     if (job->debug)
@@ -163,7 +163,7 @@ jhandler(struct sts_job *sj)
 }
 
 static struct job *
-jinit(struct job *job, uint qnum, uint delay_msec, atomic_t *var, int var_wait, int var_add)
+jinit(struct job *job, uint qnum, uint delay_msec, atomic_int *var, int var_wait, int var_add)
 {
     memset(job, 0, sizeof(*job));
 
@@ -199,7 +199,7 @@ static merr_t
 job_ping(struct sts *s, uint qnum, uint wait_usec, u64 *time_nsec)
 {
     struct job *job;
-    atomic_t    var;
+    atomic_int  var;
     u64         t0, t1;
 
     job = mapi_safe_malloc(sizeof(*job));
@@ -421,7 +421,7 @@ MTF_DEFINE_UTEST_PRE(test, t_ping, pre_test)
 MTF_DEFINE_UTEST_PRE(test, t_workers_concurrent, pre_test)
 {
     merr_t      err;
-    atomic_t    var;
+    atomic_int  var;
     int         v;
     struct sts *s;
     struct job  job1, job2;
@@ -456,7 +456,7 @@ MTF_DEFINE_UTEST_PRE(test, t_workers_concurrent, pre_test)
 MTF_DEFINE_UTEST_PRE(test, t_sts_pause, pre_test)
 {
     merr_t      err;
-    atomic_t    var;
+    atomic_int  var;
     int         v1, v2;
     uint        i, q;
     uint        nq = 3;

--- a/tests/unit/util/atomic_test.c
+++ b/tests/unit/util/atomic_test.c
@@ -23,7 +23,7 @@ MTF_BEGIN_UTEST_COLLECTION(atomic_test);
 MTF_DEFINE_UTEST(atomic_test, basic)
 {
     int old_val, new_val;
-    atomic_t v;
+    atomic_int v;
     bool b;
 
     atomic_set(&v, 23);
@@ -63,9 +63,9 @@ MTF_DEFINE_UTEST(atomic_test, basic)
 
 MTF_DEFINE_UTEST(atomic_test, basic64)
 {
-    atomic64_t v;
-    long       i;
-    u64        s;
+    atomic_long v;
+    long        i;
+    u64         s;
 
     ASSERT_EQ(sizeof(i), 8);
     ASSERT_EQ(sizeof(v), 8);
@@ -179,10 +179,10 @@ struct test {
     /* global/shared state
      * - ptrs to shared vars
      */
-    int *       nav32; /* 32-bit non-atomic */
-    atomic_t *  av32;  /* 32-bit atomic */
-    long *      nav64; /* 64-bit non-atomic */
-    atomic64_t *av64;  /* 64-bit atomic */
+    int *        nav32; /* 32-bit non-atomic */
+    atomic_int  *av32;  /* 32-bit atomic */
+    long *       nav64; /* 64-bit non-atomic */
+    atomic_long *av64;  /* 64-bit atomic */
 
     /* per-worker state */
     struct worker_state **wstate;
@@ -416,8 +416,8 @@ test_init(struct test *t, struct test_params *params, struct mtf_test_info *lcl_
     /* allocate shared vars on separate cache lines */
     t->nav32 = (int *)mtest_alloc(sizeof(*t->nav32));
     t->nav64 = (long *)mtest_alloc(sizeof(*t->nav64));
-    t->av32 = (atomic_t *)mtest_alloc(sizeof(*t->av32));
-    t->av64 = (atomic64_t *)mtest_alloc(sizeof(*t->av64));
+    t->av32 = (atomic_int *)mtest_alloc(sizeof(*t->av32));
+    t->av64 = (atomic_long *)mtest_alloc(sizeof(*t->av64));
 
     /* intialize shared vars */
     *t->nav32 = 0;

--- a/tests/unit/util/rest_api_test.c
+++ b/tests/unit/util/rest_api_test.c
@@ -192,7 +192,7 @@ parallel_test_get(
     struct kv_iter *  iter,
     void *            context)
 {
-    atomic_inc((atomic_t *)context);
+    atomic_inc((atomic_int *)context);
 
     return 0;
 }
@@ -206,20 +206,20 @@ parallel_rest_req(void *info)
 
     err = curl_get(path, sock, buf, sizeof(buf));
     if (err)
-        atomic_inc((atomic_t *)info);
+        atomic_inc((atomic_int *)info);
 
     return 0;
 }
 
 MTF_DEFINE_UTEST_PREPOST(rest_api, multisession_test, rest_start, rest_stop)
 {
-    char *    path = "parallel/rest/req";
-    merr_t    err;
-    atomic_t  calls;
-    atomic_t  failures;
-    const int num_threads = 5;
-    pthread_t t[num_threads];
-    int       i, rc;
+    char      *path = "parallel/rest/req";
+    merr_t     err;
+    atomic_int calls;
+    atomic_int failures;
+    const int  num_threads = 5;
+    pthread_t  t[num_threads];
+    int        i, rc;
 
     rest_init();
     atomic_set(&calls, 0);

--- a/tests/unit/util/workqueue_test.c
+++ b/tests/unit/util/workqueue_test.c
@@ -50,8 +50,8 @@ MTF_DEFINE_UTEST(workqueue_test, create)
     destroy_workqueue(q);
 }
 
-atomic_t counter;
-atomic_t counter2;
+atomic_int counter;
+atomic_int counter2;
 
 void
 simple_worker(struct work_struct *wstruct)

--- a/tools/capput/capput.c
+++ b/tools/capput/capput.c
@@ -54,9 +54,9 @@
 
 #include "kvs_helper.h"
 
-static atomic64_t  pfx HSE_L1D_ALIGNED;
-static atomic64_t  sfx HSE_L1D_ALIGNED;
-static uint64_t    last_del HSE_L1D_ALIGNED;
+static atomic_ulong pfx HSE_ACP_ALIGNED;
+static atomic_ulong sfx HSE_ACP_ALIGNED;
+static uint64_t last_del HSE_ACP_ALIGNED;
 
 pthread_barrier_t   put_barrier1;
 pthread_barrier_t   put_barrier2;
@@ -91,7 +91,7 @@ struct opts {
 
 struct thread_info {
     int           idx;
-    atomic64_t    ops HSE_L1D_ALIGNED;
+    atomic_ulong  ops HSE_L1D_ALIGNED;
     volatile int  state;
 };
 

--- a/tools/kmt/kmt.c
+++ b/tools/kmt/kmt.c
@@ -474,13 +474,13 @@ struct km_lor km_lor = {
 
 struct km_latency {
     struct hdr_histogram *km_histogram;
-    atomic64_t            km_samples;
-    atomic64_t            km_samples_err;
+    atomic_ulong          km_samples;
+    atomic_ulong          km_samples_err;
 };
 
 struct km_sync_latency {
-    atomic64_t km_sync_iterations;
-    atomic64_t km_total_sync_latency_us;
+    atomic_ulong km_sync_iterations;
+    atomic_ulong km_total_sync_latency_us;
 };
 
 /* The implementation object maintains both the methods and data
@@ -512,7 +512,7 @@ struct km_impl {
     mongoc_uri_t *        active_uri;
     mongoc_client_pool_t *client_pool;
 
-    atomic64_t keydistchunk HSE_ACP_ALIGNED;
+    atomic_ulong keydistchunk HSE_ACP_ALIGNED;
 
     struct km_latency      km_latency[KMT_LAT_REC_CNT] HSE_ACP_ALIGNED;
     struct km_sync_latency km_sync_latency;
@@ -3358,7 +3358,7 @@ latency_aggregate(struct km_latency *to, struct km_latency *from, int count)
 void *
 spawn_main(void *arg)
 {
-    static atomic_t workers;
+    static atomic_int workers;
     struct km_inst *inst = arg;
     char            collname[16];
     int             i;

--- a/tools/longtest/longtest.c
+++ b/tools/longtest/longtest.c
@@ -291,9 +291,9 @@ struct test {
 	u32                 stat_rows_no_hdr;
 	u32                 running_threads;
 	pthread_barrier_t   bar_sync;
-	atomic_t            errors;
-	atomic_t            test_complete;
-	atomic_t            hard_stop;
+	atomic_int          errors;
+	atomic_int          test_complete;
+	atomic_int          hard_stop;
 	u8                 *seqnum_pfx_key;
 	struct test_stats   tot;
 	struct test_stats   stats[MAX_THREADS];

--- a/tools/mpool/mdc/mdcperf.c
+++ b/tools/mpool/mdc/mdcperf.c
@@ -146,7 +146,7 @@ struct thread_args {
     int              instance;
     pthread_mutex_t *start_mutex;
     pthread_cond_t  *start_line;
-    atomic_t        *start_cnt;
+    atomic_int      *start_cnt;
     void            *arg;
 };
 
@@ -205,7 +205,7 @@ thread_create(
     pthread_attr_t *attr;
     pthread_cond_t  start_line = PTHREAD_COND_INITIALIZER;
     pthread_mutex_t start_mutex = PTHREAD_MUTEX_INITIALIZER;
-    atomic_t        start_cnt;
+    atomic_int      start_cnt;
     int             still_to_start;
     int             i, rc;
 

--- a/tools/multicursor/multicursor.c
+++ b/tools/multicursor/multicursor.c
@@ -57,9 +57,9 @@ struct thread_info {
 	int           start HSE_ACP_ALIGNED;
 	int           end;
 	int           num_cursors;
-	atomic64_t    puts;
-	atomic64_t    reads;
-	atomic64_t    cursors;
+	atomic_ulong  puts;
+	atomic_ulong  reads;
+	atomic_ulong  cursors;
 };
 
 struct thread_info *g_ti;

--- a/tools/pfx_probe/pfx_probe.c
+++ b/tools/pfx_probe/pfx_probe.c
@@ -62,7 +62,7 @@ enum phase {
 };
 enum phase phase;
 uint64_t total_puts;
-atomic64_t completed_puts;
+atomic_ulong completed_puts;
 
 int err;
 
@@ -110,16 +110,16 @@ loader(void *arg)
 				     val, sizeof(val));
 			if (rc)
 				fatal(rc, "put failure");
-
-			atomic_inc(&completed_puts);
 		}
+
+        atomic_fetch_add(&completed_puts, ti->sfx);
 	}
 }
 
 bool killthreads = false;
 
-atomic64_t rd_count;
-atomic64_t rd_time;
+atomic_ulong rd_count;
+atomic_ulong rd_time;
 
 enum hse_kvs_pfx_probe_cnt
 _pfx_probe(

--- a/tools/range_read/range_read.c
+++ b/tools/range_read/range_read.c
@@ -78,9 +78,9 @@ struct opts {
 
 static volatile bool stopthreads HSE_ACP_ALIGNED;
 
-atomic64_t n_write HSE_ACP_ALIGNED;
-atomic64_t n_cursor HSE_ACP_ALIGNED;
-atomic64_t n_read HSE_ACP_ALIGNED;
+atomic_ulong n_write HSE_ACP_ALIGNED;
+atomic_ulong n_cursor HSE_ACP_ALIGNED;
+atomic_ulong n_read HSE_ACP_ALIGNED;
 
 
 u64 gtod_usec(void)

--- a/tools/throttle/throttle.c
+++ b/tools/throttle/throttle.c
@@ -564,7 +564,7 @@ fmt_key(
     int len,
     unsigned long num)
 {
-    static atomic_t u;
+    static atomic_int u;
     unsigned char *str = ti->ref_key;
     uint v;
 

--- a/tools/waltest/waltest.c
+++ b/tools/waltest/waltest.c
@@ -78,7 +78,7 @@ const char *mode = "";
 const char *progname = NULL;
 struct timeval tv_start;
 int verbose = 0;
-atomic64_t errors;
+atomic_ulong errors;
 static bool ingest_mode;
 static u32 sync_time;
 
@@ -87,10 +87,10 @@ static const long key_space_size = 4000000000UL;
 static bool single_kvs;
 
 struct hse_kvdb *kvdb;
-atomic64_t put_cnt;
-atomic64_t del_cnt;
-atomic64_t put_verify_cnt;
-atomic64_t del_verify_cnt;
+atomic_long put_cnt;
+atomic_long del_cnt;
+atomic_long put_verify_cnt;
+atomic_long del_verify_cnt;
 
 struct thread_info {
     struct hse_kvdb        *kvdb;
@@ -664,7 +664,7 @@ fmt_key(
     int len,
     unsigned long num)
 {
-    static atomic_t u;
+    static atomic_int u;
     unsigned char *str = ti->ref_key;
 
     if (len < 3) {


### PR DESCRIPTION
- Reduce c0sk_ingestref_wait() latency by eliminating redundant scans...
- Replace atomic_t and atomic64_t with appropriate C11 atomic types...
