### PR TITLE
Add public API for checking if a media class is configured

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,16 +19,14 @@ jobs:
 
       - name: Initialize
         run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          sudo dnf install -y git poetry python-unversioned-command pkg-config libmicrohttpd-devel userspace-rcu-devel libyaml-devel lz4-devel libbsd-devel libcurl-devel doxygen
+          sudo dnf install -y git ninja-build meson poetry python-unversioned-command pkg-config libmicrohttpd-devel userspace-rcu-devel libyaml-devel lz4-devel libbsd-devel libcurl-devel doxygen
           sudo dnf install -y xz mongo-c-driver libbson openssl-devel cyrus-sasl-devel ncurses-devel cmake make automake gcc gcc-c++ kernel-devel
-          sudo dnf install -y python-pip python-wheel python3-devel libxml2-devel libxslt-devel
-          poetry install
+          sudo dnf install -y python3-devel libxml2-devel libxslt-devel
 
       - name: Setup
         run: |
-          poetry run meson builddir --fatal-meson-warnings -Dwerror=true -Ddocs=true -Dtests=false -Dtools=disabled -Dbindings=none -Dcli=false -Dsamples=false -Ddb_bench=false
+          meson builddir --fatal-meson-warnings -Dwerror=true -Ddocs=true -Dtests=false -Dtools=disabled -Dbindings=none -Dcli=false -Dsamples=false -Ddb_bench=false
 
       - name: Build
         run: |
-          poetry run ninja -C builddir docs/doxygen/api
+          ninja -C builddir docs/doxygen/api

--- a/include/hse/hse.h
+++ b/include/hse/hse.h
@@ -293,6 +293,21 @@ hse_kvdb_kvs_names_free(struct hse_kvdb *kvdb, char **namev);
 hse_err_t
 hse_kvdb_mclass_info_get(struct hse_kvdb *kvdb, enum hse_mclass mclass, struct hse_mclass_info *info);
 
+/** @brief Check if a media class is configured for a KVDB.
+ *
+ * @note This function is thread safe.
+ *
+ * @param kvdb: KVDB handle from hse_kvdb_open().
+ * @param mclass: Media class to query for.
+ *
+ * @remark @p kvdb must not be NULL.
+ *
+ * @returns Whether or not @p mclass is configured.
+ * @retval false: if @p kvdb or @p mclass is invalid.
+ */
+bool
+hse_kvdb_mclass_is_configured(struct hse_kvdb *kvdb, enum hse_mclass mclass);
+
 /** @brief Open a KVDB.
  *
  * @note This function is not thread safe.

--- a/include/hse/types.h
+++ b/include/hse/types.h
@@ -58,7 +58,7 @@ enum hse_err_ctx {
 };
 
 /** @brief Smallest error context value */
-#define HSE_ERR_CTX_MIN HSE_ERR_CTX_NONE
+#define HSE_ERR_CTX_BASE HSE_ERR_CTX_NONE
 
 /** @brief Largest error context value */
 #define HSE_ERR_CTX_MAX HSE_ERR_CTX_NONE

--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -503,6 +503,15 @@ hse_kvdb_mclass_info_get(
     return ikvdb_mclass_info_get((struct ikvdb *)handle, mclass, info);
 }
 
+bool
+hse_kvdb_mclass_is_configured(struct hse_kvdb *const handle, const enum hse_mclass mclass)
+{
+    if (HSE_UNLIKELY(!handle || mclass >= HSE_MCLASS_COUNT))
+        return false;
+
+    return ikvdb_mclass_is_configured((struct ikvdb *)handle, mclass);
+}
+
 hse_err_t
 hse_kvdb_kvs_create(
     struct hse_kvdb *        handle,

--- a/lib/include/hse_ikvdb/ikvdb.h
+++ b/lib/include/hse_ikvdb/ikvdb.h
@@ -101,6 +101,18 @@ ikvdb_drop(const char *kvdb_home);
 merr_t
 ikvdb_mclass_info_get(struct ikvdb *kvdb, enum hse_mclass mclass, struct hse_mclass_info *info);
 
+/** @brief Check if a media class is configured for a KVDB.
+ *
+ * @note This function is thread safe.
+ *
+ * @param kvdb: KVDB handle from hse_kvdb_open().
+ * @param mclass: Media class to query for.
+ *
+ * @returns Whether or not the @p mclass is configured.
+ */
+bool
+ikvdb_mclass_is_configured(struct ikvdb *kvdb, enum hse_mclass mclass);
+
 /**
  * Add media class to a KVDB
  *

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -591,6 +591,19 @@ ikvdb_mclass_info_get(
     return mpool_mclass_info_get(self->ikdb_mp, mclass, info);
 }
 
+bool
+ikvdb_mclass_is_configured(struct ikvdb *const kvdb, const enum hse_mclass mclass)
+{
+    struct ikvdb_impl *self;
+
+    INVARIANT(kvdb);
+    INVARIANT(mclass < HSE_MCLASS_COUNT);
+
+    self = ikvdb_h2r(kvdb);
+
+    return mpool_mclass_is_configured(self->ikdb_mp, mclass);
+}
+
 static inline void
 ikvdb_tb_configure(struct ikvdb_impl *self, u64 burst, u64 rate, bool initialize)
 {


### PR DESCRIPTION
Talked to Steve, and we agreed that this API may be valuable in certain
situations. This was already possible to check if a user looked for an
ENOENT on hse_kvdb_mclass_info_get(), but this is more explicit and
mimics the new mpool mpool_mclass_is_configured().

Signed-off-by: Tristan Partin <tpartin@micron.com>
