### PR TITLE
Cleanup PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,3 @@
 
 ## Issue(s) Addressed
 <!-- Issue number -->
-
-## Verified checks?
-Have the checks completed?
-- [ ] meson test -C build --setup=ci
-- [ ] All commits are signed off


### PR DESCRIPTION
The verified checks get caught by the CI. Pointless to continuously
check them in the PR template itself.

Signed-off-by: Tristan Partin <tpartin@micron.com>
