### PR TITLE
Add -DHSE_CI when compiling in CI

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,10 @@ hse_major_version = version_components[0]
 hse_minor_version = version_components[1]
 hse_patch_version = version_components[2]
 
+if ci
+    add_project_arguments('-DHSE_CI', language: 'c')
+endif
+
 # Compute the relative path used by compiler invocations.
 relative_dir = run_command(
     python,

--- a/tests/unit/util/perfc_test.c
+++ b/tests/unit/util/perfc_test.c
@@ -26,7 +26,7 @@ MTF_MODULE_UNDER_TEST(hse_platform);
 
 MTF_BEGIN_UTEST_COLLECTION_PRE(perfc, platform_pre);
 
-
+#ifndef HSE_CI
 /* Test that calls to get_cycles() always return a count greater
  * than any previous call and are accurately measuring elapsed
  * time w.r.t get_time_ns().  This might fail on amd64 if the TSC
@@ -114,6 +114,7 @@ again:
 
     free(cyclev);
 }
+#endif
 
 MTF_DEFINE_UTEST(perfc, perfc_basic_create_find_and_remove)
 {


### PR DESCRIPTION
This will help to ignore code that we know is faulty in CI environments.
This should be used with caution since we obviously want all code
compiling and running as often as possible.

Signed-off-by: Tristan Partin <tpartin@micron.com>
