### PR TITLE
NFSE-5217: Skip hse_fini when not closing kvdb

### DIFF
--- a/tools/putbin/putbin.c
+++ b/tools/putbin/putbin.c
@@ -473,7 +473,10 @@ main(int argc, char **argv)
         free(info[c].key);
     free(info);
 
-    hse_fini();
+    /* Call hse_fini only if the kvdb was closed.
+     */
+    if (!opt_sync)
+        hse_fini();
 
     pg_destroy(pg);
     svec_reset(&hse_gparm);


### PR DESCRIPTION
Signed-off-by: Gaurav Ramdasi <10132364+gsramdasi@users.noreply.github.com>

## Description
Do not call hse_fini unless the kvdb has already been closed.

## Issue(s) Addressed
NFSE-5217
