### PR TITLE
NFSE-5103 pass in a mock health object

### DIFF
--- a/tests/unit/kvs/kvs_cursor_test.c
+++ b/tests/unit/kvs/kvs_cursor_test.c
@@ -19,6 +19,7 @@
 
 static struct ikvs *kvs;
 static struct lc *lc;
+static struct kvdb_health mock_health;
 
 static int
 test_pre(struct mtf_test_info *lcl_ti)
@@ -32,7 +33,7 @@ test_pre(struct mtf_test_info *lcl_ti)
 
     mock_c0cn_set();
 
-    err = lc_create(&lc, (void *)-1);
+    err = lc_create(&lc, &mock_health);
     ASSERT_EQ_RET(0, err, -1);
 
     lc_ingest_seqno_set(lc, 1);

--- a/tests/unit/lc/lc_test.c
+++ b/tests/unit/lc/lc_test.c
@@ -13,8 +13,10 @@
 #include <hse_ikvdb/tuple.h>
 #include <hse_ikvdb/lc.h>
 #include <hse_ikvdb/cursor.h>
+#include <hse_ikvdb/kvdb_health.h>
 
 struct lc *lc;
+struct kvdb_health mock_health;
 
 int
 test_collection_setup(struct mtf_test_info *info)
@@ -33,7 +35,7 @@ test_pre(struct mtf_test_info *lcl_ti)
 {
     merr_t err;
 
-    err = lc_create(&lc, (void *)-1);
+    err = lc_create(&lc, &mock_health);
     ASSERT_EQ_RET(0, err, -1);
 
     lc_ingest_seqno_set(lc, 0);


### PR DESCRIPTION
## Description
Pass in a mocked health object to lc_create.

## Issue(s) Addressed
NFSE-5103
