### PR TITLE
Remove quiet flag from grep

### DIFF
--- a/scripts/dev/format.sh
+++ b/scripts/dev/format.sh
@@ -37,9 +37,9 @@ files=$(find \
     -type f \( -name "*.[ch]" -o -name "*.h.in" \) -print)
 
 clang_format_help=$(clang-format --help)
-echo "$clang_format_help" | grep --quiet -- "--Werror"
+echo "$clang_format_help" | grep -- "--Werror"
 clang_format_has_werror=$?
-echo "$clang_format_help" | grep --quiet -- "--dry-run"
+echo "$clang_format_help" | grep -- "--dry-run"
 clang_format_has_dry_run=$?
 
 check=0

--- a/tests/functional/cli/help.sh
+++ b/tests/functional/cli/help.sh
@@ -8,7 +8,7 @@
 
 output=$(cmd hse -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse [options] <command> ..."
-echo "$output" | cmd grep --quiet -F "Options:"
-echo "$output" | cmd grep --quiet -F "Commands:"
-echo "$output" | cmd grep --quiet -F "Examples:"
+echo "$output" | cmd grep -F "Usage: hse [options] <command> ..."
+echo "$output" | cmd grep -F "Options:"
+echo "$output" | cmd grep -F "Commands:"
+echo "$output" | cmd grep -F "Examples:"

--- a/tests/functional/cli/kvdb/compact/help.sh
+++ b/tests/functional/cli/kvdb/compact/help.sh
@@ -8,5 +8,5 @@
 
 output=$(cmd hse kvdb compact -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse kvdb compact [options] <kvdb_home>"
-echo "$output" | cmd grep --quiet -F "Options:"
+echo "$output" | cmd grep -F "Usage: hse kvdb compact [options] <kvdb_home>"
+echo "$output" | cmd grep -F "Options:"

--- a/tests/functional/cli/kvdb/compact/unknown-arg.sh
+++ b/tests/functional/cli/kvdb/compact/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvdb compact --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvdb compact: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvdb compact: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/kvdb/create/help.sh
+++ b/tests/functional/cli/kvdb/create/help.sh
@@ -8,5 +8,5 @@
 
 output=$(cmd hse kvdb create -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse kvdb create [options] <kvdb_home> [<param>=<value>]..."
-echo "$output" | cmd grep --quiet -F "Options:"
+echo "$output" | cmd grep -F "Usage: hse kvdb create [options] <kvdb_home> [<param>=<value>]..."
+echo "$output" | cmd grep -F "Options:"

--- a/tests/functional/cli/kvdb/create/unknown-arg.sh
+++ b/tests/functional/cli/kvdb/create/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvdb create --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvdb create: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvdb create: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/kvdb/drop/help.sh
+++ b/tests/functional/cli/kvdb/drop/help.sh
@@ -8,5 +8,5 @@
 
 output=$(cmd hse kvdb drop -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse kvdb drop [options] <kvdb_home>"
-echo "$output" | cmd grep --quiet -F "Options:"
+echo "$output" | cmd grep -F "Usage: hse kvdb drop [options] <kvdb_home>"
+echo "$output" | cmd grep -F "Options:"

--- a/tests/functional/cli/kvdb/drop/unknown-arg.sh
+++ b/tests/functional/cli/kvdb/drop/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvdb drop --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvdb drop: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvdb drop: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/kvdb/help.sh
+++ b/tests/functional/cli/kvdb/help.sh
@@ -8,10 +8,10 @@
 
 output=$(cmd hse kvdb -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse kvdb [options] <command> ..."
-echo "$output" | cmd grep --quiet -F "Options:"
-echo "$output" | cmd grep --quiet -F "Commands:"
-echo "$output" | cmd grep --quiet -F "create"
-echo "$output" | cmd grep --quiet -F "drop"
-echo "$output" | cmd grep --quiet -F "info"
-echo "$output" | cmd grep --quiet -F "compact"
+echo "$output" | cmd grep -F "Usage: hse kvdb [options] <command> ..."
+echo "$output" | cmd grep -F "Options:"
+echo "$output" | cmd grep -F "Commands:"
+echo "$output" | cmd grep -F "create"
+echo "$output" | cmd grep -F "drop"
+echo "$output" | cmd grep -F "info"
+echo "$output" | cmd grep -F "compact"

--- a/tests/functional/cli/kvdb/info/help.sh
+++ b/tests/functional/cli/kvdb/info/help.sh
@@ -8,5 +8,5 @@
 
 output=$(cmd hse kvdb info -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse kvdb info [options] <kvdb_home>"
-echo "$output" | cmd grep --quiet -F "Options:"
+echo "$output" | cmd grep -F "Usage: hse kvdb info [options] <kvdb_home>"
+echo "$output" | cmd grep -F "Options:"

--- a/tests/functional/cli/kvdb/info/unknown-arg.sh
+++ b/tests/functional/cli/kvdb/info/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvdb info --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvdb info: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvdb info: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/kvdb/unknown-arg.sh
+++ b/tests/functional/cli/kvdb/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvdb --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvdb: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvdb: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/kvdb/unknown-command.sh
+++ b/tests/functional/cli/kvdb/unknown-command.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvdb does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvdb: invalid command 'does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvdb: invalid command 'does-not-exist', use -h for help"

--- a/tests/functional/cli/kvs/create/help.sh
+++ b/tests/functional/cli/kvs/create/help.sh
@@ -8,6 +8,6 @@
 
 output=$(cmd hse kvs create -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse kvs create [options] <kvdb_home> <kvs> [<param>=<value>]..."
-echo "$output" | cmd grep --quiet -F "Options:"
-echo "$output" | cmd grep --quiet -F "Parameters:"
+echo "$output" | cmd grep -F "Usage: hse kvs create [options] <kvdb_home> <kvs> [<param>=<value>]..."
+echo "$output" | cmd grep -F "Options:"
+echo "$output" | cmd grep -F "Parameters:"

--- a/tests/functional/cli/kvs/create/unknown-arg.sh
+++ b/tests/functional/cli/kvs/create/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvs create --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvs create: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvs create: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/kvs/drop/help.sh
+++ b/tests/functional/cli/kvs/drop/help.sh
@@ -8,5 +8,5 @@
 
 output=$(cmd hse kvs drop -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse kvs drop [options] <kvdb_home> <kvs>"
-echo "$output" | cmd grep --quiet -F "Options:"
+echo "$output" | cmd grep -F "Usage: hse kvs drop [options] <kvdb_home> <kvs>"
+echo "$output" | cmd grep -F "Options:"

--- a/tests/functional/cli/kvs/drop/unknown-arg.sh
+++ b/tests/functional/cli/kvs/drop/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvs drop --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvs drop: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvs drop: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/kvs/help.sh
+++ b/tests/functional/cli/kvs/help.sh
@@ -8,8 +8,8 @@
 
 output=$(cmd hse kvs -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse kvs [options] <command> ..."
-echo "$output" | cmd grep --quiet -F "Options:"
-echo "$output" | cmd grep --quiet -F "Commands:"
-echo "$output" | cmd grep --quiet -F "create"
-echo "$output" | cmd grep --quiet -F "drop"
+echo "$output" | cmd grep -F "Usage: hse kvs [options] <command> ..."
+echo "$output" | cmd grep -F "Options:"
+echo "$output" | cmd grep -F "Commands:"
+echo "$output" | cmd grep -F "create"
+echo "$output" | cmd grep -F "drop"

--- a/tests/functional/cli/kvs/unknown-arg.sh
+++ b/tests/functional/cli/kvs/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvs --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvs: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvs: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/kvs/unknown-command.sh
+++ b/tests/functional/cli/kvs/unknown-command.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse kvs does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse kvs: invalid command 'does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse kvs: invalid command 'does-not-exist', use -h for help"

--- a/tests/functional/cli/storage/add/help.sh
+++ b/tests/functional/cli/storage/add/help.sh
@@ -8,5 +8,5 @@
 
 output=$(cmd hse storage add -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse storage add [options] <kvdb_home> [<param>=<value>]..."
-echo "$output" | cmd grep --quiet -F "Options:"
+echo "$output" | cmd grep -F "Usage: hse storage add [options] <kvdb_home> [<param>=<value>]..."
+echo "$output" | cmd grep -F "Options:"

--- a/tests/functional/cli/storage/add/unknown-arg.sh
+++ b/tests/functional/cli/storage/add/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse storage add --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse storage add: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse storage add: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/storage/help.sh
+++ b/tests/functional/cli/storage/help.sh
@@ -8,9 +8,9 @@
 
 output=$(cmd hse storage -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse storage [options] <command> ..."
-echo "$output" | cmd grep --quiet -F "Options:"
-echo "$output" | cmd grep --quiet -F "Commands:"
-echo "$output" | cmd grep --quiet -F "add"
-echo "$output" | cmd grep --quiet -F "info"
-echo "$output" | cmd grep --quiet -F "profile"
+echo "$output" | cmd grep -F "Usage: hse storage [options] <command> ..."
+echo "$output" | cmd grep -F "Options:"
+echo "$output" | cmd grep -F "Commands:"
+echo "$output" | cmd grep -F "add"
+echo "$output" | cmd grep -F "info"
+echo "$output" | cmd grep -F "profile"

--- a/tests/functional/cli/storage/info/help.sh
+++ b/tests/functional/cli/storage/info/help.sh
@@ -8,5 +8,5 @@
 
 output=$(cmd hse storage info -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse storage info [options] <kvdb_home>"
-echo "$output" | cmd grep --quiet -F "Options:"
+echo "$output" | cmd grep -F "Usage: hse storage info [options] <kvdb_home>"
+echo "$output" | cmd grep -F "Options:"

--- a/tests/functional/cli/storage/info/success.sh
+++ b/tests/functional/cli/storage/info/success.sh
@@ -12,15 +12,15 @@ kvdb_create
 
 output=$(cmd hse storage info "$home")
 
-echo "$output" | cmd grep --quiet -F "MEDIA_CLASS"
-echo "$output" | cmd grep --quiet -F "ALLOCATED_BYTES"
-echo "$output" | cmd grep --quiet -F "USED_BYTES"
-echo "$output" | cmd grep --quiet -F "PATH"
+echo "$output" | cmd grep -F "MEDIA_CLASS"
+echo "$output" | cmd grep -F "ALLOCATED_BYTES"
+echo "$output" | cmd grep -F "USED_BYTES"
+echo "$output" | cmd grep -F "PATH"
 
-echo "$output" | cmd grep --quiet -F "capacity"
-echo "$output" | cmd grep --quiet -F "staging"
-echo "$output" | cmd grep --quiet -F "pmem"
+echo "$output" | cmd grep -F "capacity"
+echo "$output" | cmd grep -F "staging"
+echo "$output" | cmd grep -F "pmem"
 
-echo "$output" | cmd grep --quiet -F "$home/capacity"
+echo "$output" | cmd grep -F "$home/capacity"
 
 cmd test "$(echo "$output" | cmd wc -l)" -eq 4

--- a/tests/functional/cli/storage/info/unknown-arg.sh
+++ b/tests/functional/cli/storage/info/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse storage info --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse storage info: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse storage info: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/storage/profile/help.sh
+++ b/tests/functional/cli/storage/profile/help.sh
@@ -8,5 +8,5 @@
 
 output=$(cmd hse storage profile -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse storage profile [options] <storage_path>"
-echo "$output" | cmd grep --quiet -F "Options:"
+echo "$output" | cmd grep -F "Usage: hse storage profile [options] <storage_path>"
+echo "$output" | cmd grep -F "Options:"

--- a/tests/functional/cli/storage/profile/success.sh
+++ b/tests/functional/cli/storage/profile/success.sh
@@ -12,8 +12,8 @@ kvdb_create
 
 output=$(cmd hse storage profile --quiet "$home")
 
-echo "$output" | cmd grep --quiet -P "(medium|heavy|light)"
+echo "$output" | cmd grep -P "(medium|heavy|light)"
 
 output=$(cmd hse storage profile "$home")
 
-echo "$output" | cmd grep --quiet -P "Recommended throttling\.init_policy: \"(medium|heavy|light)\""
+echo "$output" | cmd grep -P "Recommended throttling\.init_policy: \"(medium|heavy|light)\""

--- a/tests/functional/cli/storage/profile/unknown-arg.sh
+++ b/tests/functional/cli/storage/profile/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse storage profile --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse storage profile: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse storage profile: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/storage/unknown-arg.sh
+++ b/tests/functional/cli/storage/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse storage --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse storage: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse storage: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/storage/unknown-command.sh
+++ b/tests/functional/cli/storage/unknown-command.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse storage does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse storage: invalid command 'does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse storage: invalid command 'does-not-exist', use -h for help"

--- a/tests/functional/cli/unknown-arg.sh
+++ b/tests/functional/cli/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/unknown-command.sh
+++ b/tests/functional/cli/unknown-command.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse: invalid command 'does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse: invalid command 'does-not-exist', use -h for help"

--- a/tests/functional/cli/utils/help.sh
+++ b/tests/functional/cli/utils/help.sh
@@ -8,7 +8,7 @@
 
 output=$(cmd hse utils -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse utils [options] <command> ..."
-echo "$output" | cmd grep --quiet -F "Options:"
-echo "$output" | cmd grep --quiet -F "Commands:"
-echo "$output" | cmd grep --quiet -F "strerror"
+echo "$output" | cmd grep -F "Usage: hse utils [options] <command> ..."
+echo "$output" | cmd grep -F "Options:"
+echo "$output" | cmd grep -F "Commands:"
+echo "$output" | cmd grep -F "strerror"

--- a/tests/functional/cli/utils/strerror/help.sh
+++ b/tests/functional/cli/utils/strerror/help.sh
@@ -8,5 +8,5 @@
 
 output=$(cmd hse utils strerror -h)
 
-echo "$output" | cmd grep --quiet -F "Usage: hse utils strerror [options] [--] <errorcode>"
-echo "$output" | cmd grep --quiet -F "Options:"
+echo "$output" | cmd grep -F "Usage: hse utils strerror [options] [--] <errorcode>"
+echo "$output" | cmd grep -F "Options:"

--- a/tests/functional/cli/utils/strerror/unknown-arg.sh
+++ b/tests/functional/cli/utils/strerror/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse utils strerror --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse utils strerror: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse utils strerror: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/utils/unknown-arg.sh
+++ b/tests/functional/cli/utils/unknown-arg.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse utils --does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse utils: invalid option '--does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse utils: invalid option '--does-not-exist', use -h for help"

--- a/tests/functional/cli/utils/unknown-command.sh
+++ b/tests/functional/cli/utils/unknown-command.sh
@@ -8,4 +8,4 @@
 
 output=$(cmd -e hse utils does-not-exist 2>&1)
 
-echo "$output" | cmd grep --quiet -F "hse utils: invalid command 'does-not-exist', use -h for help"
+echo "$output" | cmd grep -F "hse utils: invalid command 'does-not-exist', use -h for help"

--- a/tests/functional/cli/version.sh
+++ b/tests/functional/cli/version.sh
@@ -12,8 +12,8 @@ verbose_output=$(cmd hse -vV)
 
 cmd test "$long_output" == "$short_ouptut"
 
-echo "$short_ouptut" | cmd grep --quiet -P '^r\d+\.\d+\.\d+'
+echo "$short_ouptut" | cmd grep -P '^r\d+\.\d+\.\d+'
 
 cmd test "$(printf "%s\n" "$verbose_output" | wc -l)" -eq 2
-echo "$verbose_output" | cmd grep --quiet -P '^version: r\d+\.\d+\.\d+'
-echo "$verbose_output" | cmd grep --quiet -P '^build-configuration: '
+echo "$verbose_output" | cmd grep -P '^version: r\d+\.\d+\.\d+'
+echo "$verbose_output" | cmd grep -P '^build-configuration: '

--- a/tests/functional/smoke/large-values1.sh
+++ b/tests/functional/smoke/large-values1.sh
@@ -34,7 +34,7 @@ kvs_oparams="kvs-oparams cn_maint_disable=true"
 cmd kmt "$home" "$kvs" -s1 "$VLEN" "-i$KEYS" $kvs_oparams
 
 # verify no spill occurred
-cmd cn_metrics "$home" "$kvs" | cmd -e grep -q n.1,
+cmd cn_metrics "$home" "$kvs" | cmd -e grep n.1,
 
 # verify keys and values
 # shellcheck disable=SC2086

--- a/tests/functional/smoke/prefix-tree-shape1.sh
+++ b/tests/functional/smoke/prefix-tree-shape1.sh
@@ -79,6 +79,6 @@ for fanout in 2 4 8 16; do
 
     # TODO: verify tree shape, remove shellcheck directive above
     #metrics_log=$LOG
-    #cmd grep -q "^n $lvl," $metrics_log
-    #cmd -e grep -q "^n $((lvl+1))," $metrics_log
+    #cmd grep "^n $lvl," $metrics_log
+    #cmd -e grep "^n $((lvl+1))," $metrics_log
 done


### PR DESCRIPTION
Grep is closing the pipe on us while we are writing to it because it has
found a match. Behavior seems non-deterministic based on the machine the
command is running on. Failures were most obvious on GitHub Actions
probably due to the lower powered machine.

Signed-off-by: Tristan Partin <tpartin@micron.com>
