### PR TITLE
NFSE-4590 Cursor Read enhancements

### DIFF
--- a/include/hse/hse.h
+++ b/include/hse/hse.h
@@ -826,7 +826,7 @@ hse_kvs_cursor_destroy(struct hse_kvs_cursor *cursor);
 /** @brief Iteratively access the elements pointed to by the cursor.
  *
  * Read a key-value pair from the cursor, advancing the cursor past its current
- * location.
+ * location. If the argument @p val is NULL, only the key is read.
  *
  * @note If the cursor is at EOF, attempts to read from it will not change the
  * state of the cursor.
@@ -860,6 +860,50 @@ hse_kvs_cursor_read(
     const void **          key,
     size_t *               key_len,
     const void **          val,
+    size_t *               val_len,
+    bool *                 eof);
+
+/** @brief Iteratively access the elements pointed to by the cursor.
+ *
+ * Read a key-value pair from the cursor, advancing the cursor past its current
+ * location. The key-value pair will be copied into the user's buffer(s). If the
+ * argument @p valbuf is NULL, only the key is read.
+ *
+ * @note If the cursor is at EOF, attempts to read from it will not change the
+ * state of the cursor.
+ * @note This function is thread safe across disparate cursors.
+ *
+ * <b>Flags:</b>
+ * @arg 0 - Reserved for future use.
+ *
+ * @param cursor: Cursor handle from hse_kvs_cursor_create().
+ * @param flags: Flags for operation specialization.
+ * @param keybuf[in,out]: Buffer into which the next key will be copied.
+ * @param keybuf_sz: Size of @p keybuf.
+ * @param[out] key_len: Length of the key.
+ * @param valbuf[in,out]: Buffer into which the next key's value will be copied.
+ * @param valbuf_sz: Size of @p valbuf
+ * @param[out] val_len: Length of @p val.
+ * @param[out] eof: If true, no more key-value pairs in sequence.
+ *
+ * @remark @p cursor must not be NULL.
+ * @remark @p key must not be NULL.
+ * @remark @p key_len must not be NULL.
+ * @remark @p val must not be NULL.
+ * @remark @p val_len must not be NULL.
+ * @remark @p eof must not be NULL.
+ *
+ * @returns Error status
+ */
+hse_err_t
+hse_kvs_cursor_read_copy(
+    struct hse_kvs_cursor *cur,
+    const unsigned int     flags,
+    const void *           keybuf,
+    size_t                 keybuf_sz,
+    size_t *               key_len,
+    const void *           valbuf,
+    size_t                 valbuf_sz,
     size_t *               val_len,
     bool *                 eof);
 

--- a/include/hse/hse.h
+++ b/include/hse/hse.h
@@ -778,7 +778,7 @@ hse_kvdb_txn_state_get(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * doesn't create a prefix cursor -- it must meet the two conditions listed
  * above.
  *
- * @note This function is thread safe across disparate cursors.
+ * @note This function is thread safe.
  *
  * <b>Flags:</b>
  * @arg HSE_CURSOR_CREATE_REV - Iterate in reverse lexicographical order.
@@ -811,7 +811,7 @@ hse_kvs_cursor_create(
  * @warning After invoking this function, calling any other cursor functions
  * with this handle will result in undefined behavior.
  *
- * @note This function is thread safe.
+ * @note Cursor objects are not thread safe.
  *
  * @param cursor: Cursor handle from hse_kvs_cursor_create().
  *
@@ -830,7 +830,7 @@ hse_kvs_cursor_destroy(struct hse_kvs_cursor *cursor);
  *
  * @note If the cursor is at EOF, attempts to read from it will not change the
  * state of the cursor.
- * @note This function is thread safe across disparate cursors.
+ * @note Cursor objects are not thread safe.
  *
  * <b>Flags:</b>
  * @arg 0 - Reserved for future use.
@@ -871,7 +871,7 @@ hse_kvs_cursor_read(
  *
  * @note If the cursor is at EOF, attempts to read from it will not change the
  * state of the cursor.
- * @note This function is thread safe across disparate cursors.
+ * @note Cursor objects are not thread safe.
  *
  * <b>Flags:</b>
  * @arg 0 - Reserved for future use.
@@ -913,7 +913,7 @@ hse_kvs_cursor_read_copy(
  * The next hse_kvs_cursor_read() will start at this point. Both @p found and @p
  * found_len must be non-NULL for that functionality to work.
  *
- * @note This function is thread safe across disparate cursors.
+ * @note Cursor objects are not thread safe.
  *
  * <b>Flags:</b>
  * @arg 0 - Reserved for future use.
@@ -951,7 +951,7 @@ hse_kvs_cursor_seek(
  * found_len must be non-NULL for that functionality to work.
  *
  * @note This is only supported for forward cursors.
- * @note This function is thread safe across disparate cursors.
+ * @note Cursor objects are not thread safe.
  *
  * <b>Flags:</b>
  * @arg 0 - Reserved for future use.
@@ -988,7 +988,7 @@ hse_kvs_cursor_seek_range(
  * This operation updates the snapshot view of a non-transaction cursor. It is a
  * no-op on transaction cursors.
  *
- * @note This function is thread safe across disparate cursors.
+ * @note Cursor objects are not thread safe.
  *
  * <b>Flags:</b>
  * @arg 0 - Reserved for future use.

--- a/include/hse/hse.h
+++ b/include/hse/hse.h
@@ -898,11 +898,11 @@ hse_kvs_cursor_read(
 hse_err_t
 hse_kvs_cursor_read_copy(
     struct hse_kvs_cursor *cursor,
-    const unsigned int     flags,
-    const void *           keybuf,
+    unsigned int           flags,
+    void *                 keybuf,
     size_t                 keybuf_sz,
     size_t *               key_len,
-    const void *           valbuf,
+    void *                 valbuf,
     size_t                 valbuf_sz,
     size_t *               val_len,
     bool *                 eof);

--- a/include/hse/hse.h
+++ b/include/hse/hse.h
@@ -878,10 +878,10 @@ hse_kvs_cursor_read(
  *
  * @param cursor: Cursor handle from hse_kvs_cursor_create().
  * @param flags: Flags for operation specialization.
- * @param keybuf[in,out]: Buffer into which the next key will be copied.
+ * @param[in,out] keybuf: Buffer into which the next key will be copied.
  * @param keybuf_sz: Size of @p keybuf.
  * @param[out] key_len: Length of the key.
- * @param valbuf[in,out]: Buffer into which the next key's value will be copied.
+ * @param[in,out] valbuf: Buffer into which the next key's value will be copied.
  * @param valbuf_sz: Size of @p valbuf
  * @param[out] val_len: Length of @p val.
  * @param[out] eof: If true, no more key-value pairs in sequence.
@@ -897,7 +897,7 @@ hse_kvs_cursor_read(
  */
 hse_err_t
 hse_kvs_cursor_read_copy(
-    struct hse_kvs_cursor *cur,
+    struct hse_kvs_cursor *cursor,
     const unsigned int     flags,
     const void *           keybuf,
     size_t                 keybuf_sz,

--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -1117,7 +1117,7 @@ hse_kvs_cursor_seek_range(
 hse_err_t
 hse_kvs_cursor_read(
     struct hse_kvs_cursor *cursor,
-    const unsigned int     flags,
+    unsigned int           flags,
     const void **          key,
     size_t *               klen,
     const void **          val,
@@ -1150,11 +1150,11 @@ hse_kvs_cursor_read(
 hse_err_t
 hse_kvs_cursor_read_copy(
     struct hse_kvs_cursor *cursor,
-    const unsigned int     flags,
-    const void *           keybuf,
+    unsigned int           flags,
+    void *                 keybuf,
     size_t                 keybuf_sz,
     size_t *               key_len,
-    const void *           valbuf,
+    void *                 valbuf,
     size_t                 valbuf_sz,
     size_t *               val_len,
     bool *                 eof)

--- a/lib/include/hse_ikvdb/ikvdb.h
+++ b/lib/include/hse_ikvdb/ikvdb.h
@@ -503,6 +503,18 @@ ikvdb_kvs_cursor_read(
     size_t *               val_len,
     bool *                 eof);
 
+merr_t
+ikvdb_kvs_cursor_read_copy(
+    struct hse_kvs_cursor *cur,
+    const unsigned int     flags,
+    const void *           keybuf,
+    size_t                 keybuf_sz,
+    size_t *               key_len,
+    const void *           valbuf,
+    size_t                 valbuf_sz,
+    size_t *               val_len,
+    bool *                 eof);
+
 /**
  * ikvdb_kvs_cursor_destroy() - allow the caller to indicate that is is done
  * with the scan and release the associated cursor

--- a/lib/include/hse_ikvdb/ikvdb.h
+++ b/lib/include/hse_ikvdb/ikvdb.h
@@ -506,11 +506,11 @@ ikvdb_kvs_cursor_read(
 merr_t
 ikvdb_kvs_cursor_read_copy(
     struct hse_kvs_cursor *cur,
-    const unsigned int     flags,
-    const void *           keybuf,
+    unsigned int           flags,
+    void *                 keybuf,
     size_t                 keybuf_sz,
     size_t *               key_len,
-    const void *           valbuf,
+    void *                 valbuf,
     size_t                 valbuf_sz,
     size_t *               val_len,
     bool *                 eof);

--- a/lib/include/hse_ikvdb/kvs.h
+++ b/lib/include/hse_ikvdb/kvs.h
@@ -128,13 +128,27 @@ merr_t
 kvs_cursor_read(struct hse_kvs_cursor *cursor, unsigned int flags, bool *eof);
 
 void
-kvs_cursor_key_copy(struct hse_kvs_cursor *cursor, const void *kbuf, size_t kbufsz, const void **key_out, size_t *klen_out);
+kvs_cursor_key_copy(
+    struct hse_kvs_cursor  *cursor,
+    void                   *buf,
+    size_t                  bufsz,
+    const void            **key_out,
+    size_t                 *klen_out);
 
 merr_t
-kvs_cursor_val_copy(struct hse_kvs_cursor *cursor, const void *vbuf, size_t vbufsz, const void **val_out, size_t *vlen_out);
+kvs_cursor_val_copy(
+    struct hse_kvs_cursor  *cursor,
+    void                   *buf,
+    size_t                  bufsz,
+    const void            **val_out,
+    size_t                 *vlen_out);
 
 void
-kvs_cursor_perfc_alloc(uint prio, const char *dbname, struct perfc_set *pcs_cc, struct perfc_set *pcs_cd);
+kvs_cursor_perfc_alloc(
+    uint                prio,
+    const char         *dbname,
+    struct perfc_set   *pcs_cc,
+    struct perfc_set   *pcs_cd);
 
 void
 kvs_cursor_perfc_free(struct perfc_set *pcs_cc, struct perfc_set *pcs_cd);

--- a/lib/include/hse_ikvdb/kvs.h
+++ b/lib/include/hse_ikvdb/kvs.h
@@ -125,7 +125,13 @@ kvs_cursor_seek(
     struct kvs_ktuple *    kt);
 
 merr_t
-kvs_cursor_read(struct hse_kvs_cursor *cursor, struct kvs_kvtuple *kvt, bool *eof);
+kvs_cursor_read(struct hse_kvs_cursor *cursor, unsigned int flags, bool *eof);
+
+const void *
+kvs_cursor_key_copy(struct hse_kvs_cursor *cursor, const void *kbuf, size_t kbufsz, size_t *klen);
+
+const void *
+kvs_cursor_val_copy(struct hse_kvs_cursor *cursor, const void *vbuf, size_t vbufsz, size_t *vlen);
 
 void
 kvs_cursor_perfc_alloc(uint prio, const char *dbname, struct perfc_set *pcs_cc, struct perfc_set *pcs_cd);

--- a/lib/include/hse_ikvdb/kvs.h
+++ b/lib/include/hse_ikvdb/kvs.h
@@ -127,11 +127,11 @@ kvs_cursor_seek(
 merr_t
 kvs_cursor_read(struct hse_kvs_cursor *cursor, unsigned int flags, bool *eof);
 
-const void *
-kvs_cursor_key_copy(struct hse_kvs_cursor *cursor, const void *kbuf, size_t kbufsz, size_t *klen);
+void
+kvs_cursor_key_copy(struct hse_kvs_cursor *cursor, const void *kbuf, size_t kbufsz, const void **key_out, size_t *klen_out);
 
-const void *
-kvs_cursor_val_copy(struct hse_kvs_cursor *cursor, const void *vbuf, size_t vbufsz, size_t *vlen);
+merr_t
+kvs_cursor_val_copy(struct hse_kvs_cursor *cursor, const void *vbuf, size_t vbufsz, const void **val_out, size_t *vlen_out);
 
 void
 kvs_cursor_perfc_alloc(uint prio, const char *dbname, struct perfc_set *pcs_cc, struct perfc_set *pcs_cd);

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -2728,11 +2728,11 @@ ikvdb_kvs_cursor_read(
     if (*eof)
         return 0;
 
-    *key = kvs_cursor_key_copy(cur, NULL, 0, key_len);
+    kvs_cursor_key_copy(cur, NULL, 0, key, key_len);
     if (val) {
-        *val = kvs_cursor_val_copy(cur, NULL, 0, val_len);
-        if (ev(!val))
-            return merr(EBUG);
+        err = kvs_cursor_val_copy(cur, NULL, 0, val, val_len);
+        if (ev(err))
+            return err;
     }
 
     perfc_lat_record(
@@ -2776,13 +2776,11 @@ ikvdb_kvs_cursor_read_copy(
     if (*eof)
         return 0;
 
-    kvs_cursor_key_copy(cur, keybuf, keybuf_sz, key_len);
+    kvs_cursor_key_copy(cur, keybuf, keybuf_sz, NULL, key_len);
     if (valbuf) {
-        const void *v;
-
-        v = kvs_cursor_val_copy(cur, valbuf, valbuf_sz, val_len);
-        if (ev(!v))
-            return merr(EBUG);
+        err = kvs_cursor_val_copy(cur, valbuf, valbuf_sz, NULL, val_len);
+        if (ev(err))
+            return err;
     }
 
     perfc_lat_record(

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -2701,7 +2701,7 @@ ikvdb_kvs_cursor_seek(
 merr_t
 ikvdb_kvs_cursor_read(
     struct hse_kvs_cursor *cur,
-    const unsigned int     flags,
+    unsigned int           flags,
     const void **          key,
     size_t *               key_len,
     const void **          val,
@@ -2747,11 +2747,11 @@ ikvdb_kvs_cursor_read(
 merr_t
 ikvdb_kvs_cursor_read_copy(
     struct hse_kvs_cursor *cur,
-    const unsigned int     flags,
-    const void *           keybuf,
+    unsigned int           flags,
+    void *                 keybuf,
     size_t                 keybuf_sz,
     size_t *               key_len,
-    const void *           valbuf,
+    void *                 valbuf,
     size_t                 valbuf_sz,
     size_t *               val_len,
     bool *                 eof)

--- a/lib/kvs/kvs_cursor.c
+++ b/lib/kvs/kvs_cursor.c
@@ -1100,32 +1100,58 @@ out:
     return err;
 }
 
-static merr_t
-ikvs_cursor_kv_copy(struct kvs_cursor_impl *cursor, struct kvs_kvtuple *kvt)
+const void *
+kvs_cursor_key_copy(struct hse_kvs_cursor *cursor, const void *kbuf, size_t kbufsz, size_t *klen)
 {
-    struct kvs_vtuple *vt = &cursor->kci_elem_last.kce_vt;
-    uint               clen = cursor->kci_elem_last.kce_complen;
-    void *             vbuf = cursor->kci_buf + HSE_KVS_KEY_LEN_MAX;
+    struct kvs_cursor_impl *cur = cursor_h2r(cursor);
+    void                   *buf = (void *)kbuf;
+    size_t                  bufsz = kbufsz;
+    uint                    keylen;
+    const void             *key;
+
+    if (!buf) {
+        buf = (void *)cur->kci_buf;
+        bufsz = HSE_KVS_KEY_LEN_MAX;
+    }
+
+    key = key_obj_copy(buf, bufsz, &keylen, cur->kci_last);
+    *klen = keylen;
+
+    return key;
+}
+
+const void *
+kvs_cursor_val_copy(struct hse_kvs_cursor *cursor, const void *vbuf, size_t vbufsz, size_t *vlen)
+{
+    struct kvs_cursor_impl *cur = cursor_h2r(cursor);
+
+    struct kvs_vtuple *vt = &cur->kci_elem_last.kce_vt;
+    uint               clen = cur->kci_elem_last.kce_complen;
+    void              *buf = (void *)vbuf;
+    size_t             bufsz = vbufsz;
     merr_t             err = 0;
 
-    kvt->kvt_key.kt_data = key_obj_copy(
-        cursor->kci_buf, HSE_KVS_KEY_LEN_MAX, (uint *)&kvt->kvt_key.kt_len, cursor->kci_last);
+    if (!buf) {
+        buf = cur->kci_buf + HSE_KVS_KEY_LEN_MAX;
+        bufsz = HSE_KVS_VALUE_LEN_MAX;
+    }
+
+    *vlen = vt->vt_xlen;
 
     if (clen) {
         uint outlen;
 
-        err = compress_lz4_ops.cop_decompress(vt->vt_data, clen, vbuf, HSE_KVS_VALUE_LEN_MAX, &outlen);
+        err = compress_lz4_ops.cop_decompress(vt->vt_data, clen, buf, bufsz, &outlen);
         if (ev(err))
-            return err;
+            return NULL;
 
-        if (ev(outlen != vt->vt_xlen))
-            return merr(EBUG);
+        if (ev(outlen != min_t(u64, vt->vt_xlen, bufsz)))
+            return NULL;
     } else {
-        memcpy(vbuf, vt->vt_data, vt->vt_xlen);
+        memcpy(buf, vt->vt_data, min_t(u64, vt->vt_xlen, bufsz));
     }
 
-    kvs_vtuple_init(&kvt->kvt_value, vbuf, vt->vt_xlen);
-    return err;
+    return buf;
 }
 
 static merr_t
@@ -1143,7 +1169,7 @@ kvs_cursor_prepare(struct hse_kvs_cursor *cursor)
 }
 
 merr_t
-kvs_cursor_read(struct hse_kvs_cursor *handle, struct kvs_kvtuple *kvt, bool *eofp)
+kvs_cursor_read(struct hse_kvs_cursor *handle, unsigned int flags, bool *eofp)
 {
     struct kvs_cursor_impl *cursor = (void *)handle;
 
@@ -1205,7 +1231,6 @@ kvs_cursor_read(struct hse_kvs_cursor *handle, struct kvs_kvtuple *kvt, bool *eo
     if (*eofp)
         return 0;
 
-    cursor->kci_err = ikvs_cursor_kv_copy(cursor, kvt);
     return cursor->kci_err;
 }
 

--- a/tests/unit/kvs/kvs_cursor_test.c
+++ b/tests/unit/kvs/kvs_cursor_test.c
@@ -150,7 +150,7 @@ void verify_range(struct mtf_test_info *lcl_ti, const char *pfx, int start, int 
         if (eof)
             break;
 
-        key = kvs_cursor_key_copy(cur, NULL, 0, &key_len);
+        kvs_cursor_key_copy(cur, NULL, 0, &key, &key_len);
 
         expect_pfx(lcl_ti, key, key_len, pfx);
 
@@ -158,7 +158,7 @@ void verify_range(struct mtf_test_info *lcl_ti, const char *pfx, int start, int 
         expect_key(lcl_ti, key, key_len, buf);
 
         key_len = 0;
-        key = kvs_cursor_key_copy(cur, (const char *)keybuf, sizeof(keybuf), &key_len);
+        kvs_cursor_key_copy(cur, (const char *)keybuf, sizeof(keybuf), &key, &key_len);
         expect_key(lcl_ti, key, key_len, buf);
 
         ++c;

--- a/tests/unit/kvs/kvs_cursor_test.c
+++ b/tests/unit/kvs/kvs_cursor_test.c
@@ -158,7 +158,7 @@ void verify_range(struct mtf_test_info *lcl_ti, const char *pfx, int start, int 
         expect_key(lcl_ti, key, key_len, buf);
 
         key_len = 0;
-        kvs_cursor_key_copy(cur, (const char *)keybuf, sizeof(keybuf), &key, &key_len);
+        kvs_cursor_key_copy(cur, keybuf, sizeof(keybuf), &key, &key_len);
         expect_key(lcl_ti, key, key_len, buf);
 
         ++c;

--- a/tools/pscan/pscan.c
+++ b/tools/pscan/pscan.c
@@ -402,7 +402,10 @@ main(int argc, char **argv)
         if (stats)
             EVENT_START(tr);
 
-        err = hse_kvs_cursor_read(cursor, 0, &key, &klen, &val, &vlen, &eof);
+        if (countem && !cksum)
+            err = hse_kvs_cursor_read(cursor, 0, &key, &klen, NULL, NULL, &eof);
+        else
+            err = hse_kvs_cursor_read(cursor, 0, &key, &klen, &val, &vlen, &eof);
 
         if (stats)
             EVENT_SAMPLE(tr);


### PR DESCRIPTION
Signed-off-by: Gaurav Ramdasi <10132364+gsramdasi@users.noreply.github.com>

## Description
The cursor read api can now return just keys if the valur parameter is set to NULL. There's a new api called hse_kvs_cursor_read_copy(...) which allows the user to pass in buffers for the key and value and hse will copy the key-value pait into these buffers. This api will also return just the key if the value buffer is set to NULL.

## Issue(s) Addressed
NFSE-4590
