### PR TITLE
Remove yield from tests option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -351,7 +351,12 @@ endif
 run_env = environment()
 
 if 'python' in bindings
-    hse_python = subproject('hse-python')
+    hse_python = subproject(
+        'hse-python',
+        default_options: [
+            'tests=false',
+        ]
+    )
 
     hse_python_depends = [
         hse_python.get_variable('extension_modules'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,7 @@ option('cli', type: 'boolean', value: true,
     description: 'Build the CLI')
 option('experimental', type: 'boolean', value: true, yield: true,
     description: 'Build the experimental parts of HSE')
-option('tests', type: 'boolean', value: true, yield: true,
+option('tests', type: 'boolean', value: true,
     description: 'Build and enable tests')
 option('ycsb', type: 'boolean', value: false,
     description: 'Build JNI bridge artifacts')


### PR DESCRIPTION
In the end, this didn't make any sense. It has only caused grief for
hse-python.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Verified checks?
Have the checks completed?
- [x] meson test -C build --setup=ci
- [x] All commits are signed off
