### PR TITLE
Make it so that CI doesn't run when PR description is edited

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - master
       - v2.*
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
 
 env:
   MESON_TESTTHREADS: 1


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
