### PR TITLE
Allow hse-python to test the hse:python test suite

### DIFF
--- a/scripts/git-hooks/link.sh
+++ b/scripts/git-hooks/link.sh
@@ -1,14 +1,12 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # SPDX-License-Identifier: Apache-2.0
 #
 # Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
 
-set -e
-
 git_hooks_dir="$(git rev-parse --git-path hooks)"
 
-rel_path=$(python3 -c "import os; print(os.path.relpath('$(dirname "${BASH_SOURCE[0]}")', '$git_hooks_dir'))")
+rel_path=$(realpath --relative-to "$git_hooks_dir" "$(dirname "$(realpath "$0")")")
 
 # TODO: Add pre-commit hook back when formatting is all sorted out
 # shellcheck disable=2043

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -17,26 +17,24 @@ if get_option('b_sanitize') != 'none'
     endif
 endif
 
+wrapper = [
+    python,
+    test_runner,
+    '--',
+]
+
 add_test_setup(
     'default',
-    exe_wrapper: [
-        python,
-        test_runner,
-        '--',
-    ],
+    exe_wrapper: wrapper,
     env: run_env,
-    is_default: true,
+    is_default: not meson.is_subproject(),
     # TODO: Check with Meson 0.59 else PR to Meson...
     exclude_suites: ['long', 'non-deterministic', 'stress', 'stress-large', 'nightly-small'] + additional_suite_exclusions,
 )
 
 add_test_setup(
     'ci',
-    exe_wrapper: [
-        python,
-        test_runner,
-        '--',
-    ],
+    exe_wrapper: wrapper,
     env: run_env,
     is_default: false,
     # TODO: Check with Meson 0.59 else PR to Meson...


### PR DESCRIPTION
Can only be one "is_default" in your entire dependency chain...Meson...

Signed-off-by: Tristan Partin <tpartin@micron.com>
