### PR TITLE
Move checkoss to own workflow

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -1,12 +1,26 @@
-name: CI
+name: Builds
 
 on:
   push:
     branches:
       - master
       - v2.*
+    paths-ignore:
+      - "**/*.md"
+      - .clang-format
+      - .gitattributes
+      - .gitignore
+      - .shellcheckrc
+      - LICENSE
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "**/*.md"
+      - .clang-format
+      - .gitattributes
+      - .gitignore
+      - .shellcheckrc
+      - LICENSE
 
 env:
   MESON_TESTTHREADS: 1
@@ -228,13 +242,3 @@ jobs:
           path: |
             builddir/meson-logs/
             /var/log/messages
-
-  checkoss:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: checkoss
-        run: |
-          scripts/dev/checkoss.sh

--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -2,7 +2,11 @@ name: Cancel
 
 on:
   workflow_run:
-    workflows: [CI]
+    workflows:
+      - Builds
+      - checkoss
+      - Docs
+      - ShellCheck
     types:
       - requested
 

--- a/.github/workflows/checkoss.yaml
+++ b/.github/workflows/checkoss.yaml
@@ -1,0 +1,16 @@
+name: checkoss
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: checkoss
+        run: |
+          scripts/dev/checkoss.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
     paths:
       - 'docs/**'
       - 'include/**/*.h'

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -2,7 +2,7 @@ name: ShellCheck
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
     paths:
       - '**/*.sh'
       - 'scripts/git-hooks/*'


### PR DESCRIPTION
Builds were being generated even when just making changes to markdown
files. Wastes CI resources, so this refactor should fix that.

Signed-off-by: Tristan Partin <tpartin@micron.com>
