### PR TITLE
Fix db_bench disabler() creation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -370,19 +370,17 @@ else
     hse_python_depends = disabler()
 endif
 
-if get_option('db_bench')
-    if get_option('experimental')
-        db_bench_proj = subproject(
-            'db_bench',
-            default_options: [
-                'cpp_std=c++11',
-            ]
-        )
-        db_bench = db_bench_proj.get_variable('db_bench')
-        executable_paths += fs.parent(db_bench.full_path())
-    else
-        db_bench = disabler()
-    endif
+if get_option('db_bench') and get_option('experimental')
+    db_bench_proj = subproject(
+        'db_bench',
+        default_options: [
+            'cpp_std=c++11',
+        ]
+    )
+    db_bench = db_bench_proj.get_variable('db_bench')
+    executable_paths += fs.parent(db_bench.full_path())
+else
+    db_bench = disabler()
 endif
 
 subdir('tools')


### PR DESCRIPTION
This was causing a build issue when -Ddb_bench=false. This is the reason the hse-python builds have been failing recently.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
