### PR TITLE
greg/NFSE-5110-workqueue-semantics

### DIFF
--- a/lib/c0/c0sk.c
+++ b/lib/c0/c0sk.c
@@ -484,7 +484,7 @@ c0sk_open(
 
     tdmax = clamp_t(uint, kvdb_rp->c0_ingest_threads, 1, HSE_C0_INGEST_THREADS_MAX);
 
-    c0sk->c0sk_wq_ingest = alloc_workqueue("c0sk_ingest", 0, tdmax);
+    c0sk->c0sk_wq_ingest = alloc_workqueue("hse_c0sk_ingest", 0, 1, tdmax);
     if (!c0sk->c0sk_wq_ingest) {
         err = merr(ENOMEM);
         goto errout;
@@ -492,7 +492,7 @@ c0sk_open(
 
     tdmax = clamp_t(uint, kvdb_rp->c0_maint_threads, 1, HSE_C0_MAINT_THREADS_MAX);
 
-    c0sk->c0sk_wq_maint = alloc_workqueue("c0sk_maint", 0, tdmax);
+    c0sk->c0sk_wq_maint = alloc_workqueue("hse_c0sk_maint", 0, 1, tdmax);
     if (!c0sk->c0sk_wq_maint) {
         err = merr(ENOMEM);
         goto errout;

--- a/lib/cn/cn_internal.h
+++ b/lib/cn/cn_internal.h
@@ -37,7 +37,6 @@ struct cn {
     atomic_ulong cn_ingest_dgen;
 
     atomic_int cn_refcnt;
-    bool       cn_closing;
     bool       cn_replay;
 
     /* for asynchronous mblock I/O */
@@ -59,6 +58,7 @@ struct cn {
     struct workqueue_struct *cn_maint_wq;
     struct delayed_work      cn_maint_dwork;
     atomic_int               cn_maint_cancel;
+    bool                     cn_maint_running;
 
     struct kvs_rparams *  rp;
     struct kvs_cparams *  cp;

--- a/lib/cn/cn_kvdb.c
+++ b/lib/cn/cn_kvdb.c
@@ -28,13 +28,13 @@ cn_kvdb_create(uint cn_maint_threads, uint cn_io_threads, struct cn_kvdb **out)
     atomic_set(&self->cnd_kblk_size, 0);
     atomic_set(&self->cnd_vblk_size, 0);
 
-    self->cn_maint_wq = alloc_workqueue("cn_maint", 0, cn_maint_threads);
+    self->cn_maint_wq = alloc_workqueue("hse_cn_maint", 0, 3, cn_maint_threads);
     if (ev(!self->cn_maint_wq)) {
         free(self);
         return merr(ENOMEM);
     }
 
-    self->cn_io_wq = alloc_workqueue("cn_io", 0, cn_io_threads);
+    self->cn_io_wq = alloc_workqueue("hse_cn_io", 0, 1, cn_io_threads);
     if (ev(!self->cn_io_wq)) {
         destroy_workqueue(self->cn_maint_wq);
         free(self);

--- a/lib/cn/cn_tree_internal.h
+++ b/lib/cn/cn_tree_internal.h
@@ -21,6 +21,7 @@
 #include "cn_tree.h"
 #include "cn_tree_iter.h"
 #include "cn_metrics.h"
+#include "cn_work.h"
 #include "omf.h"
 
 #include "csched_sp3.h"
@@ -158,6 +159,7 @@ struct cn_tree {
  * @tn_rspills_lock:  lock to protect @tn_rspills
  * @tn_rspills:       list of active spills from this node to its children
  * @tn_compacting:   true if node is being compacted
+ * @tn_destroy_work: used for async destroy
  * @tn_hlog:         hyperloglog structure
  * @tn_add_cntr:
  * @tn_rem_cntr:
@@ -180,8 +182,9 @@ struct cn_tree_node {
     atomic_int       tn_compacting;
 
     union {
-        struct sp3_node sp3n;
-    } tn_sched;
+        struct sp3_node tn_sp3n;
+        struct cn_work  tn_destroy_work;
+    };
 
     struct hlog         *tn_hlog HSE_L1D_ALIGNED;
     struct cn_node_stats tn_ns;
@@ -199,8 +202,8 @@ struct cn_tree_node {
 };
 
 /* cn_tree_node to sp3_node */
-#define tn2spn(_tn) (&(_tn)->tn_sched.sp3n)
-#define spn2tn(_spn) container_of(_spn, struct cn_tree_node, tn_sched.sp3n)
+#define tn2spn(_tn) (&(_tn)->tn_sp3n)
+#define spn2tn(_spn) container_of(_spn, struct cn_tree_node, tn_sp3n)
 
 /**
  * cn_tree_find_node - map a node location to a node pointer

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -2451,7 +2451,7 @@ sp3_create(
     if (ev(err))
         goto err_exit;
 
-    sp->wqueue = alloc_workqueue("sp3_monitor", 0, 1);
+    sp->wqueue = alloc_workqueue("hse_sp3_monitor", 0, 1, 1);
     if (ev(!sp->wqueue)) {
         err = merr(ENOMEM);
         goto err_exit;

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -209,12 +209,7 @@ kvset_put_ref(struct kvset *ks)
 
     cn = cn_tree_get_cn(ks->ks_tree);
 
-    if (cn_get_maint_wq(cn)) {
-        cn_work_submit(cn, kvset_put_ref_work, &ks->ks_kvset_cn_work);
-        return;
-    }
-
-    kvset_put_ref_work(&ks->ks_kvset_cn_work);
+    cn_work_submit(cn, kvset_put_ref_work, &ks->ks_kvset_cn_work);
 }
 
 static merr_t

--- a/lib/config/hse_gparams.c
+++ b/lib/config/hse_gparams.c
@@ -313,6 +313,48 @@ static const struct param_spec pspecs[] = {
         },
     },
     {
+        .ps_name = "workqueue_tcdelay",
+        .ps_description = "set workqueue thread-create delay (milliseconds)",
+        .ps_flags = PARAM_FLAG_EXPERIMENTAL,
+        .ps_type = PARAM_TYPE_U32,
+        .ps_offset = offsetof(struct hse_gparams, gp_workqueue_tcdelay),
+        .ps_size = PARAM_SZ(struct hse_gparams, gp_workqueue_tcdelay),
+        .ps_convert = param_default_converter,
+        .ps_validate = param_default_validator,
+        .ps_stringify = param_default_stringify,
+        .ps_jsonify = param_default_jsonify,
+        .ps_default_value = {
+            .as_uscalar = 1000,
+        },
+        .ps_bounds = {
+            .as_uscalar = {
+                .ps_min = 0,
+                .ps_max = UINT32_MAX,
+            },
+        },
+    },
+    {
+        .ps_name = "workqueue_idle_ttl",
+        .ps_description = "set workqueue idle thread time-to-live (seconds)",
+        .ps_flags = PARAM_FLAG_EXPERIMENTAL,
+        .ps_type = PARAM_TYPE_U32,
+        .ps_offset = offsetof(struct hse_gparams, gp_workqueue_idle_ttl),
+        .ps_size = PARAM_SZ(struct hse_gparams, gp_workqueue_idle_ttl),
+        .ps_convert = param_default_converter,
+        .ps_validate = param_default_validator,
+        .ps_stringify = param_default_stringify,
+        .ps_jsonify = param_default_jsonify,
+        .ps_default_value = {
+            .as_uscalar = 300,
+        },
+        .ps_bounds = {
+            .as_uscalar = {
+                .ps_min = 0,
+                .ps_max = UINT32_MAX,
+            },
+        },
+    },
+    {
         .ps_name = "perfc.level",
         .ps_description = "set kvs perf counter enagagement level (min:0 default:2 max:9)",
         .ps_flags = PARAM_FLAG_EXPERIMENTAL,

--- a/lib/include/hse_ikvdb/cn.h
+++ b/lib/include/hse_ikvdb/cn.h
@@ -65,10 +65,6 @@ cn_is_capped(const struct cn *cn);
 
 /* MTF_MOCK */
 bool
-cn_is_closing(const struct cn *cn);
-
-/* MTF_MOCK */
-bool
 cn_is_replay(const struct cn *cn);
 
 /* MTF_MOCK */
@@ -172,6 +168,9 @@ cn_ref_get(struct cn *cn);
 /* MTF_MOCK */
 void
 cn_ref_put(struct cn *cn);
+
+void
+cn_ref_wait(struct cn *cn);
 
 /* MTF_MOCK */
 struct workqueue_struct *

--- a/lib/include/hse_ikvdb/hse_gparams.h
+++ b/lib/include/hse_ikvdb/hse_gparams.h
@@ -23,6 +23,8 @@ struct hse_gparams {
     uint64_t gp_c0kvs_ccache_sz;
     uint64_t gp_c0kvs_cheap_sz;
     uint64_t gp_vlb_cache_sz;
+    uint32_t gp_workqueue_tcdelay;
+    uint32_t gp_workqueue_idle_ttl;
     uint8_t  gp_perfc_level;
 
     struct {

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -673,6 +673,8 @@ ikvdb_throttle_task(struct work_struct *work)
     struct ikvdb_impl *self;
     u64                throttle_update_prev = 0;
 
+    pthread_setname_np(pthread_self(), "hse_throttle");
+
     self = container_of(work, struct ikvdb_impl, ikdb_throttle_work);
 
     while (!self->ikdb_work_stop) {
@@ -1052,7 +1054,7 @@ ikvdb_maint_start(struct ikvdb_impl *self)
     merr_t err;
 
     self->ikdb_work_stop = false;
-    self->ikdb_workqueue = alloc_workqueue("kvdb_maint", 0, 2);
+    self->ikdb_workqueue = alloc_workqueue("hse_kvdb_maint", 0, 2, 2);
     if (!self->ikdb_workqueue) {
         err = merr(ENOMEM);
         log_errx("%s cannot start kvdb maintenance", err, self->ikdb_home);

--- a/lib/lc/lc.c
+++ b/lib/lc/lc.c
@@ -390,7 +390,7 @@ lc_create(struct lc **handle, struct kvdb_health *health)
     }
 
     self->lc_gc_delay_ms = 1000;
-    self->lc_gc_wq = alloc_workqueue("lc_gc", 0, 1);
+    self->lc_gc_wq = alloc_workqueue("hse_lc_gc", 0, 1, 1);
     if (ev(!self->lc_gc_wq)) {
         err = merr(ENOMEM);
         goto err_exit;

--- a/lib/mpool/src/mpool.c
+++ b/lib/mpool/src/mpool.c
@@ -362,7 +362,7 @@ mpool_destroy(const char *home, const struct mpool_dparams *dparams)
     if (!home || !dparams)
         return merr(EINVAL);
 
-    mpdwq = alloc_workqueue("mp_destroy", 0, MP_DESTROY_THREADS);
+    mpdwq = alloc_workqueue("hse_mp_destroy", 0, 1, MP_DESTROY_THREADS);
     ev(!mpdwq);
 
     for (int i = HSE_MCLASS_COUNT - 1; i >= HSE_MCLASS_BASE; i--) {

--- a/lib/util/include/hse_util/logging.h
+++ b/lib/util/include/hse_util/logging.h
@@ -32,16 +32,16 @@
 /*
  * A single log instance can have no more than MAX_HSE_SPECS hse-specific
  * conversion specifiers. For that instance there can be no more than
- * MAX_HSE_NV_PAIRS of structured log data entries created.
+ * HSE_LOG_NV_PAIRS_MAX of structured log data entries created.
  *
  * As structured name value data is accumulated it must be retained
  * until right before the dynamic call to json payload formatter so that
  * those values can be tacked onto its argument list.
  */
-#define MAX_HSE_SPECS       (10)
+#define HSE_LOG_SPECS_MAX   (10)
 
 /*
- * A single log instance can have no more than MAX_HSE_NV_PAIRS of structured
+ * A single log instance can have no more than HSE_LOG_NV_PAIRS_MAX of structured
  * log data entries created.
  *
  * The need for the space is due to current logging logic that requies the
@@ -51,7 +51,7 @@
  * As structured name value data is accumulated it must be retained until
  * those values can be tacked onto its argument list.
  */
-#define MAX_HSE_NV_PAIRS    (40 * MAX_HSE_SPECS)
+#define HSE_LOG_NV_PAIRS_MAX  (40 * HSE_LOG_SPECS_MAX)
 
 /*
  * The HSE platform logging subsystem needs to accept client-registered
@@ -198,7 +198,7 @@ static inline HSE_PRINTF(1, 2) int hse_slog_validate_list(char *fmt, ...)
     return _SLOG_LIST_TOKEN;
 }
 
-extern FILE *logging_file;
+extern FILE *hse_log_file;
 
 /* clang-format on */
 

--- a/lib/util/include/hse_util/workqueue.h
+++ b/lib/util/include/hse_util/workqueue.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_PLATFORM_WORKQUEUE_H
@@ -38,19 +38,10 @@ struct delayed_work {
     struct workqueue_struct *wq;
 };
 
-/*
- * Barrier work item for flush workqueue
- */
-struct wq_barrier {
-    struct work_struct wqb_work;
-    uint               wqb_visitors;
-    uint               wqb_barid;
-};
-
-#define INIT_WORK(_WORK, _FUNC)          \
-    do {                                 \
-        (_WORK)->func = (_FUNC);         \
-        INIT_LIST_HEAD(&(_WORK)->entry); \
+#define INIT_WORK(_work, _func)                 \
+    do {                                        \
+        (_work)->func = (_func);                \
+        INIT_LIST_HEAD(&(_work)->entry);        \
     } while (0)
 
 #define INIT_DELAYED_WORK(_dwork, _func)                                \
@@ -66,9 +57,10 @@ struct workqueue_struct *
 alloc_workqueue(
     const char * fmt,        /* fmt string for name workqueue */
     unsigned int flags,      /* ignored */
-    int          max_active, /* number of threads servicing queue */
+    int          min_active, /* min number of threads servicing queue */
+    int          max_active, /* max number of threads servicing queue */
     ...                      /* fmt string arguments */
-    ) HSE_PRINTF(1, 4);
+    ) HSE_PRINTF(1, 5);
 
 /*
  * Destroy a workqueue.  Waits until all running work has finished and
@@ -86,6 +78,9 @@ destroy_workqueue(struct workqueue_struct *wq);
  */
 void
 flush_workqueue(struct workqueue_struct *wq);
+
+void
+dump_workqueue(struct workqueue_struct *wq);
 
 /*
  * Add work to a workqueue.  Return false if work was already on a
@@ -108,15 +103,5 @@ cancel_delayed_work(struct delayed_work *work);
 
 void
 delayed_work_timer_fn(unsigned long data);
-
-#if HSE_MOCKING
-
-/* MTF_MOCK */
-bool
-queue_work_locked(struct workqueue_struct *wq, struct work_struct *work);
-
-#include "workqueue_ut.h"
-
-#endif /* HSE_MOCKING */
 
 #endif /* HSE_PLATFORM_WORKQUEUE_H */

--- a/lib/util/src/hse_log_fmt.c
+++ b/lib/util/src/hse_log_fmt.c
@@ -157,5 +157,5 @@ hse_log_reg_platform(void)
 {
     hse_log_register('E', fmt_event_counter_stats, add_event_counter_stats);
     if (!hse_log_register('e', fmt_hse_err, add_hse_err))
-        backstop_log("init_hse_logging() cannot add hse_err formatter");
+        hse_log_backstop("%s: cannot add hse_err formatter\n", __func__);
 }

--- a/lib/util/src/logging.c
+++ b/lib/util/src/logging.c
@@ -232,7 +232,7 @@ errout:
 
 /* Note that this function only disables async logging and maybe
  * redirects the logging destination.  Calls to hse_log() should
- * work before, during,and after calls to this function.
+ * work before, during, and after calls to this function.
  */
 void
 hse_log_fini(void)

--- a/lib/util/src/logging.c
+++ b/lib/util/src/logging.c
@@ -36,21 +36,56 @@
 #define PARAM_GET_INVALID(_type, _dst, _dstsz) \
     ({ ((_dstsz) < sizeof(_type) || !(_dst) || (uintptr_t)(_dst) & (__alignof(_type) - 1)); })
 
-DEFINE_MUTEX(hse_logging_lock);
+/**
+ * struct hse_log_async_entry - an asynchronous log message in the circular
+ * buffer.
+ * @ae_source_line:
+ * @ae_priority:
+ * @ae_buf: The format is: <source filename>0<string>
+ *      with "string" 0 terminated. While is should not happen, string may be
+ *      empty or not be there at all if <source filename> it too big.
+ *      "string" is logged by the async log consumer thread with a format %s.
+ */
+struct hse_log_async_entry {
+    s32          ae_source_line;
+    hse_logpri_t ae_priority;
+    char         ae_buf[HSE_LOG_STRUCTURED_DATALEN_MAX];
+};
 
-FILE *logging_file = NULL;
+/**
+ * struct hse_log_async - allow to log from interrupt context.
+ *      The log messages are only stored in a circular buffer attached to
+ *      structure. The hse_log workqueue calls hse_log_async() to process them later.
+ * @al_wstruct:
+ * @al_lock: Protect the fields below.
+ * @al_th_working: true if the async log consumer thread is working.
+ * @al_cons: always increasing and rolling integer.
+ *      al_cons%MAX_LOGGING_ASYNC_ENTRIES is the index in al_entries[]
+ *      where the next entry to consume is located.
+ *      Only changed by the thread _hse_log_async_cons_th().
+ * @al_nb: 0 <= al_nb <= MAX_LOGGING_ASYNC_ENTRIES. Number on entries
+ *      in al_entries[] ready to be consumed.
+ * @al_entries: circular buffer of log messages.
+ */
+struct hse_log_async {
+    struct workqueue_struct *   al_wq;
+    struct work_struct          al_wstruct;
+    struct mutex                al_lock;
+    bool                        al_running;
+    u32                         al_cons;
+    u32                         al_nb;
+    struct hse_log_async_entry *al_entries;
+};
 
-struct hse_logging_infrastructure hse_logging_inf = {
-    .mli_nm_buf = 0,    /* temp buffer for structured data field name */
-    .mli_fmt_buf = 0,   /* intermediate format buffer                 */
-    .mli_sd_buf = 0,    /* buffer to accumulate structured data       */
-    .mli_name_buf = 0,  /* buffer to accumulate key offsets data      */
-    .mli_value_buf = 0, /* buffer to accumulate value offsets         */
-    .mli_json_buf = 0,  /* buffer to accumulate json elements         */
-    .mli_active = 0,    /* has the logging been initialized           */
-    .mli_opened = 0,    /* has the logging been "opened"              */
-    .mli_async =
-        {.al_wq = NULL, .al_cons = 0, .al_nb = 0, .al_entries = NULL, .al_th_working = false }
+struct hse_log_infrastructure {
+    char  mli_nm_buf[HSE_LOG_STRUCTURED_DATALEN_MAX] HSE_ACP_ALIGNED;
+    char  mli_fmt_buf[HSE_LOG_STRUCTURED_DATALEN_MAX];
+    char  mli_sd_buf[HSE_LOG_STRUCTURED_DATALEN_MAX];
+    char  mli_json_buf[HSE_LOG_STRUCTURED_DATALEN_MAX];
+    char *mli_name_buf[HSE_LOG_NV_PAIRS_MAX];
+    char *mli_value_buf[HSE_LOG_NV_PAIRS_MAX];
+    bool  mli_active;
+    struct hse_log_async mli_async;
 };
 
 struct hse_log_code {
@@ -58,15 +93,20 @@ struct hse_log_code {
     hse_log_add_func_t *add; /* structured field */
 };
 
+static DEFINE_MUTEX(hse_log_lock);
+static struct hse_log_infrastructure hse_log_inf;
+
+FILE *hse_log_file = NULL;
+
 /**
- * _hse_consume_one_async() - log one entry of the circular buffer.
+ * hse_log_async_consume() - log one entry of the circular buffer.
  * @entry: entry in the circular buffer that needs to be logged.
  *
  * Locking: no lock held because this entry in the circular buffer can only
  *      be changed by this thread at the moment.
  */
 static void
-_hse_consume_one_async(struct hse_log_async_entry *entry)
+hse_log_async_consume(struct hse_log_async_entry *entry)
 {
     u32 source_file_len;
     const char *slog_prefix = hse_gparams.gp_logging.structured ? "@cee:" : "";
@@ -82,7 +122,7 @@ _hse_consume_one_async(struct hse_log_async_entry *entry)
 }
 
 /**
- * _hse_log_async_cons_th() - consumer of the async logs.
+ * hse_log_async() - consumer of the async logs.
  * @wstruct:
  *
  * Process the log messages that were posted in the circular buffer
@@ -90,7 +130,7 @@ _hse_consume_one_async(struct hse_log_async_entry *entry)
  * It offloads the processing and actual logging of the log messages.
  */
 static void
-_hse_log_async_cons_th(struct work_struct *wstruct)
+hse_log_async(struct work_struct *wstruct)
 {
     struct hse_log_async *      async;
     struct hse_log_async_entry *entry;
@@ -103,10 +143,10 @@ _hse_log_async_cons_th(struct work_struct *wstruct)
     mutex_lock(&async->al_lock);
 
     while (async->al_nb > 0) {
-        entry = async->al_entries + async->al_cons % MAX_LOGGING_ASYNC_ENTRIES;
+        entry = async->al_entries + async->al_cons % HSE_LOG_ASYNC_ENTRIES_MAX;
         mutex_unlock(&async->al_lock);
 
-        _hse_consume_one_async(entry);
+        hse_log_async_consume(entry);
 
         /* Don't hog the cpu. */
         if ((++loop % 128) == 0)
@@ -117,214 +157,132 @@ _hse_log_async_cons_th(struct work_struct *wstruct)
         async->al_nb--;
     }
 
-    async->al_th_working = false;
+    async->al_running = false;
     mutex_unlock(&async->al_lock);
 }
 
+/* Note that this function only enables async logging and maybe
+ * redirects the logging destination.  Calls to hse_log() should
+ * work before, during, and after calls to this function,
+ * regardless of whether or not it succeeds.
+ */
 merr_t
-hse_logging_init(void)
+hse_log_init(void)
 {
-    void * nm_buf = 0, *fmt_buf = 0, *sd_buf = 0;
-    void * json_buf = 0;
-    char **name_buf = 0, **value_buf = 0;
-    void * async_entries = NULL;
-    merr_t err;
-
+    struct hse_log_async *async = &hse_log_inf.mli_async;
+    struct hse_log_async_entry *entryv = NULL;
     struct workqueue_struct *wq = NULL;
-    struct hse_log_async *   async;
+    FILE *fp = NULL;
+    merr_t err;
 
     if (!hse_gparams.gp_logging.enabled)
         return 0;
 
     if (hse_gparams.gp_logging.destination == LD_STDOUT) {
-        logging_file = stdout;
+        fp = stdout;
     } else if (hse_gparams.gp_logging.destination == LD_STDERR) {
-        logging_file = stderr;
+        fp = stderr;
     } else if (hse_gparams.gp_logging.destination == LD_FILE) {
-        logging_file = fopen(hse_gparams.gp_logging.path, "a");
-        if (!logging_file)
-            return merr(errno);
+        fp = fopen(hse_gparams.gp_logging.path, "a");
+        if (!fp) {
+            err = merr(errno);
+            log_errx("failed to open log file %s: @@e",
+                     err, hse_gparams.gp_logging.path);
+            return err;
+        }
+
+        setlinebuf(fp);
     }
 
-    /* stdout is already line buffered */
-    if (logging_file && logging_file != stdout) {
-        if (setvbuf(logging_file, NULL, _IOLBF, 0) != 0)
-            return merr(errno);
-    }
-
-    mutex_lock(&hse_logging_lock);
-    err = hse_logging_inf.mli_active ? EBUSY : 0;
-    mutex_unlock(&hse_logging_lock);
-
-    if (err)
-        return merr(err);
-
-    nm_buf = malloc(MAX_STRUCTURED_DATA_LENGTH);
-    if (!nm_buf) {
-        backstop_log("init_hse_logging() failed to allocate "
-                     "name buffer");
+    entryv = calloc(HSE_LOG_ASYNC_ENTRIES_MAX, sizeof(*entryv));
+    if (!entryv) {
+        log_err("failed to alloc async entries");
         err = merr(ENOMEM);
-        goto out_err;
+        goto errout;
     }
 
-    fmt_buf = malloc(MAX_STRUCTURED_DATA_LENGTH);
-    if (!fmt_buf) {
-        backstop_log("init_hse_logging() failed to allocate "
-                     "format buffer");
-        err = merr(ENOMEM);
-        goto out_err;
-    }
-
-    sd_buf = malloc(MAX_STRUCTURED_DATA_LENGTH);
-    if (!sd_buf) {
-        backstop_log("init_hse_logging() failed to allocate "
-                     "structured data buffer");
-        err = merr(ENOMEM);
-        goto out_err;
-    }
-
-    json_buf = malloc(MAX_STRUCTURED_DATA_LENGTH);
-    if (!json_buf) {
-        backstop_log("init_hse_logging() failed to allocate "
-                     "json structured data buffer");
-        err = merr(ENOMEM);
-        goto out_err;
-    }
-
-    name_buf = malloc(sizeof(void *) * MAX_HSE_NV_PAIRS);
-    if (!name_buf) {
-        backstop_log("init_hse_logging() failed to allocate "
-                     "name offset structured data buffer");
-        err = merr(ENOMEM);
-        goto out_err;
-    }
-
-    value_buf = malloc(sizeof(void *) * MAX_HSE_NV_PAIRS);
-    if (!value_buf) {
-        backstop_log("init_hse_logging() failed to allocate "
-                     "value offset structured data buffer");
-        err = merr(ENOMEM);
-        goto out_err;
-    }
-
-    async_entries = malloc(sizeof(struct hse_log_async_entry) * MAX_LOGGING_ASYNC_ENTRIES);
-    if (!async_entries) {
-        backstop_log("init_hse_logging() failed to allocate "
-                     "async entries");
-        err = merr(ENOMEM);
-        goto out_err;
-    }
-
-    wq = alloc_workqueue("hse_logd", 0, 1);
+    wq = alloc_workqueue("hse_log", 0, 1, 1);
     if (!wq) {
-        backstop_log("init_hse_logging() failed to allocate "
-                     "the work queue");
+        log_err("failed to create hse_log workqueue");
         err = merr(ENOMEM);
-        goto out_err;
+        goto errout;
     }
 
-    mutex_lock(&hse_logging_lock);
-    if (hse_logging_inf.mli_active) {
-        /* Lost race to initialize logging, free memory and return */
-        mutex_unlock(&hse_logging_lock);
-        err = merr(EBUSY);
-        goto out_err;
+    mutex_lock(&hse_log_lock);
+    err = hse_log_inf.mli_active ? merr(EBUSY) : 0;
+    if (!err) {
+        mutex_init(&async->al_lock);
+        async->al_entries = entryv;
+        async->al_wq = wq;
+        hse_log_file = fp;
+        hse_log_inf.mli_active = true;
     }
+    mutex_unlock(&hse_log_lock);
 
-    hse_logging_inf.mli_nm_buf = nm_buf;
-    hse_logging_inf.mli_fmt_buf = fmt_buf;
-    hse_logging_inf.mli_sd_buf = sd_buf;
-    hse_logging_inf.mli_json_buf = json_buf;
-    hse_logging_inf.mli_name_buf = name_buf;
-    hse_logging_inf.mli_value_buf = value_buf;
-    async = &(hse_logging_inf.mli_async);
-    async->al_entries = async_entries;
-    async->al_wq = wq;
-    mutex_init(&async->al_lock);
-    hse_logging_inf.mli_active = 1;
-
-    mutex_unlock(&hse_logging_lock);
-
-    return 0;
-
-out_err:
-    free(nm_buf);
-    free(fmt_buf);
-    free(sd_buf);
-    free(json_buf);
-    free(name_buf);
-    free(value_buf);
-    free(async_entries);
-    destroy_workqueue(wq);
+errout:
+    if (err) {
+        if (fp && fp != stdout && fp != stderr)
+            fclose(fp);
+        destroy_workqueue(wq);
+        free(entryv);
+    }
 
     return err;
 }
 
+/* Note that this function only disables async logging and maybe
+ * redirects the logging destination.  Calls to hse_log() should
+ * work before, during,and after calls to this function.
+ */
 void
-hse_logging_fini(void)
+hse_log_fini(void)
 {
-    struct workqueue_struct *wq;
-    struct hse_log_async *   async;
+    struct hse_log_async *async = &hse_log_inf.mli_async;
+    struct workqueue_struct *wq = NULL;
+    void *entryv;
+    FILE *fp;
 
-    if (!hse_gparams.gp_logging.enabled)
+    mutex_lock(&hse_log_lock);
+    if (hse_log_inf.mli_active) {
+        mutex_lock(&async->al_lock);
+        wq = async->al_wq;
+        async->al_wq = NULL;
+        mutex_unlock(&async->al_lock);
+    }
+    mutex_unlock(&hse_log_lock);
+
+    if (!wq)
         return;
-
-    mutex_lock(&hse_logging_lock);
-    hse_gparams.gp_logging.level = -1;
-    mutex_unlock(&hse_logging_lock);
-
-    async = &hse_logging_inf.mli_async;
-
-    mutex_lock(&async->al_lock);
-    wq = async->al_wq;
-    async->al_wq = NULL;
-    mutex_unlock(&async->al_lock);
 
     /* Wait for the async logging consumer thread to exit. */
     destroy_workqueue(wq);
 
-    mutex_lock(&hse_logging_lock);
-
-    if (hse_gparams.gp_logging.destination == LD_FILE &&
-        logging_file != stdout &&
-        logging_file != stderr)
-        fclose(logging_file);
-
-    free(hse_logging_inf.mli_name_buf);
-    hse_logging_inf.mli_name_buf = 0;
-
-    free(hse_logging_inf.mli_value_buf);
-    hse_logging_inf.mli_value_buf = 0;
-
-    free(hse_logging_inf.mli_nm_buf);
-    hse_logging_inf.mli_nm_buf = 0;
-
-    free(hse_logging_inf.mli_fmt_buf);
-    hse_logging_inf.mli_fmt_buf = 0;
-
-    free(hse_logging_inf.mli_sd_buf);
-    hse_logging_inf.mli_sd_buf = 0;
-
-    free(hse_logging_inf.mli_json_buf);
-    hse_logging_inf.mli_json_buf = 0;
-
-    /*
-     * Thread _hse_log_async_cons_th() exited, the async logging resources
-     * can be freed.
+    /* Other than the async logger (which has an implicit reference
+     * on hse_log_file) all other usage of hse_log_file should be
+     * guarded by hse_log_lock such that it should now be safe to
+     * reset it now that the async logger is no longer running.
      */
-    free(async->al_entries);
+    mutex_lock(&hse_log_lock);
+    fp = hse_log_file;
+    hse_log_file = NULL;
+
+    mutex_destroy(&async->al_lock);
+    entryv = async->al_entries;
     async->al_entries = NULL;
     async->al_cons = 0;
     async->al_nb = 0;
 
-    hse_logging_inf.mli_active = 0;
-    hse_logging_inf.mli_opened = 0;
+    hse_log_inf.mli_active = false;
+    mutex_unlock(&hse_log_lock);
 
-    mutex_unlock(&hse_logging_lock);
+    if (fp && fp != stdout && fp != stderr)
+        fclose(fp);
+
+    free(entryv);
 }
 
 /*
- * _hse_log_post_vasync() - post the log message in a circular buffer.
+ * hse_log_post_vasync() - post the log message in a circular buffer.
  * @source_file: source file of the logging site
  * @source_line: line number of the logging site
  * @priority: priority of the log message
@@ -334,7 +292,7 @@ hse_logging_fini(void)
  * Locking: can be called from interrupt handler => can't block.
  */
 static void
-_hse_log_post_vasync(
+hse_log_post_vasync(
     const char   *source_file,
     s32           source_line,
     hse_logpri_t  priority,
@@ -346,10 +304,10 @@ _hse_log_post_vasync(
     bool                        start;
     char *                      buf;
 
-    async = &(hse_logging_inf.mli_async);
+    async = &(hse_log_inf.mli_async);
 
     mutex_lock(&async->al_lock);
-    if (async->al_nb == MAX_LOGGING_ASYNC_ENTRIES || !async->al_wq) {
+    if (async->al_nb == HSE_LOG_ASYNC_ENTRIES_MAX || !async->al_wq) {
         /* Circular buffer full. */
         mutex_unlock(&async->al_lock);
         ev(ENOENT);
@@ -357,7 +315,7 @@ _hse_log_post_vasync(
     }
 
     /* Next free entry */
-    entry = async->al_entries + (async->al_cons + async->al_nb) % MAX_LOGGING_ASYNC_ENTRIES;
+    entry = async->al_entries + (async->al_cons + async->al_nb) % HSE_LOG_ASYNC_ENTRIES_MAX;
 
     buf = entry->ae_buf;
     buf[0] = 0;
@@ -382,19 +340,19 @@ _hse_log_post_vasync(
     async->al_nb++;
 
     /* Start the consumer thread if it is not already working. */
-    start = !async->al_th_working;
+    start = !async->al_running;
     if (start)
-        async->al_th_working = true;
+        async->al_running = true;
     mutex_unlock(&async->al_lock);
 
     if (start) {
-        INIT_WORK(&async->al_wstruct, _hse_log_async_cons_th);
+        INIT_WORK(&async->al_wstruct, hse_log_async);
         queue_work(async->al_wq, &async->al_wstruct);
     }
 }
 
 /*
- * _hse_log_post_async() - post the log message as json payload
+ * hse_log_post_async() - post the log message as json payload
  * in a circular buffer.
  * @source_file: source file of the logging site
  * @source_line: line number of the logging site
@@ -404,17 +362,17 @@ _hse_log_post_vasync(
  * Locking: can be called from interrupt handler => can't block.
  */
 static void
-_hse_log_post_async(const char *source_file, s32 source_line, hse_logpri_t priority, char *payload)
+hse_log_post_async(const char *source_file, s32 source_line, hse_logpri_t priority, char *payload)
 {
     struct hse_log_async *      async;
     struct hse_log_async_entry *entry;
     bool                        start;
     char *                      buf;
 
-    async = &(hse_logging_inf.mli_async);
+    async = &(hse_log_inf.mli_async);
 
     mutex_lock(&async->al_lock);
-    if (async->al_nb == MAX_LOGGING_ASYNC_ENTRIES || !async->al_wq) {
+    if (async->al_nb == HSE_LOG_ASYNC_ENTRIES_MAX || !async->al_wq) {
         /* Circular buffer full. */
         mutex_unlock(&async->al_lock);
         ev(ENOENT);
@@ -422,7 +380,7 @@ _hse_log_post_async(const char *source_file, s32 source_line, hse_logpri_t prior
     }
 
     /* Next free entry */
-    entry = async->al_entries + (async->al_cons + async->al_nb) % MAX_LOGGING_ASYNC_ENTRIES;
+    entry = async->al_entries + (async->al_cons + async->al_nb) % HSE_LOG_ASYNC_ENTRIES_MAX;
 
     buf = entry->ae_buf;
     buf[0] = 0;
@@ -447,19 +405,19 @@ _hse_log_post_async(const char *source_file, s32 source_line, hse_logpri_t prior
     async->al_nb++;
 
     /* Start the consumer thread if it is not already working. */
-    start = !async->al_th_working;
+    start = !async->al_running;
     if (start)
-        async->al_th_working = true;
+        async->al_running = true;
     mutex_unlock(&async->al_lock);
 
     if (start) {
-        INIT_WORK(&async->al_wstruct, _hse_log_async_cons_th);
+        INIT_WORK(&async->al_wstruct, hse_log_async);
         queue_work(async->al_wq, &async->al_wstruct);
     }
 }
 
 /*
- * The function _hse_log() accomplishes the actual logging function and is
+ * The function hse_log() accomplishes the actual logging function and is
  * invoked by client code through the use of macros. The code does two things:
  * (1) abstracts away the difference between logging in user space via
  * syslog() and in kernel space via printk(), and (2) offers structured
@@ -492,7 +450,7 @@ hse_log(
     struct hse_log_fmt_state state;
     va_list                  args;
     int                      num_hse_args;
-    char *                   int_fmt = hse_logging_inf.mli_fmt_buf;
+    char *                   int_fmt = hse_log_inf.mli_fmt_buf;
     bool                     res = false;
     u64 now;
 
@@ -507,34 +465,26 @@ hse_log(
 
     ev->ev_priv = now + hse_gparams.gp_logging.squelch_ns;
 
-    mutex_lock(&hse_logging_lock);
+    mutex_lock(&hse_log_lock);
 
-    assert(hse_logging_inf.mli_nm_buf != 0);
-    assert(hse_logging_inf.mli_fmt_buf != 0);
-    assert(hse_logging_inf.mli_sd_buf != 0);
-    assert(hse_logging_inf.mli_name_buf != 0);
-    assert(hse_logging_inf.mli_value_buf != 0);
-    assert(hse_logging_inf.mli_json_buf != 0);
-
-    state.dict = hse_logging_inf.mli_sd_buf;
-    state.dict_rem = MAX_STRUCTURED_DATA_LENGTH;
+    state.dict = hse_log_inf.mli_sd_buf;
+    state.dict_rem = HSE_LOG_STRUCTURED_DATALEN_MAX;
     state.dict_pos = state.dict;
-    state.names = hse_logging_inf.mli_name_buf;
-    state.values = hse_logging_inf.mli_value_buf;
+    state.names = hse_log_inf.mli_name_buf;
+    state.values = hse_log_inf.mli_value_buf;
 
     /*
      * This code is at the mercy of the caller actually putting a NULL
      * as the last element of the hse_args array. The following code
-     * scans until either a NULL is found or MAX_HSE_SPECS have been
-     * found. In the latter case, the call is aborted.
+     * scans until either a NULL is found or HSE_LOG_SPECS_MAX have
+     * been found. In the latter case, the call is aborted.
      */
     num_hse_args = 0;
     if (hse_args) {
-        while (hse_args[num_hse_args] && num_hse_args <= MAX_HSE_SPECS)
+        while (hse_args[num_hse_args] && num_hse_args <= HSE_LOG_SPECS_MAX)
             num_hse_args++;
         if (hse_args[num_hse_args]) {
-            backstop_log("Too many HSE arguments given to _hse_log(), "
-                         "aborting log attempt");
+            hse_log_backstop("%s: hse_args list too long\n", __func__);
             goto out;
         }
     } else {
@@ -543,7 +493,7 @@ hse_log(
         hse_args = hse_args_none;
     }
     state.num_hse_specs = num_hse_args;
-    assert(state.num_hse_specs <= MAX_HSE_SPECS);
+    assert(state.num_hse_specs <= HSE_LOG_SPECS_MAX);
 
     state.hse_spec_cnt = 0;
     state.nv_index = 0;
@@ -553,18 +503,20 @@ hse_log(
 
     va_start(args, hse_args);
     res = vpreprocess_fmt_string(
-        &state, ev->ev_dte.dte_func, fmt_string, int_fmt, MAX_STRUCTURED_DATA_LENGTH, hse_args, args);
+        &state, ev->ev_dte.dte_func, fmt_string, int_fmt,
+        HSE_LOG_STRUCTURED_DATALEN_MAX, hse_args, args);
     va_end(args);
 
-    if (!res)
-        goto out;
+    if (res) {
+        async = async && hse_log_inf.mli_async.al_wq;
 
-    va_start(args, hse_args);
-    finalize_log_structure(ev->ev_pri, async, ev->ev_file, ev->ev_line, &state, int_fmt, args);
-    va_end(args);
+        va_start(args, hse_args);
+        finalize_log_structure(ev->ev_pri, async, ev->ev_file, ev->ev_line, &state, int_fmt, args);
+        va_end(args);
+    }
 
 out:
-    mutex_unlock(&hse_logging_lock);
+    mutex_unlock(&hse_log_lock);
 }
 
 static struct hse_log_code codetab[52];
@@ -630,7 +582,7 @@ vpreprocess_fmt_string(
      * IN_HSE_FORMAT when an extended conversion is detected.
      */
 
-    const char *msg1 = "Extra hse conversion specifiers found\n";
+    const char *msg1 = "%s: extra hse conversion specifiers found\n";
 
     bool  res = true;
     char *src_pos = (char *)fmt;
@@ -666,7 +618,7 @@ vpreprocess_fmt_string(
 
             case IN_HSE_FORMAT:
                 if (hse_cnt == state->num_hse_specs) {
-                    backstop_log(msg1);
+                    hse_log_backstop(msg1, __func__);
                     return false;
                 }
 
@@ -759,21 +711,18 @@ IN_HSE_FORMAT_handler(
      */
 
     struct hse_log_code *slot = get_code_slot(**src_pos);
-    char                 errmsg[50];
 
     c = **src_pos;
 
     if (!slot || !slot->fmt) {
-        snprintf(errmsg, sizeof(errmsg), "invalid hse conversion specifier %c", c);
-        backstop_log(errmsg);
+        hse_log_backstop("%s: invalid hse conversion specifier %c\n", __func__, c);
         return false;
     }
 
     ++*src_pos; /* [HSE_REVISIT]: multi-char: pos += slot->len? */
 
     if (!append_hse_arg(slot, tgt_pos, tgt_end, state, obj)) {
-        snprintf(errmsg, sizeof(errmsg), "cannot append hse conversion specifier %c", c);
-        backstop_log(errmsg);
+        hse_log_backstop("%s: cannot append hse conversion specifier %c\n", __func__, c);
         return false;
     }
 
@@ -786,31 +735,34 @@ bool
 hse_log_register(int code, hse_log_fmt_func_t *fmt, hse_log_add_func_t *add)
 {
     struct hse_log_code *slot;
+    bool b = false;
 
-    if (!fmt || !add)
-        return false;
-
+    mutex_lock(&hse_log_lock);
     slot = get_code_slot(code);
+    if (slot && !slot->fmt && fmt && add) {
+        slot->fmt = fmt;
+        slot->add = add;
+        b = true;
+    }
+    mutex_unlock(&hse_log_lock);
 
-    if (!slot || slot->fmt)
-        return false;
-
-    slot->fmt = fmt;
-    slot->add = add;
-    return true;
+    return b;
 }
 
 bool
 hse_log_deregister(int code)
 {
-    struct hse_log_code *slot = get_code_slot(code);
+    struct hse_log_code *slot;
 
-    if (!slot)
-        return false;
+    mutex_lock(&hse_log_lock);
+    slot = get_code_slot(code);
+    if (slot) {
+        slot->fmt = NULL;
+        slot->add = NULL;
+    }
+    mutex_unlock(&hse_log_lock);
 
-    slot->fmt = 0;
-    slot->add = 0;
-    return true;
+    return !!slot;
 }
 
 /* -------------------------------------------------- */
@@ -894,18 +846,18 @@ hse_log_push(struct hse_log_fmt_state *state, bool index, const char *name, cons
 bool
 push_nv(struct hse_log_fmt_state *state, bool index, const char *name, const char *val)
 {
-    char * buf = hse_logging_inf.mli_nm_buf;
+    char * buf = hse_log_inf.mli_nm_buf;
     size_t sz;
     char * tmp = (char *)name;
     char * name_offset;
     char * val_offset;
 
-    if (state->nv_index >= MAX_HSE_NV_PAIRS)
+    if (state->nv_index >= HSE_LOG_NV_PAIRS_MAX)
         return false;
 
     if (index) {
-        sz = snprintf(buf, MAX_STRUCTURED_NAME_LENGTH, name, state->hse_spec_cnt);
-        if (sz > MAX_STRUCTURED_NAME_LENGTH)
+        sz = snprintf(buf, HSE_LOG_STRUCTURED_NAMELEN_MAX, name, state->hse_spec_cnt);
+        if (sz > HSE_LOG_STRUCTURED_NAMELEN_MAX)
             return false;
         tmp = buf;
     }
@@ -988,9 +940,9 @@ finalize_log_structure(
     char *              msg_buf;
     const char *        slog_prefix = "@cee:";
 
-    msg_buf = hse_logging_inf.mli_nm_buf;
+    msg_buf = hse_log_inf.mli_nm_buf;
 
-    i = vsnprintf(msg_buf, MAX_STRUCTURED_DATA_LENGTH, fmt, args);
+    i = vsnprintf(msg_buf, HSE_LOG_STRUCTURED_DATALEN_MAX, fmt, args);
 
     if (!hse_gparams.gp_logging.structured) {
         jc.json_buf = msg_buf;
@@ -998,8 +950,8 @@ finalize_log_structure(
         goto emit_logs;
     }
 
-    jc.json_buf = hse_logging_inf.mli_json_buf;
-    jc.json_buf_sz = MAX_STRUCTURED_DATA_LENGTH;
+    jc.json_buf = hse_log_inf.mli_json_buf;
+    jc.json_buf_sz = HSE_LOG_STRUCTURED_DATALEN_MAX;
 
     json_element_start(&jc, NULL);
 
@@ -1019,7 +971,7 @@ finalize_log_structure(
 
   emit_logs:
     if (async)
-        _hse_log_post_async(source_file, source_line, priority, jc.json_buf);
+        hse_log_post_async(source_file, source_line, priority, jc.json_buf);
     else
         hse_slog_emit(priority, "%s%s\n", slog_prefix, jc.json_buf);
 }
@@ -1153,11 +1105,11 @@ hse_format_payload(struct json_context *jc, va_list payload)
  *
  * hse_slog_commit(HSE_NOTICE, logger);
  *
- * 1) The hse_log and hse_alog macros resolve to the same _hse_log() call.
+ * 1) The hse_log and hse_alog macros resolve to the same hse_log() call.
  * Since all hse_log calls are asynchronous by default, hse_alog should be
  * removed.
  *
- * 2) The _hse_log() call does duplicate work since it handles both async
+ * 2) The hse_log() call does duplicate work since it handles both async
  * and sync calls. The logic should be divided similar to hse_slog() and
  * hse_slog_emit().
  *
@@ -1192,24 +1144,24 @@ hse_slog_internal(hse_logpri_t priority, const char *fmt, ...)
         return;
 
     va_start(payload, fmt);
-    mutex_lock(&hse_logging_lock);
+    mutex_lock(&hse_log_lock);
 
     if (fmt) {
         buf = fmt;
     } else {
         struct json_context jc = { 0 };
 
-        jc.json_buf = hse_logging_inf.mli_fmt_buf;
-        jc.json_buf_sz = MAX_STRUCTURED_DATA_LENGTH;
+        jc.json_buf = hse_log_inf.mli_fmt_buf;
+        jc.json_buf_sz = HSE_LOG_STRUCTURED_DATALEN_MAX;
 
         hse_format_payload(&jc, payload);
 
-        buf = hse_logging_inf.mli_fmt_buf;
+        buf = hse_log_inf.mli_fmt_buf;
     }
 
-    _hse_log_post_vasync("_hse_slog", 1, priority, buf, payload);
+    hse_log_post_vasync("_hse_slog", 1, priority, buf, payload);
 
-    mutex_unlock(&hse_logging_lock);
+    mutex_unlock(&hse_log_lock);
     va_end(payload);
 }
 
@@ -1221,10 +1173,10 @@ hse_slog_emit(hse_logpri_t priority, const char *fmt, ...)
     va_list payload;
 
     va_start(payload, fmt);
-    if (hse_gparams.gp_logging.destination == LD_SYSLOG) {
-        vsyslog(priority, fmt, payload);
+    if (hse_log_file) {
+        vfprintf(hse_log_file, fmt, payload);
     } else {
-        vfprintf(logging_file, fmt, payload);
+        vsyslog(priority, fmt, payload);
     }
     va_end(payload);
 }
@@ -1244,14 +1196,17 @@ hse_slog_create(hse_logpri_t priority, struct slog **sl, const char *type)
 
     *sl = calloc(1, sizeof(struct slog));
     if (ev(!*sl))
-        goto err2;
+        return ENOMEM;
 
     jc = &((*sl)->sl_json);
     jc->json_buf_sz = 2048;
 
     jc->json_buf = malloc(jc->json_buf_sz);
-    if (ev(!jc->json_buf))
-        goto err1;
+    if (ev(!jc->json_buf)) {
+        free(*sl);
+        *sl = NULL;
+        return ENOMEM;
+    }
 
     json_element_start(jc, NULL);
     json_element_field(jc, "type", "%s", type);
@@ -1262,11 +1217,6 @@ hse_slog_create(hse_logpri_t priority, struct slog **sl, const char *type)
     (*sl)->sl_entries = 0;
 
     return 0;
-err1:
-    free(*sl);
-err2:
-    *sl = NULL;
-    return ENOMEM;
 }
 
 int
@@ -1317,8 +1267,10 @@ hse_slog_commit(struct slog *sl)
     json_element_end(jc);
     json_element_end(jc);
 
+    mutex_lock(&hse_log_lock);
     if (sl->sl_entries)
         hse_slog_emit(sl->sl_priority, "@cee:%s\n", jc->json_buf);
+    mutex_unlock(&hse_log_lock);
 
     free(jc->json_buf);
     free(sl);

--- a/lib/util/src/logging_util.c
+++ b/lib/util/src/logging_util.c
@@ -3,24 +3,23 @@
  * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
  */
 
-#define MTF_MOCK_IMPL_logging_util
-#include "logging_util.h"
 #include <stdio.h>
 #include <syslog.h>
 
 #include <hse_util/logging.h>
-#include <hse_ikvdb/hse_gparams.h>
+
+#include "logging_util.h"
 
 void
-backstop_log(const char *fmt)
+hse_log_backstop(const char *fmt, ...)
 {
-    if (hse_gparams.gp_logging.destination == LD_SYSLOG) {
-        syslog(3, "%s: %s", __func__, fmt);
-    } else {
-        fprintf(logging_file, "%s: %s", __func__, fmt);
-    }
-}
+    va_list ap;
 
-#if HSE_MOCKING
-#include "logging_util_ut_impl.i"
-#endif /* HSE_MOCKING */
+    va_start(ap, fmt);
+    if (hse_log_file) {
+        vfprintf(hse_log_file, fmt, ap);
+    } else {
+        vsyslog(LOG_ERR, fmt, ap);
+    }
+    va_end(ap);
+}

--- a/lib/util/src/logging_util.h
+++ b/lib/util/src/logging_util.h
@@ -6,17 +6,9 @@
 #ifndef HSE_LOGGING_UTIL_HEADER
 #define HSE_LOGGING_UTIL_HEADER
 
-#include <hse_util/logging.h>
-#include <hse_util/inttypes.h>
+#include <hse_util/compiler.h>
 
-/* MTF_MOCK_DECL(logging_util) */
-
-/* MTF_MOCK */
-void
-backstop_log(const char *msg);
-
-#if HSE_MOCKING
-#include "logging_util_ut.h"
-#endif /* HSE_MOCKING */
+void HSE_NONNULL(1)
+hse_log_backstop(const char *fmt, ...);
 
 #endif /* HSE_LOGGING_UTIL_HEADER */

--- a/lib/util/src/platform.c
+++ b/lib/util/src/platform.c
@@ -170,21 +170,21 @@ hse_platform_init(void)
     dt_init();
     event_counter_init();
 
-    err = hse_logging_init();
+    err = hse_cpu_init();
+    if (err)
+        goto errout;
+
+    err = hse_timer_init();
+    if (err)
+        goto errout;
+
+    err = hse_log_init();
     if (err)
         goto errout;
 
     hse_log_reg_platform();
 
-    err = hse_cpu_init();
-    if (err)
-        goto errout;
-
     err = vlb_init();
-    if (err)
-        goto errout;
-
-    err = hse_timer_init();
     if (err)
         goto errout;
 
@@ -220,9 +220,9 @@ hse_platform_fini(void)
     rest_destroy();
     kmem_cache_fini();
     perfc_fini();
-    hse_timer_fini();
     vlb_fini();
-    hse_logging_fini();
+    hse_log_fini();
+    hse_timer_fini();
     hse_cgroup_fini();
     dt_fini();
 }

--- a/lib/util/src/rest_api.c
+++ b/lib/util/src/rest_api.c
@@ -1077,7 +1077,7 @@ rest_server_start(const char *sock_path)
 
     spin_lock_init(&rest.sessions_lock);
 
-    rest.url_hdlr_wq = alloc_workqueue("url_handler_wq", 0, WQ_THREADS);
+    rest.url_hdlr_wq = alloc_workqueue("hse_url_handler", 0, 1, WQ_THREADS);
     if (!rest.url_hdlr_wq) {
         unlink(rest.sock_name);
         return merr(ev(ENOMEM));

--- a/lib/util/src/slab.c
+++ b/lib/util/src/slab.c
@@ -1058,7 +1058,7 @@ kmem_cache_init(void)
         INIT_LIST_HEAD(&kmc.kmc_nodev[i].node_full);
     }
 
-    kmc.kmc_wq = alloc_workqueue("kmc", 0, 1);
+    kmc.kmc_wq = alloc_workqueue("hse_kmc_reaper", 0, 1, 1);
     if (ev(!kmc.kmc_wq)) {
         for (i = 0; i < NELEM(kmc.kmc_nodev); ++i)
             kmc_node_lock_destroy(kmc.kmc_nodev + i);

--- a/lib/util/src/workqueue.c
+++ b/lib/util/src/workqueue.c
@@ -7,10 +7,11 @@
 #include <hse_util/mutex.h>
 #include <hse_util/condvar.h>
 #include <hse_util/minmax.h>
-#include <hse_util/page.h>
 #include <hse_util/event_counter.h>
 #include <hse_util/workqueue.h>
 #include <hse_util/logging.h>
+
+#include <hse_ikvdb/hse_gparams.h>
 
 #include <signal.h>
 #include <pthread.h>
@@ -18,77 +19,149 @@
 /**
  * struct wq_priv - worker thread private data
  * @wqp_barid:  ID of most recently processed barrier
- * @wqp_id:     logical thread ID
+ * @wqp_wq:     workqueue ptr
  * @wqp_tid:    pthread thread ID
  */
 struct wq_priv {
     uint      wqp_barid;
-    uint      wqp_id;
+    void     *wqp_wq;
     pthread_t wqp_tid;
+};
+
+/**
+ * struct wq_barrier - Barrier work item for flush_workqueue()
+ */
+struct wq_barrier {
+    struct work_struct wqb_work;
+    uint               wqb_visitors;
+    uint               wqb_barid;
 };
 
 /**
  * struct workqueue_struct - per-workqueue private data
  * @wq_lock:        lock to protect workqueue data
  * @wq_pending:     list of work to be dispatched ASAP
- * @wq_shutdown:    workqueue is shutting down if true
+ * @wq_running:     workqueue is able to dispatch requests
+ * @wq_growing:     workqueue is spawning worker threads
+ * @wq_refcnt:      references held by long-lived threads and delayed work
  * @wq_tdcnt:       current number of worker threads
- * @wq_idle:        condvar where idle worker threads wait
- * @wq_barrier:     condvar where all threads wait for barrier completion
- * @wq_refcnt:      number of threads with long term references on workqueue
+ * @wq_tdmax:       maximum number of worker threads
+ * @wq_tdmin:       minimum number of worker threads
  * @wq_barid:       barrier ID generator
- * @wq_tdmax:       max number of worker threads
+ * @wq_barrier:     condvar where all threads wait for barrier completion
+ * @wq_idle:        condvar where idle worker threads wait
  * @wq_delayed:     list of work to be dispatched in the future
+ * @wq_grow:        timer for grow callback
  * @wq_name:        workqueue name (see pthread_setname_np())
- * @wq_base:        base of workqueue memory allocation for free()
  * @wq_priv:        flexible array of worker thread private data structs
  */
 struct workqueue_struct {
-    struct mutex     wq_lock;
-    struct list_head wq_pending;
-    bool             wq_shutdown;
-    int              wq_tdcnt;
-    struct cv        wq_idle;
-    struct cv        wq_barrier;
-    int              wq_refcnt;
-    uint             wq_barid;
-    int              wq_tdmax;
-    struct list_head wq_delayed;
-    char             wq_name[16];
-    void *           wq_base;
-    struct wq_priv   wq_priv[];
+    struct mutex      wq_lock;
+    struct list_head  wq_pending;
+    bool              wq_running;
+    bool              wq_growing;
+    int               wq_refcnt;
+    int               wq_tdcnt;
+    int               wq_tdmax;
+    int               wq_tdmin;
+    uint              wq_barid;
+    uint              wq_tcdelay;
+    struct cv         wq_barrier;
+    struct cv         wq_idle;
+    struct list_head  wq_delayed;
+    struct timer_list wq_grow;
+    char              wq_name[16];
+    struct wq_priv    wq_priv[];
 };
 
 static void
-workqueue_dump(struct workqueue_struct *wq);
-static void
-flush_barrier(struct work_struct *work);
+dump_workqueue_locked(struct workqueue_struct *wq);
+
 static void *
 worker_thread(void *arg);
 
+static HSE_ALWAYS_INLINE struct work_struct *
+workqueue_first(struct workqueue_struct *wq)
+{
+    return list_first_entry_or_null(&wq->wq_pending, struct work_struct, entry);
+}
+
+static void
+grow_workqueue_cb(ulong arg)
+{
+    struct workqueue_struct *wq = (void *)arg;
+    struct wq_priv *priv = NULL;
+    int rc, i;
+
+    mutex_lock(&wq->wq_lock);
+    for (i = 0; i < wq->wq_tdmax; ++i) {
+        priv = wq->wq_priv + (wq->wq_tdcnt + i) % wq->wq_tdmax;
+        if (!priv->wqp_wq)
+            break;
+    }
+
+    assert(priv && i < wq->wq_tdmax);
+
+    priv->wqp_wq = wq;
+    ++wq->wq_refcnt;
+    ++wq->wq_tdcnt;
+    mutex_unlock(&wq->wq_lock);
+
+    rc = pthread_create(&priv->wqp_tid, NULL, worker_thread, priv);
+    if (rc) {
+        merr_t err = merr(rc);
+
+        log_warnx("growing failed (%s %d/%d%d): @@e",
+                  err, wq->wq_name, wq->wq_tdcnt, wq->wq_tdmin, wq->wq_tdmax);
+    }
+
+    mutex_lock(&wq->wq_lock);
+    if (rc) {
+        struct work_struct *first = workqueue_first(wq);
+
+        /* If there is a flush in progress then we must awaken all
+         * visitors so that each can re-evaluate the barrier state.
+         */
+        if (first && !first->func)
+            cv_broadcast(&wq->wq_barrier);
+
+        priv->wqp_wq = NULL;
+        --wq->wq_refcnt;
+        --wq->wq_tdcnt;
+    }
+
+    wq->wq_growing = workqueue_first(wq) && (wq->wq_tdcnt < wq->wq_tdmax);
+    if (wq->wq_growing) {
+        wq->wq_grow.expires = jiffies + wq->wq_tcdelay;
+        add_timer(&wq->wq_grow);
+        ++wq->wq_refcnt;
+    }
+
+    --wq->wq_refcnt;
+    mutex_unlock(&wq->wq_lock);
+}
+
+
 struct workqueue_struct *
-alloc_workqueue(const char *fmt, unsigned int flags, int max_active, ...)
+alloc_workqueue(const char *fmt, unsigned int flags, int min_active, int max_active, ...)
 {
     struct workqueue_struct *wq;
 
-    void *  base;
     va_list args;
     size_t  wqsz;
-    int     i, rc;
+    int     i;
 
     max_active = max_active ?: WQ_DFL_ACTIVE;
-    max_active = max_t(int, max_active, 1);
-    max_active = min_t(int, max_active, WQ_MAX_ACTIVE);
+    max_active = clamp_t(int, max_active, 1, WQ_MAX_ACTIVE);
+    min_active = clamp_t(int, min_active, 0, max_active);
 
     wqsz = sizeof(*wq) + max_active * sizeof(wq->wq_priv[0]);
 
-    base = calloc(1, wqsz + 64);
-    if (ev(!base))
+    wq = aligned_alloc(HSE_ACP_LINESIZE, roundup(wqsz, HSE_ACP_LINESIZE));
+    if (ev(!wq))
         return NULL;
 
-    wq = PTR_ALIGN(base, 64);
-    wq->wq_base = base;
-
+    memset(wq, 0, wqsz);
     va_start(args, max_active);
     vsnprintf(wq->wq_name, sizeof(wq->wq_name), fmt ? fmt : "workqueue", args);
     va_end(args);
@@ -100,25 +173,36 @@ alloc_workqueue(const char *fmt, unsigned int flags, int max_active, ...)
     INIT_LIST_HEAD(&wq->wq_pending);
     INIT_LIST_HEAD(&wq->wq_delayed);
 
-    wq->wq_tdmax = max_active;
-    wq->wq_tdcnt = max_active;
-    wq->wq_refcnt = max_active;
+    setup_timer(&wq->wq_grow, grow_workqueue_cb, wq);
+    wq->wq_tcdelay = msecs_to_jiffies(1000);
 
-    for (i = 0; i < wq->wq_tdmax; i++) {
-        struct wq_priv *priv = wq->wq_priv + i;
+    /* refcnt, tdmin, and tdmax are carefully managed to ensure
+     * grow_workqueue_cb() doesn't call add_timer() and to prevent
+     * threads entering worker_thread() from exiting until after
+     * we have spawned the minimum number of worker threads.
+     */
+    wq->wq_refcnt = min_active;
+    wq->wq_tdmin = max_active;
+    wq->wq_running = true;
 
-        priv->wqp_id = i;
-
-        rc = pthread_create(&priv->wqp_tid, NULL, worker_thread, priv);
-        if (ev(rc)) {
-            wq->wq_tdcnt = i;
-            wq->wq_refcnt = i;
-            destroy_workqueue(wq);
-            return NULL;
-        }
-
-        pthread_detach(priv->wqp_tid);
+    for (i = 0; i < min_active; ++i) {
+        wq->wq_growing = true;
+        wq->wq_tdmax = i + 1;
+        grow_workqueue_cb((ulong)wq);
     }
+
+    mutex_lock(&wq->wq_lock);
+    assert(!wq->wq_growing);
+
+    if (wq->wq_tdcnt < min_active) {
+        mutex_unlock(&wq->wq_lock);
+        destroy_workqueue(wq);
+        return NULL;
+    }
+
+    wq->wq_tdmin = min_active;
+    wq->wq_tdmax = max_active;
+    mutex_unlock(&wq->wq_lock);
 
     return wq;
 }
@@ -126,36 +210,37 @@ alloc_workqueue(const char *fmt, unsigned int flags, int max_active, ...)
 void
 destroy_workqueue(struct workqueue_struct *wq)
 {
+    int rc;
+
     if (ev(!wq))
         return;
 
     mutex_lock(&wq->wq_lock);
-    if (!list_empty(&wq->wq_delayed)) {
-        log_err("delayed work pending");
-        workqueue_dump(wq);
-        mutex_unlock(&wq->wq_lock);
-        return;
-    }
-
-    /* Signal shutdown to worker threads, then wait for all threads
-     * who have a reference on the workqueue to each drop their ref.
-     */
-    wq->wq_shutdown = 1;
     cv_broadcast(&wq->wq_idle);
+    wq->wq_running = false;
+    wq->wq_tcdelay = 10;
 
-    while (wq->wq_refcnt > 0)
-        cv_timedwait(&wq->wq_idle, &wq->wq_lock, 1);
+    /* Wait for all pending and delayed work to complete and all worker
+     * threads to exit.  Caller should cancel all delayed work before
+     * calling this function to avoid interminable hangs...
+     */
+    while (wq->wq_refcnt > 0) {
+        rc = cv_timedwait(&wq->wq_idle, &wq->wq_lock, 10000);
+        if (rc)
+            dump_workqueue_locked(wq);
+    }
 
     assert(list_empty(&wq->wq_pending));
     assert(list_empty(&wq->wq_delayed));
     assert(wq->wq_tdcnt == 0);
+    assert(!wq->wq_growing);
     mutex_unlock(&wq->wq_lock);
 
     cv_destroy(&wq->wq_barrier);
     cv_destroy(&wq->wq_idle);
     mutex_destroy(&wq->wq_lock);
 
-    free(wq->wq_base);
+    free(wq);
 }
 
 static HSE_ALWAYS_INLINE bool
@@ -164,43 +249,30 @@ work_pending(const struct work_struct *work)
     return !list_empty(&work->entry);
 }
 
-static HSE_ALWAYS_INLINE struct work_struct *
-workqueue_first(struct workqueue_struct *wq)
-{
-    return list_first_entry_or_null(&wq->wq_pending, struct work_struct, entry);
-}
-
-#pragma push_macro("queue_work_locked")
-#undef queue_work_locked
-
-MTF_STATIC
-bool
+static bool
 queue_work_locked(struct workqueue_struct *wq, struct work_struct *work)
 {
     bool enqueued;
 
-    assert(wq->wq_tdcnt > 0);
-
     enqueued = !work_pending(work);
-    if (enqueued)
+    if (enqueued) {
         list_add_tail(&work->entry, &wq->wq_pending);
 
+        /* Try to spawn a new worker thread if there was work pending
+         * when we arrived or we have no worker threads.
+         */
+        if ((workqueue_first(wq) != work && wq->wq_tdcnt < wq->wq_tdmax) || wq->wq_tdcnt < 1) {
+            if (!wq->wq_growing) {
+                wq->wq_grow.expires = jiffies + 1;
+                add_timer(&wq->wq_grow);
+                wq->wq_growing = true;
+                wq->wq_refcnt++;
+            }
+        }
+
+    }
+
     return enqueued;
-}
-
-#pragma pop_macro("queue_work_locked")
-
-/**
- * flush_barrier() - sentinel function used to discern barrier work items
- * @work:   not used
- *
- * This function is never called.  It is only used to provide a unique
- * address to differentiate barrier from non-barrier work items.
- */
-static void
-flush_barrier(struct work_struct *work)
-{
-    abort();
 }
 
 /**
@@ -220,7 +292,7 @@ flush_workqueue(struct workqueue_struct *wq)
     if (ev(!wq))
         return;
 
-    INIT_WORK(&barrier.wqb_work, flush_barrier);
+    INIT_WORK(&barrier.wqb_work, NULL);
 
     mutex_lock(&wq->wq_lock);
     ++wq->wq_refcnt;
@@ -230,12 +302,11 @@ flush_workqueue(struct workqueue_struct *wq)
         barrier.wqb_barid = ++wq->wq_barid;
         barrier.wqb_visitors = 0;
 
-        /* Awaken just one idle worker, the first visitor
-         * will awaken all remaining idle workers.
-         */
-        cv_signal(&wq->wq_idle);
+        cv_broadcast(&wq->wq_idle);
 
-        while (barrier.wqb_visitors < wq->wq_tdcnt)
+        /* Wait for all workers to visit the barrier.
+         */
+        while (barrier.wqb_visitors < UINT_MAX)
             cv_wait(&wq->wq_barrier, &wq->wq_lock);
     }
 
@@ -259,32 +330,38 @@ static void *
 worker_thread(void *arg)
 {
     struct wq_priv *         priv = arg;
-    struct workqueue_struct *wq;
-    struct work_struct *     work;
-    struct wq_barrier *      barrier;
-    sigset_t                 set;
+    struct workqueue_struct *wq = priv->wqp_wq;
+    sigset_t                 sigset;
 
-    /* background threads should not be handling signals */
-    sigfillset(&set);
-    pthread_sigmask(SIG_BLOCK, &set, NULL);
+    sigfillset(&sigset);
+    pthread_sigmask(SIG_BLOCK, &sigset, NULL);
 
-    wq = container_of(priv, struct workqueue_struct, wq_priv[priv->wqp_id]);
-
-    pthread_setname_np(priv->wqp_tid, wq->wq_name);
+    pthread_setname_np(pthread_self(), wq->wq_name);
+    pthread_detach(pthread_self());
 
     mutex_lock(&wq->wq_lock);
 
     while (1) {
+        struct wq_barrier *barrier;
+        struct work_struct *work;
+
         work = workqueue_first(wq);
         if (!work) {
-            if (wq->wq_shutdown)
+            bool extra = wq->wq_tdcnt > wq->wq_tdmin;
+            static thread_local int timedout = 0;
+
+            if (!wq->wq_running || (timedout && extra))
                 break;
 
-            cv_wait(&wq->wq_idle, &wq->wq_lock);
+            /* Sleep a short time if there are extra workers.  If we time out
+             * and still have extra workers after draining the pending queue
+             * then exit (above).  Otherwise, sleep here until signaled.
+             */
+            timedout = cv_timedwait(&wq->wq_idle, &wq->wq_lock, extra ? 10000 : -1);
             continue;
         }
 
-        if (work->func != flush_barrier) {
+        if (work->func) {
             list_del_init(&work->entry);
             mutex_unlock(&wq->wq_lock);
 
@@ -301,8 +378,7 @@ worker_thread(void *arg)
          */
         if (priv->wqp_barid != barrier->wqb_barid) {
             priv->wqp_barid = barrier->wqb_barid;
-            if (barrier->wqb_visitors++ == 0)
-                cv_broadcast(&wq->wq_idle);
+            ++barrier->wqb_visitors;
         }
 
         /* Wait until all worker threads have visited this barrier.
@@ -312,15 +388,17 @@ worker_thread(void *arg)
             continue;
         }
 
-        /* All threads have visited this barrier, so remove it
-         * and continue with next pending work item.
+        /* All threads have visited this barrier, so remove
+         * it and proceed with the next pending work item.
          */
+        barrier->wqb_visitors = UINT_MAX;
         list_del_init(&work->entry);
         cv_broadcast(&wq->wq_barrier);
     }
 
-    --wq->wq_tdcnt;
     --wq->wq_refcnt;
+    --wq->wq_tdcnt;
+    priv->wqp_wq = NULL;
     cv_signal(&wq->wq_idle);
     mutex_unlock(&wq->wq_lock);
 
@@ -335,6 +413,8 @@ bool
 queue_work(struct workqueue_struct *wq, struct work_struct *work)
 {
     bool enqueued;
+
+    assert(work->func);
 
     mutex_lock(&wq->wq_lock);
     enqueued = queue_work_locked(wq, work);
@@ -366,11 +446,13 @@ delayed_work_timer_fn(unsigned long data)
     pending = work_pending(&dwork->work);
     if (pending) {
         list_del_init(&dwork->work.entry);
+
         enqueued = queue_work_locked(dwork->wq, &dwork->work);
         if (enqueued)
             cv_signal(&wq->wq_idle);
 
         assert(enqueued);
+        --wq->wq_refcnt;
     }
 
     assert(pending);
@@ -383,10 +465,9 @@ queue_delayed_work(struct workqueue_struct *wq, struct delayed_work *dwork, unsi
     bool pending;
     u64  expires;
 
-    /* Linux uses WARN_ON_ONCE() for these checks rather than assert().
-     */
     assert(dwork->timer.function == delayed_work_timer_fn);
     assert(dwork->timer.data == (ulong)dwork);
+    assert(dwork->work.func);
 
     expires = nsecs_to_jiffies(get_time_ns()) + delay;
 
@@ -396,6 +477,7 @@ queue_delayed_work(struct workqueue_struct *wq, struct delayed_work *dwork, unsi
         list_add_tail(&dwork->work.entry, &wq->wq_delayed);
         dwork->timer.expires = expires;
         dwork->wq = wq;
+        ++wq->wq_refcnt;
     }
     mutex_unlock(&wq->wq_lock);
 
@@ -418,8 +500,10 @@ cancel_delayed_work(struct delayed_work *dwork)
     pending = work_pending(&dwork->work);
     if (pending) {
         pending = del_timer(&dwork->timer);
-        if (pending)
+        if (pending) {
             list_del_init(&dwork->work.entry);
+            --wq->wq_refcnt;
+        }
     }
     mutex_unlock(&wq->wq_lock);
 
@@ -427,44 +511,44 @@ cancel_delayed_work(struct delayed_work *dwork)
 }
 
 /**
- * workqueue_dump() - dump all workqueue thread state and work items
+ * dump_workqueue_locked() - dump all workqueue thread state and work items
  * @wq:     ptr to workqueue
  *
  * You can call this from gdb if the system gets wedged.  Find a stack
  * frame with a valid workqueue ptr and run:
  *
- *   (gdb) call workqueue_dump(wq)
+ *   (gdb) call dump_workqueue_locked(wq)
  */
 static void
-workqueue_dump(struct workqueue_struct *wq)
+dump_workqueue_locked(struct workqueue_struct *wq)
 {
     struct delayed_work *d;
-    struct work_struct * w;
-    struct wq_barrier *  b;
-    char                 buf[128];
-    int                  i, n;
+    struct work_struct *w;
+    int i, n;
 
-    log_err("wq %p name %s, refcnt %d, tdcnt %u, tdmax %u",
-            wq, wq->wq_name, wq->wq_refcnt,
-            wq->wq_tdcnt, wq->wq_tdmax);
+    log_warn("%s %p: pid %d, refcnt %d, tdcnt %d, tdmin %d, tdmax %d, growing %d",
+             wq->wq_name, wq, getpid(), wq->wq_refcnt,
+             wq->wq_tdcnt, wq->wq_tdmin, wq->wq_tdmax,
+             wq->wq_growing);
 
     for (i = 0; i < wq->wq_tdmax; ++i) {
         struct wq_priv *priv = wq->wq_priv + i;
 
-        snprintf(buf, sizeof(buf),
-                 "thread %3u, tid %8lx, barid %u",
-                 priv->wqp_id,
-                 priv->wqp_tid,
-                 priv->wqp_barid);
+        if (!priv->wqp_wq)
+            continue;
 
-        log_err("wq %p %s", wq, buf);
+        log_warn("%s %p: %3u, barid %u, tid %lx",
+                 wq->wq_name, wq, i, priv->wqp_barid, priv->wqp_tid);
     }
 
     i = 0;
-    list_for_each_entry (w, &wq->wq_pending, entry) {
+    list_for_each_entry(w, &wq->wq_pending, entry) {
+        struct wq_barrier *b;
+        char buf[128];
+
         n = snprintf(buf, sizeof(buf), "  work %3d %p", i++, w);
 
-        if (w->func == flush_barrier) {
+        if (!w->func) {
             b = container_of(w, struct wq_barrier, wqb_work);
 
             snprintf(buf + n, sizeof(buf) - n,
@@ -473,18 +557,23 @@ workqueue_dump(struct workqueue_struct *wq)
                      b->wqb_visitors);
         }
 
-        log_err("wq %p %s", wq, buf);
+        log_warn("%s %p: %s", wq->wq_name, wq, buf);
     }
 
     i = 0;
-    list_for_each_entry (d, &wq->wq_delayed, work.entry) {
-        n = snprintf(
-            buf, sizeof(buf), " dwork %3d %p, expires %lu", i++, d, (ulong)d->timer.expires);
-
-        log_err("wq %p %s", wq, buf);
+    list_for_each_entry(d, &wq->wq_delayed, work.entry) {
+        log_warn("%s %p: dwork %3d %p, expires in %lu jiffies",
+                 wq->wq_name, wq, i++, d, (ulong)d->timer.expires - jiffies);
     }
 }
 
-#if HSE_MOCKING
-#include "workqueue_ut_impl.i"
-#endif /* HSE_MOCKING */
+void
+dump_workqueue(struct workqueue_struct *wq)
+{
+    if (!wq)
+        return;
+
+    mutex_lock(&wq->wq_lock);
+    dump_workqueue_locked(wq);
+    mutex_unlock(&wq->wq_lock);
+}

--- a/lib/wal/wal_buffer.c
+++ b/lib/wal/wal_buffer.c
@@ -281,7 +281,7 @@ wal_bufset_open(
     }
 
     threads = wbs->wbs_bufc;
-    wbs->wbs_flushwq = alloc_workqueue("wal_flush_wq", 0, threads);
+    wbs->wbs_flushwq = alloc_workqueue("hse_wal_flush", 0, 1, threads);
     if (!wbs->wbs_flushwq)
         goto errout;
 

--- a/lib/wal/wal_replay.c
+++ b/lib/wal/wal_replay.c
@@ -970,7 +970,7 @@ wal_replay_prepare(struct wal_replay *rep)
     /* The no. of worker threads must not be lower than rep->r_cnt.
      * More details in the replay worker code
      */
-    rep->r_wq = alloc_workqueue("wal_replay_wq", 0, rep->r_cnt);
+    rep->r_wq = alloc_workqueue("hse_wal_replay", 0, rep->r_cnt, rep->r_cnt);
     if (!rep->r_wq)
         return merr(ENOMEM);
 

--- a/tests/functional/smoke/large-values1.sh
+++ b/tests/functional/smoke/large-values1.sh
@@ -44,7 +44,7 @@ cmd kmt "$home" "$kvs" -s1 "$VLEN" -c $kvs_oparams
 cmd putbin "$home" "$kvs" -n 1000 kvs-oparms cn_close_wait=true
 
 # verify spill has occurred
-cmd cn_metrics "$home" "$kvs" | cmd grep -q n.1,
+cmd cn_metrics "$home" "$kvs" | cmd grep n.1,
 
 # verify keys and values
 # shellcheck disable=SC2086

--- a/tests/unit/cn/cn_tree_test.c
+++ b/tests/unit/cn/cn_tree_test.c
@@ -504,7 +504,7 @@ MTF_DEFINE_UTEST_PRE(test, t_cn_tree_create_node, test_setup)
     err = cn_tree_create(&tree, NULL, 0, &cp, &mock_health, rp);
     ASSERT_EQ(err, 0);
 
-    cn_tree_setup(tree, mock_ds, (void *)0x1234, rp, (void *)0x5678, 10, (void *)0x9abc);
+    cn_tree_setup(tree, mock_ds, NULL, rp, (void *)0x5678, 10, (void *)0x9abc);
     ASSERT_EQ(0x9abc, cn_tree_get_cnkvdb(tree));
     ASSERT_EQ(mock_ds, cn_tree_get_ds(tree));
     ASSERT_EQ(rp, cn_tree_get_rp(tree));

--- a/tests/unit/cn/vblock_reader_test.c
+++ b/tests/unit/cn/vblock_reader_test.c
@@ -429,7 +429,7 @@ MTF_DEFINE_UTEST_PRE(vblock_reader_test, t_vbr_madvise_async, pre)
     u64                      argv[1];
     int                      rc;
 
-    vbr_wq = alloc_workqueue("vbr", 0, 0);
+    vbr_wq = alloc_workqueue("vbr", 0, 0, 0);
     ASSERT_NE(NULL, vbr_wq);
 
     vblk_sz = PAGE_SIZE + n_entries * vlen;

--- a/tests/unit/config/hse_gparams_test.c
+++ b/tests/unit/config/hse_gparams_test.c
@@ -154,6 +154,44 @@ MTF_DEFINE_UTEST_PRE(hse_gparams_test, vlb_cache_sz, test_pre)
     ASSERT_EQ(HSE_VLB_CACHESZ_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
+MTF_DEFINE_UTEST_PRE(hse_gparams_test, workqueue_tcdelay, test_pre)
+{
+    const struct param_spec *ps = ps_get("workqueue_tcdelay");
+
+    ASSERT_NE(NULL, ps);
+    ASSERT_NE(NULL, ps->ps_description);
+    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
+    ASSERT_EQ(PARAM_TYPE_U32, ps->ps_type);
+    ASSERT_EQ(offsetof(struct hse_gparams, gp_workqueue_tcdelay), ps->ps_offset);
+    ASSERT_EQ(sizeof(uint32_t), ps->ps_size);
+    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
+    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
+    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
+    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
+    ASSERT_EQ(1000, params.gp_workqueue_tcdelay);
+    ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
+    ASSERT_EQ(UINT32_MAX, ps->ps_bounds.as_uscalar.ps_max);
+}
+
+MTF_DEFINE_UTEST_PRE(hse_gparams_test, workqueue_idle_ttl, test_pre)
+{
+    const struct param_spec *ps = ps_get("workqueue_idle_ttl");
+
+    ASSERT_NE(NULL, ps);
+    ASSERT_NE(NULL, ps->ps_description);
+    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
+    ASSERT_EQ(PARAM_TYPE_U32, ps->ps_type);
+    ASSERT_EQ(offsetof(struct hse_gparams, gp_workqueue_idle_ttl), ps->ps_offset);
+    ASSERT_EQ(sizeof(uint32_t), ps->ps_size);
+    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
+    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
+    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
+    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
+    ASSERT_EQ(300, params.gp_workqueue_idle_ttl);
+    ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
+    ASSERT_EQ(UINT32_MAX, ps->ps_bounds.as_uscalar.ps_max);
+}
+
 MTF_DEFINE_UTEST_PRE(hse_gparams_test, perfc_level, test_pre)
 {
     const struct param_spec *ps = ps_get("perfc.level");

--- a/tests/unit/util/logging_test.c
+++ b/tests/unit/util/logging_test.c
@@ -535,8 +535,8 @@ MTF_DEFINE_UTEST(hse_logging_test, Test_hse_alog)
     merr_t rc;
     int    i;
 
-    hse_logging_fini();
-    rc = hse_logging_init();
+    hse_log_fini();
+    rc = hse_log_init();
     ASSERT_EQ(0, rc);
 
     hse_log_err("Test %s %d", "test", -1);
@@ -544,14 +544,14 @@ MTF_DEFINE_UTEST(hse_logging_test, Test_hse_alog)
     /*
      * Fill up the circular buffer and overflow it by 20 entries
      * before the consumer thread has a chance to start filling it.
-     * Only the first MAX_LOGGING_ASYNC_ENTRIES should show, the last 20
-     * shoud be discarded.
+     * Only the first HSE_LOG_ASYNC_ENTRIES_MAX should show, the
+     * last 20 should be discarded.
      */
-    for (i = 0; i < MAX_LOGGING_ASYNC_ENTRIES + 20; i++)
+    for (i = 0; i < HSE_LOG_ASYNC_ENTRIES_MAX + 20; i++)
         hse_alog("Test %s %d", "test", i);
     /*
      * Give the consumer thread time  to consume and show all
-     * MAX_LOGGING_ASYNC_ENTRIES log messages.
+     * HSE_LOG_ASYNC_ENTRIES_MAX log messages.
      */
     sleep(2);
 
@@ -562,11 +562,13 @@ MTF_DEFINE_UTEST(hse_logging_test, Test_hse_alog)
 
 MTF_DEFINE_UTEST(hse_logging_test, Test_hse_slog)
 {
-    int   argc = 3;
-    char *argv[3] = { "abc", "123", "!@#" };
+    char *argv[] = { "abc", "123", "!@#" };
+    int argc = NELEM(argv);
+    int rc;
 
-    hse_logging_fini();
-    hse_logging_init();
+    hse_log_fini();
+    rc = hse_log_init();
+    ASSERT_EQ(0, rc);
 
     /* [HSE_REVISIT]
      * Should be able to use shared_result to assert the output.
@@ -702,7 +704,7 @@ MTF_DEFINE_UTEST(hse_logging_test, Test_hse_slog)
 
 MTF_DEFINE_UTEST(hse_logging_test, Test_hse_slog_dynamic)
 {
-    int                  i;
+    int                  rc, i;
     struct slog *        logger;
     struct json_context *jc;
 
@@ -713,8 +715,9 @@ MTF_DEFINE_UTEST(hse_logging_test, Test_hse_slog_dynamic)
 
     struct kv_pair kv_table[] = { { "answer", 42 }, { "foobar", 2000 } };
 
-    hse_logging_fini();
-    hse_logging_init();
+    hse_log_fini();
+    rc = hse_log_init();
+    ASSERT_EQ(0, rc);
 
     hse_slog_create(HSE_LOGPRI_NOTICE, &logger, "utest");
 
@@ -743,12 +746,13 @@ MTF_DEFINE_UTEST(hse_logging_test, Test_hse_slog_dynamic)
 
 MTF_DEFINE_UTEST(hse_logging_test, Test_hse_slog_dynamic_resize)
 {
-    int                  i, original;
+    int                  original, rc, i;
     struct slog *        logger;
     struct json_context *jc;
 
-    hse_logging_fini();
-    hse_logging_init();
+    hse_log_fini();
+    rc = hse_log_init();
+    ASSERT_EQ(0, rc);
 
     hse_slog_create(HSE_LOGPRI_NOTICE, &logger, "utest");
 

--- a/tests/unit/util/structured_logging_test.c
+++ b/tests/unit/util/structured_logging_test.c
@@ -282,10 +282,10 @@ MTF_DEFINE_UTEST(structured_logging_test, Test_preprocess_fmt_string_hse)
     static const char *const fmt = "There was an error: @@e";
     void *                   av[] = { &err, 0 };
 
-    name_buf = malloc(sizeof(void *) * MAX_HSE_NV_PAIRS);
+    name_buf = malloc(sizeof(void *) * HSE_LOG_NV_PAIRS_MAX);
     ASSERT_EQ(0, !name_buf);
 
-    value_buf = malloc(sizeof(void *) * MAX_HSE_NV_PAIRS);
+    value_buf = malloc(sizeof(void *) * HSE_LOG_NV_PAIRS_MAX);
     ASSERT_EQ(0, !value_buf);
 
     state.dict = dict;

--- a/tools/deviceprofile/deviceprofile.c
+++ b/tools/deviceprofile/deviceprofile.c
@@ -259,7 +259,7 @@ deviceprofile_calibrate_create(
 
     memset(dprofile->dp_elem_work, 0, threads * sizeof(*dprofile->dp_elem_work));
 
-    dprofile->dp_workqueue = alloc_workqueue("dp_workqueue", 0, threads);
+    dprofile->dp_workqueue = alloc_workqueue("dp_workqueue", 0, threads, threads);
     if (!dprofile->dp_workqueue) {
         free(dprofile->dp_elem_work);
         free(dprofile);


### PR DESCRIPTION
- Allow hse_log() to work whether or not async logging is enabled..
- Allow workqueue to dynamically grow and shrink the the number of worker threads.
