### PR TITLE
Error out when KVS name of "default" is passed

### DIFF
--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -260,6 +260,9 @@ validate_kvs_name(const char *name)
     if (name_len == HSE_KVS_NAME_LEN_MAX)
         return merr(ev(ENAMETOOLONG));
 
+    if (strcmp(name, "default") == 0)
+        return merr(EINVAL);
+
     /* Does the name contain invalid characters ?
      * i.e. char apart from [-_A-Za-z0-9]
      */

--- a/tests/functional/api/kvs_lifecycle_test.c
+++ b/tests/functional/api/kvs_lifecycle_test.c
@@ -112,6 +112,10 @@ MTF_DEFINE_UTEST_PREPOST(kvs_api, kvs_invalid, kvs_setup, kvs_teardown)
     err = hse_kvdb_kvs_create(kvdb_handle, kvs_name, 0, NULL);
     ASSERT_EQ(hse_err_to_errno(err), EEXIST);
 
+    /* TC: Cannot create a KVS with name of "default" */
+    err = hse_kvdb_kvs_create(kvdb_handle, "default", 0, NULL);
+    ASSERT_EQ(hse_err_to_errno(err), EINVAL);
+
     /* TC: KVDB cannot have more than 256 KVS */
     for (int i = 2; i <= HSE_KVS_COUNT_MAX; i++) {
         n = snprintf(buf, sizeof(buf), "%s_%d", kvs_name, i);


### PR DESCRIPTION
This is documented on the website and is a bug.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Description
<!-- Describe the changes in this PR and add any information helpful for reviewing. -->

## Issue(s) Addressed
NFSE-5117
