### PR TITLE
Add cn-tree-simulator

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install build-essential ninja-build pkg-config \
-            libbsd-dev libmicrohttpd-dev liburcu-dev libyaml-dev \
+            libbsd-dev libmicrohttpd-dev liburcu-dev libyaml-dev golang \
             libcurl4-openssl-dev python3-setuptools libmongoc-dev \
             libbson-dev libssl-dev libsasl2-dev
           sudo python3 -m pip install meson Cython
@@ -88,6 +88,19 @@ jobs:
           if [ $(lsb_release -rs) = "20.04" ]; then
             echo "CFLAGS=-Wno-deprecated ${CFLAGS}" >> $GITHUB_ENV
           fi
+
+      - name: Setup go
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        run: |
+          sudo mkdir /usr/local/lib/go-1.11
+          cd /tmp
+          wget --quiet https://dl.google.com/go/go1.11.linux-amd64.tar.gz
+          sudo tar -xf go1.11.linux-amd64.tar.gz --strip 1 --directory \
+            /usr/local/lib/go-1.11
+          sudo update-alternatives --install /usr/bin/go go \
+            /usr/local/lib/go-1.11/bin/go 40
+          sudo update-alternatives --set go /usr/local/lib/go-1.11/bin/go
+          echo "GOROOT=/usr/local/lib/go-1.11" >> $GITHUB_ENV
 
       - name: Setup
         run: |
@@ -146,7 +159,7 @@ jobs:
             "C Development Tools and Libraries"
           dnf install -y git ninja-build meson python-unversioned-command \
             libmicrohttpd-devel userspace-rcu-devel libyaml-devel libbsd-devel \
-            libcurl-devel libpmem-devel xz mongo-c-driver libbson \
+            libcurl-devel libpmem-devel golang xz mongo-c-driver libbson \
             openssl-devel cyrus-sasl-devel ncurses-devel \
             java-1.8.0-openjdk-devel python3-devel python3-Cython libxml2 \
             libxslt
@@ -224,7 +237,7 @@ jobs:
           dnf group install -y --with-optional "Development Tools"
           dnf install -y git ninja-build libmicrohttpd-devel \
             userspace-rcu-devel libyaml-devel libbsd-devel libcurl-devel \
-            libpmem-devel xz mongo-c-driver libbson openssl-devel \
+            libpmem-devel golang xz mongo-c-driver libbson openssl-devel \
             cyrus-sasl-devel ncurses-devel java-1.8.0-openjdk-devel \
             python36 python36-devel libxml2 libxslt
           python3 -m pip install meson Cython
@@ -275,6 +288,8 @@ jobs:
       matrix:
         buildtype: [release, debug]
         arch: [s390x]
+    env:
+      GOARCH: ${{ matrix.arch }}
 
     steps:
       - name: Checkout HSE
@@ -302,8 +317,9 @@ jobs:
             libpython3-dev:${{ matrix.arch }} liburcu-dev:${{ matrix.arch }} \
             libcurl4-openssl-dev:${{ matrix.arch }} \
             libbsd-dev:${{ matrix.arch }} libmicrohttpd-dev:${{ matrix.arch }} \
-            libyaml-dev:${{ matrix.arch }} libmongoc-dev:${{ matrix.arch }} \
-            libbson-dev:${{ matrix.arch }} libncurses-dev:${{ matrix.arch }} \
+            libyaml-dev:${{ matrix.arch }} golang \
+            libmongoc-dev:${{ matrix.arch }} libbson-dev:${{ matrix.arch }} \
+            libncurses-dev:${{ matrix.arch }} \
             openjdk-11-jdk:${{ matrix.arch }} openjdk-11-jdk
           python3 -m pip install meson Cython
 
@@ -357,7 +373,7 @@ jobs:
             "C Development Tools and Libraries"
           dnf install -y git ninja-build meson python-unversioned-command \
             libmicrohttpd-devel userspace-rcu-devel libyaml-devel libbsd-devel \
-            libcurl-devel libpmem-devel xz mongo-c-driver libbson \
+            libcurl-devel libpmem-devel golang xz mongo-c-driver libbson \
             openssl-devel cyrus-sasl-devel ncurses-devel \
             java-1.8.0-openjdk-devel python3-devel python3-Cython \
             libxml2-devel libxslt-devel libasan libubsan

--- a/.github/workflows/golangci-lint.ignore.yaml
+++ b/.github/workflows/golangci-lint.ignore.yaml
@@ -1,0 +1,17 @@
+name: golangci-lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "**.go"
+      - "**/go.mod"
+      - .github/workflows/go.yaml
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          echo "Skipping ${{ github.workflow }}/${{ github.job }}"

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,22 @@
+name: golangci-lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**.go"
+      - "**/go.mod"
+      - .github/workflows/golangci-lint.yaml
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          args: --enable gofmt --disable structcheck
+          working-directory: ${{ github.workspace }}/tools/cn-tree-simulator

--- a/.github/workflows/nightly_testing.yaml
+++ b/.github/workflows/nightly_testing.yaml
@@ -39,8 +39,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install build-essential ninja-build pkg-config \
             libbsd-dev openjdk-8-jdk libmicrohttpd-dev liburcu-dev libyaml-dev \
-            liblz4-dev libcurl4-openssl-dev libmongoc-1.0-0 libbson-1.0-0 \
-            libssl-dev libsasl2-dev
+            liblz4-dev libcurl4-openssl-dev golang libmongoc-1.0-0 \
+            libbson-1.0-0 libssl-dev libsasl2-dev
           sudo python3 -m pip install meson Cython
 
       - uses: actions/checkout@v2

--- a/tools/cn-tree-simulator/cn/event.go
+++ b/tools/cn-tree-simulator/cn/event.go
@@ -1,0 +1,202 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2022 Micron Technology, Inc. All rights reserved.
+ */
+
+package cn
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type eventType string
+
+const (
+	INGEST_EVENT    eventType = "ingest"
+	SPILL_EVENT     eventType = "spill"
+	SPLIT_EVENT     eventType = "split"
+	KCOMPACT_EVENT  eventType = "k-compact"
+	KVCOMPACT_EVENT eventType = "kv-compact"
+)
+
+type event struct {
+	Type  eventType  `json:"type"`
+	Stats *treeStats `json:"stats"`
+	State *treeState `json:"state,omitempty"`
+}
+
+type ingestEvent struct {
+	event
+	IngestID uint   `json:"ingest-id"`
+	NodeID   uint64 `json:"node-id"`
+	Size     uint64 `json:"size"`
+}
+
+type spillEvent struct {
+	event
+	SpillID uint     `json:"spill-id"`
+	NodeID  uint64   `json:"node-id"`
+	Size    uint64   `json:"size"`
+	Nodes   []uint64 `json:"nodes"`
+}
+
+type splitEvent struct {
+	event
+	Size uint64 `json:"size"`
+	Src  uint64 `json:"src-node-id"`
+	Dest uint64 `json:"dest-node-id"`
+}
+
+type kCompactEvent struct {
+	event
+	NodeID    uint64 `json:"node-id"`
+	StartID   uint64 `json:"start-id"`
+	RunLength uint   `json:"run-length"`
+	Compc     uint   `json:"compc"`
+}
+
+type kvCompactEvent struct {
+	event
+	NodeID    uint64 `json:"node-id"`
+	StartID   uint64 `json:"start-id"`
+	RunLength uint   `json:"run-length"`
+	Vgroups   uint   `json:"vgroups"`
+}
+
+func emitIngestEvent(tree *Tree, id uint, nodeID uint64, size uint64) error {
+	var state *treeState
+	if tree.params.PrintState {
+		state = tree.state()
+	}
+
+	event := ingestEvent{
+		event: event{
+			Type:  INGEST_EVENT,
+			Stats: tree.stats(),
+			State: state,
+		},
+		IngestID: id,
+		NodeID:   nodeID,
+		Size:     size,
+	}
+
+	output, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(output))
+
+	return nil
+}
+
+func emitSpillEvent(tree *Tree, id uint, nodeID uint64, size uint64, nodes []uint64) error {
+	var state *treeState
+	if tree.params.PrintState {
+		state = tree.state()
+	}
+
+	event := spillEvent{
+		event: event{
+			Type:  SPILL_EVENT,
+			Stats: tree.stats(),
+			State: state,
+		},
+		SpillID: id,
+		NodeID:  nodeID,
+		Size:    size,
+		Nodes:   nodes,
+	}
+
+	output, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(output))
+
+	return nil
+}
+
+func emitSplitEvent(tree *Tree, size uint64, src uint64, dest uint64) error {
+	var state *treeState
+	if tree.params.PrintState {
+		state = tree.state()
+	}
+
+	event := splitEvent{
+		event: event{
+			Type:  SPLIT_EVENT,
+			Stats: tree.stats(),
+			State: state,
+		},
+		Src:  src,
+		Dest: dest,
+		Size: size,
+	}
+
+	output, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(output))
+
+	return nil
+}
+
+func emitKCompactEvent(tree *Tree, nodeID uint64, startID uint64, runLength uint, compc uint) error {
+	var state *treeState
+	if tree.params.PrintState {
+		state = tree.state()
+	}
+
+	event := kCompactEvent{
+		event: event{
+			Type:  KCOMPACT_EVENT,
+			Stats: tree.stats(),
+			State: state,
+		},
+		NodeID:    nodeID,
+		StartID:   startID,
+		RunLength: runLength,
+		Compc:     compc,
+	}
+
+	output, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(output))
+
+	return nil
+}
+
+func emitKVCompactEvent(tree *Tree, nodeID uint64, startID uint64, runLength uint, vgroups uint) error {
+	var state *treeState
+	if tree.params.PrintState {
+		state = tree.state()
+	}
+
+	event := kvCompactEvent{
+		event: event{
+			Type:  KVCOMPACT_EVENT,
+			Stats: tree.stats(),
+			State: state,
+		},
+		NodeID:    nodeID,
+		StartID:   startID,
+		RunLength: runLength,
+		Vgroups:   vgroups,
+	}
+
+	output, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(output))
+
+	return nil
+}

--- a/tools/cn-tree-simulator/cn/kvset.go
+++ b/tools/cn-tree-simulator/cn/kvset.go
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2022 Micron Technology, Inc. All rights reserved.
+ */
+
+package cn
+
+type kvSet struct {
+	ID           uint64 `json:"id"`
+	CompactCount uint   `json:"compc"`
+	Vgroups      uint   `json:"vgroups"`
+	Size         uint64 `json:"size"`
+}

--- a/tools/cn-tree-simulator/cn/node.go
+++ b/tools/cn-tree-simulator/cn/node.go
@@ -1,0 +1,304 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2022 Micron Technology, Inc. All rights reserved.
+ */
+
+package cn
+
+import (
+	"container/list"
+	"math"
+)
+
+type compactionStrategy int
+
+const (
+	K_COMPACT compactionStrategy = iota
+	KV_COMPACT
+)
+
+type nodeLevel uint
+
+const (
+	ROOT nodeLevel = iota
+	LEAF
+)
+
+type node struct {
+	id       uint64
+	level    nodeLevel
+	dirty    bool
+	children *list.List
+	kvsets   *list.List
+	kvsetIdx uint64
+
+	tree *Tree
+
+	stats nodeStats
+}
+
+type nodeState struct {
+	ID     uint64   `json:"node-id"`
+	Size   uint64   `json:"size"`
+	KVSets []*kvSet `json:"kvsets"`
+}
+
+type nodeStats struct {
+	ingests       uint
+	spills        uint
+	ingested      uint64
+	written       uint64
+	splits        uint
+	kCompactions  uint
+	kvCompactions uint
+}
+
+func (n *node) addKVSet(size uint64, compc uint, vgroups uint) {
+	n.kvsets.PushFront(&kvSet{
+		ID:           n.kvsetIdx,
+		CompactCount: compc,
+		Vgroups:      vgroups,
+		Size:         size,
+	})
+
+	n.kvsetIdx++
+
+	n.dirty = true
+}
+
+func (n *node) compact(mark *list.Element, runLength uint, strategy compactionStrategy) *kvSet {
+	var size uint64
+
+	/* We assume that all KVSets we are about to compact have the same
+	 * compactCount.
+	 */
+	compactCount := mark.Value.(*kvSet).CompactCount + 1
+
+	var vgroups uint
+
+	if strategy == K_COMPACT {
+		n.stats.kCompactions++
+		vgroups = 0
+	} else if strategy == KV_COMPACT {
+		n.stats.kvCompactions++
+		vgroups = 1
+	} else {
+		panic("Unimplemented compaction strategy")
+	}
+
+	for i := uint(0); i < runLength; i++ {
+		// Save off the prev element before removing from the list
+		safe := mark.Prev()
+
+		k := n.kvsets.Remove(mark).(*kvSet)
+
+		if strategy == K_COMPACT {
+			vgroups += k.Vgroups
+		}
+
+		mark = safe
+
+		size += k.Size
+	}
+
+	compacted := &kvSet{
+		ID:           n.kvsetIdx,
+		CompactCount: compactCount,
+		Vgroups:      vgroups,
+		Size:         size,
+	}
+
+	n.kvsetIdx++
+
+	return compacted
+}
+
+func (n *node) ingest(data uint64) {
+	n.stats.ingests++
+	n.stats.ingested += data
+	n.stats.written += data
+	n.addKVSet(data, 0, 1)
+
+	if err := emitIngestEvent(n.tree, n.stats.ingests, n.id, data); err != nil {
+		panic(err)
+	}
+}
+
+func (n *node) maintain() {
+	if n.level == ROOT {
+		if n.children.Len() == 0 {
+			if n.size() < n.tree.params.RootNode.InitialSpillSize {
+				return
+			}
+
+			// Create the two initial leaf nodes to spill into
+			n.tree.addNode(n)
+			n.tree.addNode(n)
+
+			n.spill()
+
+			return
+		}
+
+		if n.size() < n.tree.params.RootNode.SpillSize {
+			return
+		}
+
+		n.spill()
+	} else {
+		var toCompact uint64
+		var runLength uint
+		var compc uint
+		var mark *list.Element
+		var vgroups uint
+
+	KCOMPACT:
+		if n.kvsets.Len() < int(n.tree.params.LeafNode.RunLengthMin) {
+			goto SPLIT
+		}
+
+		toCompact = uint64(0)
+		runLength = uint(0)
+		compc = uint(math.MaxUint32)
+
+		mark = n.kvsets.Back()
+
+		for kvset := mark; kvset != nil; kvset = kvset.Prev() {
+			if compc != kvset.Value.(*kvSet).CompactCount && runLength < n.tree.params.LeafNode.RunLengthMin {
+				compc = kvset.Value.(*kvSet).CompactCount
+				mark = kvset
+				toCompact += kvset.Value.(*kvSet).Size
+				runLength = 1
+				continue
+			} else if runLength >= n.tree.params.LeafNode.RunLengthMax-1 {
+				// One last increment because Go doesn't support inline postfix or prefix
+				runLength++
+				break
+			}
+
+			runLength++
+		}
+
+		if runLength >= n.tree.params.LeafNode.RunLengthMin && mark.Value.(*kvSet).Vgroups <= n.tree.params.LeafNode.VgroupLimit {
+			compacted := n.compact(mark, runLength, K_COMPACT)
+			n.kvsets.PushFront(compacted)
+
+			n.tree.root.stats.written += (toCompact * uint64(n.tree.params.KeyLength) / uint64(n.tree.params.ValueLength))
+
+			if err := emitKCompactEvent(n.tree, n.id, mark.Value.(*kvSet).ID, runLength, compc); err != nil {
+				panic(err)
+			}
+
+			/* If we compacted the KVSets, but number of KVSets in the node is >= to
+			 * the RunLengthMin, try to k-compact again.
+			 */
+			if n.kvsets.Len() >= int(n.tree.params.LeafNode.RunLengthMin) {
+				goto KCOMPACT
+			}
+		}
+
+	KVCOMPACT:
+		if n.kvsets.Len() < int(n.tree.params.LeafNode.RunLengthMin) {
+			goto SPLIT
+		}
+
+		toCompact = uint64(0)
+		runLength = uint(0)
+		vgroups = uint(math.MaxUint32)
+		mark = n.kvsets.Back()
+
+		for kvset := mark; kvset != nil; kvset = kvset.Prev() {
+			if vgroups != kvset.Value.(*kvSet).Vgroups && runLength < n.tree.params.LeafNode.RunLengthMin {
+				vgroups = kvset.Value.(*kvSet).Vgroups
+				mark = kvset
+				toCompact += kvset.Value.(*kvSet).Size
+				runLength = 1
+				continue
+			} else if runLength >= n.tree.params.LeafNode.RunLengthMax-1 {
+				// One last increment because Go doesn't support inline postfix or prefix
+				runLength++
+				break
+			}
+
+			runLength++
+		}
+
+		if runLength >= n.tree.params.LeafNode.RunLengthMin && mark.Value.(*kvSet).Vgroups > n.tree.params.LeafNode.VgroupLimit {
+			compacted := n.compact(mark, runLength, KV_COMPACT)
+			n.kvsets.PushFront(compacted)
+
+			n.tree.root.stats.written += toCompact
+
+			if err := emitKVCompactEvent(n.tree, n.id, mark.Value.(*kvSet).ID, runLength, vgroups); err != nil {
+				panic(err)
+			}
+
+			/* If we compacted the KVSets, but number of KVSets in the node is >= to
+			 * the RunLengthMin, try to kv-compact again.
+			 */
+			if n.kvsets.Len() >= int(n.tree.params.LeafNode.RunLengthMin) {
+				goto KVCOMPACT
+			}
+		}
+
+	SPLIT:
+		nodeSize := n.size()
+
+		if (n.stats.splits == uint(0) && nodeSize >= n.tree.params.LeafNode.InitialSplitSize) || (nodeSize >= n.tree.params.LeafNode.SplitSize) {
+			n.stats.splits++
+
+			split := n.tree.splitNode(n.tree.root, n)
+
+			if err := emitSplitEvent(n.tree, nodeSize, n.id, split.id); err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+func (n *node) size() uint64 {
+	var total uint64
+	for kvset := n.kvsets.Front(); kvset != nil; kvset = kvset.Next() {
+		total += kvset.Value.(*kvSet).Size
+	}
+
+	return total
+}
+
+func (n *node) spill() {
+	size := n.size()
+
+	n.stats.written += size
+
+	nodes := make([]uint64, n.children.Len())
+
+	kvsetSize := size / uint64(n.children.Len())
+
+	i := 0
+	for child := n.children.Front(); child != nil; child = child.Next() {
+		node := child.Value.(*node)
+
+		node.addKVSet(kvsetSize, 0, 1)
+		nodes[i] = node.id
+
+		i++
+	}
+
+	// At this point, all the data has spilled, so remove KVSets from root node
+	for kvset := n.kvsets.Front(); kvset != nil; {
+		safe := kvset.Next()
+		n.kvsets.Remove(kvset)
+		kvset = safe
+	}
+
+	n.stats.spills++
+
+	if err := emitSpillEvent(n.tree, n.stats.spills, n.id, size, nodes); err != nil {
+		panic(err)
+	}
+}
+
+func (n *node) splitKVSet(parent *node, kvset *kvSet) {
+	kvset.Size /= 2
+
+	parent.addKVSet(kvset.Size, kvset.CompactCount, kvset.Vgroups)
+}

--- a/tools/cn-tree-simulator/cn/params.go
+++ b/tools/cn-tree-simulator/cn/params.go
@@ -9,6 +9,7 @@ type TreeParams struct {
 	PrintState  bool
 	KeyLength   uint
 	ValueLength uint
+	MblockSize  uint64
 
 	RootNode RootNodeParams
 	LeafNode LeafNodeParams

--- a/tools/cn-tree-simulator/cn/params.go
+++ b/tools/cn-tree-simulator/cn/params.go
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2022 Micron Technology, Inc. All rights reserved.
+ */
+
+package cn
+
+type TreeParams struct {
+	Verbose     bool
+	PrintState  bool
+	KeyLength   uint
+	ValueLength uint
+
+	RootNode RootNodeParams
+	LeafNode LeafNodeParams
+}
+
+type RootNodeParams struct {
+	SpillSize        uint64
+	InitialSpillSize uint64
+}
+
+type LeafNodeParams struct {
+	SplitSize        uint64
+	InitialSplitSize uint64
+	VgroupLimit      uint
+	RunLengthMin     uint
+	RunLengthMax     uint
+}

--- a/tools/cn-tree-simulator/cn/tree.go
+++ b/tools/cn-tree-simulator/cn/tree.go
@@ -1,0 +1,214 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2022 Micron Technology, Inc. All rights reserved.
+ */
+
+package cn
+
+import (
+	"container/list"
+)
+
+type Tree struct {
+	params  *TreeParams
+	nodeIdx uint64
+
+	root *node
+}
+
+type treeStats struct {
+	Size          uint64       `json:"size"`
+	KCompactions  uint         `json:"k-compactions"`
+	KVCompactions uint         `json:"kv-compactions"`
+	WriteAmp      float64      `json:"write-amp"`
+	Root          *nodeStats   `json:"root,omitempty"`
+	Leaves        []*nodeStats `json:"leaves,omitempty"`
+}
+
+type treeState struct {
+	Root   nodeState   `json:"root"`
+	Leaves []nodeState `json:"leaves"`
+}
+
+func (t *Tree) Ingest(data uint64) {
+	for dirty := true; dirty; {
+		dirty = false
+
+		// Breadth-first walk of tree
+		queue := list.New()
+		queue.PushBack(t.root)
+
+		n := queue.Remove(queue.Front())
+		for n != nil {
+			if n.(*node).dirty {
+				n.(*node).maintain()
+			}
+
+			if n.(*node).children != nil {
+				queue.PushBackList(n.(*node).children)
+			}
+
+			front := queue.Front()
+			if front == nil {
+				n = nil
+			} else {
+				n = queue.Remove(front)
+			}
+		}
+	}
+
+	t.root.ingest(data)
+}
+
+func NewTree(params *TreeParams) *Tree {
+	tree := Tree{
+		params: params,
+		root: &node{
+			id:       0,
+			level:    ROOT,
+			children: list.New(),
+			kvsets:   list.New(),
+		},
+	}
+
+	tree.nodeIdx++
+
+	tree.root.tree = &tree
+
+	return &tree
+}
+
+func (t *Tree) addNode(parent *node) {
+	parent.children.PushFront(&node{
+		id:     t.nodeIdx,
+		level:  LEAF,
+		tree:   t,
+		kvsets: list.New(),
+	})
+
+	t.nodeIdx++
+}
+
+func (t *Tree) kCompactions() uint {
+	var total uint
+
+	for child := t.root.children.Front(); child != nil; child = child.Next() {
+		total += child.Value.(*node).stats.kCompactions
+	}
+
+	return total
+}
+
+func (t *Tree) kvCompactions() uint {
+	var total uint
+
+	for child := t.root.children.Front(); child != nil; child = child.Next() {
+		total += child.Value.(*node).stats.kvCompactions
+	}
+
+	return total
+}
+
+func (t *Tree) size() uint64 {
+	total := t.root.size()
+
+	for child := t.root.children.Front(); child != nil; child = child.Next() {
+		for kvset := child.Value.(*node).kvsets.Front(); kvset != nil; kvset = kvset.Next() {
+			total += kvset.Value.(*kvSet).Size
+		}
+	}
+
+	return total
+}
+
+func (t *Tree) splitNode(parent *node, src *node) *node {
+	n := &node{
+		id:     t.nodeIdx,
+		level:  LEAF,
+		tree:   t,
+		kvsets: list.New(),
+	}
+
+	for kvset := src.kvsets.Back(); kvset != nil; kvset = kvset.Prev() {
+		src.splitKVSet(n, kvset.Value.(*kvSet))
+	}
+
+	for child := parent.children.Front(); child != nil; child = child.Next() {
+		if child.Value == src {
+			parent.children.InsertBefore(n, child)
+			break
+		}
+	}
+
+	t.nodeIdx++
+
+	return n
+}
+
+func (t *Tree) state() *treeState {
+	rootKVSets := make([]*kvSet, t.root.kvsets.Len())
+
+	var i, j uint
+	for kvset := t.root.kvsets.Front(); kvset != nil; kvset = kvset.Next() {
+		rootKVSets[i] = kvset.Value.(*kvSet)
+
+		i++
+	}
+
+	leaves := make([]nodeState, t.root.children.Len())
+
+	i = 0
+	for child := t.root.children.Front(); child != nil; child = child.Next() {
+		n := child.Value.(*node)
+
+		leafKVSets := make([]*kvSet, n.kvsets.Len())
+
+		j = 0
+		for kvset := n.kvsets.Front(); kvset != nil; kvset = kvset.Next() {
+			leafKVSets[j] = kvset.Value.(*kvSet)
+
+			j++
+		}
+
+		leaves[i] = nodeState{
+			ID:     n.id,
+			Size:   n.size(),
+			KVSets: leafKVSets,
+		}
+
+		i++
+	}
+
+	return &treeState{
+		Root: nodeState{
+			Size:   t.root.size(),
+			KVSets: rootKVSets,
+		},
+		Leaves: leaves,
+	}
+}
+
+func (t *Tree) stats() *treeStats {
+	var rootStats *nodeStats
+	var leafStats []*nodeStats
+	if t.params.Verbose {
+		rootStats = &t.root.stats
+
+		leafStats = make([]*nodeStats, t.root.children.Len())
+
+		i := 0
+		for child := t.root.children.Front(); child != nil; child = child.Next() {
+			leafStats[i] = &child.Value.(*node).stats
+
+			i++
+		}
+	}
+
+	return &treeStats{
+		Size:          t.size(),
+		KCompactions:  t.kCompactions(),
+		KVCompactions: t.kvCompactions(),
+		WriteAmp:      float64(t.root.stats.written) / float64(t.root.stats.ingested),
+		Root:          rootStats,
+		Leaves:        leafStats,
+	}
+}

--- a/tools/cn-tree-simulator/cn/tree.go
+++ b/tools/cn-tree-simulator/cn/tree.go
@@ -128,8 +128,11 @@ func (t *Tree) splitNode(parent *node, src *node) *node {
 		kvsets: list.New(),
 	}
 
+	kblocks := src.kvsets.Len()
+	vblocks := 0
 	for kvset := src.kvsets.Back(); kvset != nil; kvset = kvset.Prev() {
 		src.splitKVSet(n, kvset.Value.(*kvSet))
+		vblocks += int(kvset.Value.(*kvSet).Vgroups)
 	}
 
 	for child := parent.children.Front(); child != nil; child = child.Next() {
@@ -140,6 +143,8 @@ func (t *Tree) splitNode(parent *node, src *node) *node {
 	}
 
 	t.nodeIdx++
+
+	t.root.stats.written += 2 * t.params.MblockSize * (uint64(kblocks) + uint64(vblocks))
 
 	return n
 }

--- a/tools/cn-tree-simulator/go.mod
+++ b/tools/cn-tree-simulator/go.mod
@@ -1,0 +1,3 @@
+module github.com/hse-project/hse/tools/cn-tree-simulator
+
+go 1.11

--- a/tools/cn-tree-simulator/main.go
+++ b/tools/cn-tree-simulator/main.go
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2022 Micron Technology, Inc. All rights reserved.
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/hse-project/hse/tools/cn-tree-simulator/cn"
+)
+
+type SimulationParams struct {
+	finalTreeSize uint64
+	ingestSize    uint64
+
+	cn cn.TreeParams
+}
+
+var params SimulationParams
+
+func startSimulation() {
+	cnTree := cn.NewTree(&params.cn)
+
+	ingests := uint((params.finalTreeSize) / params.ingestSize)
+
+	for i := uint(0); i < ingests; i++ {
+		cnTree.Ingest(params.ingestSize)
+	}
+}
+
+func main() {
+	fs := flag.NewFlagSet("cn-tree-simulator", flag.ExitOnError)
+
+	fs.Uint64Var(&params.finalTreeSize, "final-tree-size", 2<<40, "Final tree size")
+	fs.Uint64Var(&params.ingestSize, "ingest-size", 2<<30, "Ingest size")
+	fs.BoolVar(&params.cn.PrintState, "print-state", false, "Print tree state alongside every event")
+	fs.BoolVar(&params.cn.Verbose, "verbose", false, "Print stats for every node")
+	fs.UintVar(&params.cn.KeyLength, "key-length", 1000, "Key length")
+	fs.UintVar(&params.cn.ValueLength, "value-length", 7000, "Value length")
+	fs.Uint64Var(&params.cn.RootNode.SpillSize, "spill-size", 8<<30, "Spill size")
+	fs.Uint64Var(&params.cn.RootNode.InitialSpillSize, "initial-spill-size", 8<<30, "Initial spill size")
+	fs.Uint64Var(&params.cn.LeafNode.SplitSize, "split-size", 8<<30, "Split size")
+	fs.Uint64Var(&params.cn.LeafNode.InitialSplitSize, "initial-split-size", 8<<30, "Initial split size")
+	fs.UintVar(&params.cn.LeafNode.VgroupLimit, "vgroup-limit", 4, "Number of vgroups allowed to accumulate")
+	fs.UintVar(&params.cn.LeafNode.RunLengthMin, "run-length-min", 4, "Minimum run length")
+	fs.UintVar(&params.cn.LeafNode.RunLengthMax, "run-length-max", 4, "Maximum run length")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to parse command line arguments")
+		os.Exit(1)
+	}
+
+	startSimulation()
+}

--- a/tools/cn-tree-simulator/main.go
+++ b/tools/cn-tree-simulator/main.go
@@ -40,6 +40,7 @@ func main() {
 	fs.BoolVar(&params.cn.Verbose, "verbose", false, "Print stats for every node")
 	fs.UintVar(&params.cn.KeyLength, "key-length", 1000, "Key length")
 	fs.UintVar(&params.cn.ValueLength, "value-length", 7000, "Value length")
+	fs.Uint64Var(&params.cn.MblockSize, "mblock-size", 32<<20, "Mblock size")
 	fs.Uint64Var(&params.cn.RootNode.SpillSize, "spill-size", 8<<30, "Spill size")
 	fs.Uint64Var(&params.cn.RootNode.InitialSpillSize, "initial-spill-size", 8<<30, "Initial spill size")
 	fs.Uint64Var(&params.cn.LeafNode.SplitSize, "split-size", 8<<30, "Split size")

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -2,6 +2,8 @@ if not get_option('tools').disabled()
     subdir('scripts')
 endif
 
+go = find_program('go', required: get_option('tools'))
+
 tool_targets = {}
 
 tools = {
@@ -38,6 +40,18 @@ tools = {
             'common.c',
             'parm_groups.c',
         ),
+    },
+    'cn-tree-simulator': {
+        'sources': files(
+            'cn-tree-simulator/go.mod',
+            'cn-tree-simulator/main.go',
+            'cn-tree-simulator/cn/kvset.go',
+            'cn-tree-simulator/cn/event.go',
+            'cn-tree-simulator/cn/node.go',
+            'cn-tree-simulator/cn/params.go',
+            'cn-tree-simulator/cn/tree.go',
+        ),
+        'language': 'go',
     },
     'cndb_log': {
         'sources': files(
@@ -286,26 +300,57 @@ tools = {
 
 foreach t, params : tools
     if not get_option('tools').disabled()
-        target = executable(
-            t,
-            params['sources'],
-            c_args: params.get('c_args', []),
-            include_directories: [
-                component_root_includes,
-                hse_include_directories,
-                tools_includes,
-                params.get('include_directories', []),
-            ],
-            dependencies: [
-                hse_internal_dep,
-                hse_dependencies,
-                libhse_cli_dep,
-                params.get('dependencies', [])
-            ],
-            install: true,
-            install_rpath: rpath,
-            gnu_symbol_visibility: 'hidden',
-        )
+        language = params.get('language', 'c')
+
+        if language == 'c'
+            target = executable(
+                t,
+                params['sources'],
+                c_args: params.get('c_args', []),
+                include_directories: [
+                    component_root_includes,
+                    hse_include_directories,
+                    tools_includes,
+                    params.get('include_directories', []),
+                ],
+                dependencies: [
+                    hse_internal_dep,
+                    hse_dependencies,
+                    libhse_cli_dep,
+                    params.get('dependencies', [])
+                ],
+                install: true,
+                install_rpath: rpath,
+                gnu_symbol_visibility: 'hidden',
+            )
+        elif language == 'go'
+            if go.found()
+                target = custom_target(
+                    t,
+                    input: params.get('sources'),
+                    output: t,
+                    command: [
+                        sh,
+                        '-c',
+                        ' '.join([
+                            'cd',
+                            meson.current_source_dir() / t,
+                            '&&',
+                            go.full_path(),
+                            'build',
+                            '-o',
+                            meson.current_build_dir() / t,
+                        ])
+                    ],
+                    install: true,
+                    install_dir: get_option('prefix') / get_option('bindir')
+                )
+            else
+                target = disabler()
+            endif
+        else
+            error('Unrecognized \'language\' keyword argument')
+        endif
 
         tool_targets += { t: target }
     else


### PR DESCRIPTION
cn-tree-simulator allows a user to simulate the shape of a cN tree.
Currently it is fairly bare-bones and only allows to simulate a very
simple load phase.

Signed-off-by: Tristan Partin <tpartin@micron.com>
