### PR TITLE
Sync checkoss with hse-java

### DIFF
--- a/scripts/dev/checkoss-ignore-words.txt
+++ b/scripts/dev/checkoss-ignore-words.txt
@@ -27,12 +27,15 @@ killed
 killing
 kills
 laid
+liberal
 lies
 period
+pom
 premature
 pros
 pud
 reject
 remains
 sos
+swallow
 uk

--- a/scripts/dev/checkoss.sh
+++ b/scripts/dev/checkoss.sh
@@ -10,7 +10,7 @@ SRC_ROOT=$(realpath "${1:-"./"}")
 # Print the usage of offensive language
 bad_words=$(curl -s "https://www.cs.cmu.edu/~biglou/resources/bad-words.txt")
 bad_words=$(grep -v -f "${SRC_ROOT}/scripts/dev/checkoss-ignore-words.txt" <<< "${bad_words[*]}")
-files=$(git -C "${SRC_ROOT}" ls-files | grep -vE '(3rdparty|doxy|format|poetry|images)')
+files=$(git -C "${SRC_ROOT}" ls-files | grep -vE '(doxy|images)')
 pushd "${SRC_ROOT}" > /dev/null || exit
 # shellcheck disable=SC2086
 check_bad_words=$(echo "${files}" | xargs egrep -Hinw "$(echo ${bad_words} | tr ' ' '|')")


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>

Been working on hse-java, and fixed a shellcheck issue (?) and added some new ignore words that are so pointless. I actually hate this list of bad words! What is a `pom`????

Aside: Maybe we should make checkoss its own repo, so that way we can use git submodules or a meson subproject? It gets tiring syncing things in all the repos. Same for the test-runner...
