### PR TITLE
Fix linking with -Dwrap_mode=forcefallback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -165,7 +165,7 @@ liburcu_bp_dep = dependency(
     version: '>=0.10.1',
     fallback: 'userspace-rcu',
     default_options: [
-        'default_library=shared',
+        'default_library=static',
         'warning_level=0',
         'werror=false',
     ],
@@ -218,7 +218,7 @@ libmicrohttpd_dep = dependency(
     version: '>=0.9.59',
     fallback: 'libmicrohttpd',
     default_options: [
-        'default_library=shared',
+        'default_library=static',
         'warning_level=0',
         'werror=false',
     ],


### PR DESCRIPTION
Alex discovered that linking failed when compiling an executable when
using userspace-rcu from subprojects. For whatever reason, the symbols
don't get resolved. It isn't clear why this is happening.

One solution to this issue is statically compiling userspace-rcu when
it is used as a subproject. The reason we kept it as a shared library
beforehand was due to licensing concerns. I went and found the
following from the FSF:

> If you statically link against an LGPLed library, you must also
> provide your application in an object (not necessarily source)
> format, so that a user has the opportunity to modify the library
> and relink the application.

https://www.gnu.org/licenses/gpl-faq.en.html#LGPLStaticVsDynamic

Our source is always available on GitHub, so we satisfy the requirement
of allowing users to re-link. Of note, we don't distribute HSE binaries
to users, so this licensing restriction probably never affected us in
the first place.

Signed-off-by: Tristan Partin <tpartin@micron.com>
