### PR TITLE
Switch license field in project() to str

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,9 +2,7 @@ project(
     'hse',
     ['c'],
     version: files('VERSION'),
-    license: [
-        'Apache-2.0',
-    ],
+    license: 'Apache-2.0',
     default_options: [
         'prefix=/opt/hse',
         'b_ndebug=if-release',


### PR DESCRIPTION
This field is intended to be an SPDX expression and an array can be
ambiguous.

https://github.com/mesonbuild/meson/pull/9939

Signed-off-by: Tristan Partin <tpartin@micron.com>
