### PR TITLE
Add -Dbindings=auto and set it to the default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir -Dbuildtype=${{ matrix.build_type }} --fatal-meson-warnings -Dycsb=true -Dwerror=true
+          meson builddir -Dbuildtype=${{ matrix.build_type }} --fatal-meson-warnings -Dbindings=all -Dycsb=true -Dwerror=true
 
       - name: Build
         run: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir -Dbuildtype=${{ matrix.build_type }} --fatal-meson-warnings -Dycsb=true -Dwerror=true
+          meson builddir -Dbuildtype=${{ matrix.build_type }} --fatal-meson-warnings -Dbindings=all -Dycsb=true -Dwerror=true
 
       - name: Build
         run: |
@@ -111,7 +111,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir -Dbuildtype=${{ matrix.build_type }} --fatal-meson-warnings -Dycsb=true -Dwerror=true
+          meson builddir -Dbuildtype=${{ matrix.build_type }} --fatal-meson-warnings -Dbindings=all -Dycsb=true -Dwerror=true
 
       - name: Build
         run: |
@@ -149,7 +149,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir -Dbuildtype=${{ matrix.build_type }} --fatal-meson-warnings -Dycsb=true -Db_sanitize=address,undefined
+          meson builddir -Dbuildtype=${{ matrix.build_type }} --fatal-meson-warnings -Dbindings=all -Dycsb=true -Db_sanitize=address,undefined
 
       - name: Build
         run: |

--- a/meson.build
+++ b/meson.build
@@ -304,11 +304,23 @@ if 'all' in get_option('bindings')
     assert(get_option('bindings').length() == 1, 'The -Dbindings=all option cannot have additional values')
     bindings += 'python'
 elif 'none' in get_option('bindings')
-    assert(get_option('bindings').length() == 1, 'The -bindings=none option cannot have additional values')
+    assert(get_option('bindings').length() == 1, 'The -Dbindings=none option cannot have additional values')
+elif 'auto' in get_option('bindings')
+    assert(get_option('bindings').length() == 1, 'The -Dbindings=auto option cannot have additional values')
+
+    # Determine whether we can build hse-ython
+    cython_verison_res = run_command(
+        python,
+        '-c',
+        'from Cython.Compiler.Version import version; print(version)'
+    )
+    if cython_verison_res.returncode() == 0
+        if cython_verison_res.stdout().strip().version_compare('>=0.29.21')
+            bindings += 'python'
+        endif
+    endif
 else
-    foreach b : get_option('bindings')
-        bindings += b
-    endforeach
+    bindings = get_option('bindings')
 endif
 
 # Add paths to these variables if you want to see targets in the runtime

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,7 +12,7 @@ option('tools', type: 'feature', value: 'auto',
     description: 'Build tools')
 option('samples', type: 'boolean', value: true,
     description: 'Build samples')
-option('bindings', type: 'array', choices: ['all', 'none', 'python'], value: ['all'],
+option('bindings', type: 'array', choices: ['all', 'none', 'auto', 'python'], value: ['auto'],
     description: 'Build language bindings')
 option('docs', type: 'boolean', value: false,
     description: 'Build documentation')


### PR DESCRIPTION
This is a step in right direction for getting TTC (time to compile) even
lower for external users/contributors. By making -Dbindings=auto the
default, we can check to make sure various requirements are met before
trying to compile various bindings.

In this case, we are checking if the version of Cython is >= 0.29.21
which is the documented version that hse-python supports.

In the case of Java, it would be: Is there a version of Java >= 8 that
we can use to compile and is Maven available.

In the case of Go, it would be: Is there a Go compiler available.

etc.

Signed-off-by: Tristan Partin <tpartin@micron.com>
