### PR TITLE
Reduce durability.interval_ms lower bound to 1ms (NFSE-5140)

### DIFF
--- a/lib/include/hse_ikvdb/wal.h
+++ b/lib/include/hse_ikvdb/wal.h
@@ -11,7 +11,7 @@
 #include <hse_ikvdb/kvs.h>
 #include <hse_ikvdb/tuple.h>
 
-#define HSE_WAL_DUR_MS_MIN         (25)
+#define HSE_WAL_DUR_MS_MIN         (1)
 #define HSE_WAL_DUR_MS_DFLT        (100)
 #define HSE_WAL_DUR_MS_MAX         (1000)
 


### PR DESCRIPTION
Signed-off-by: Nabeel M Mohamed <50154757+nabeelmmd@users.noreply.github.com>
