### PR TITLE
update meson setup options in nightly tests 

### DIFF
--- a/.github/workflows/nightly_testing.yaml
+++ b/.github/workflows/nightly_testing.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir -Dbuildtype=${{ matrix.build_type }} --fatal-meson-warnings -Dycsb=true
+          meson builddir -Dbuildtype=${{ matrix.buildtype }} -Dtools=enabled -Ddocs=disabled -Dbindings=all -Dycsb=true -Dwerror=true
 
       - name: Test
         run: |

--- a/.github/workflows/nightly_testing.yaml
+++ b/.github/workflows/nightly_testing.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        buildtype: [release, debugoptimized]
+        buildtype: [release, debug]
 
     steps:
       - name: Freeing up disk space on CI system

--- a/.github/workflows/nightly_testing.yaml
+++ b/.github/workflows/nightly_testing.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        build_type: [release, debugoptimized]
+        buildtype: [release, debugoptimized]
 
     steps:
       - name: Freeing up disk space on CI system


### PR DESCRIPTION
Nightly tests were failing due to a warning caught by the --fatal-meson-warnings option. Updated setup options. 