### PR TITLE
Remove fc34 from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image-tag: [34, 35]
+        image-tag: [35]
         build_type: [release, debug]
 
     steps:


### PR DESCRIPTION
We have coverage for newer distros and older distros. Doesn't make much
sense to test something in the middle. This should free up 2 more jobs
for the pipeline.

Signed-off-by: Tristan Partin <tpartin@micron.com>
