### PR TITLE
SSVG-3709 Increase timeout for stress-large tests

### DIFF
--- a/tests/stress/meson.build
+++ b/tests/stress/meson.build
@@ -196,7 +196,7 @@ foreach p, p_params: programs
             args: t_params['args'],
             is_parallel: false,
             suite: ['stress-large'],
-            timeout: params.get('timeout', 3600),
+            timeout: params.get('timeout', 7200),
         )
     endforeach
 


### PR DESCRIPTION
Signed-off-by: bvasandani <bvasandani@micron.com>

## Description
Increasing the timeout of the stress-large tests to 2 hours

## Issue(s) Addressed
SSVG-3709

## Verified checks?
Have the checks completed?
- [ ] meson test -C build --setup=ci
- [ ] All commits are signed off
