### PR TITLE
Fix hse-python branch checkout in CI

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -50,6 +50,7 @@ jobs:
         with:
           repository: hse-project/hse-python
           path: subprojects/hse-python
+          ref: ${{ github.base_ref || github.ref }}
 
       - name: Post-checkout
         run: |
@@ -131,6 +132,7 @@ jobs:
         with:
           repository: hse-project/hse-python
           path: subprojects/hse-python
+          ref: ${{ github.base_ref || github.ref }}
 
       - name: Post-checkout
         run: |
@@ -207,6 +209,7 @@ jobs:
         with:
           repository: hse-project/hse-python
           path: subprojects/hse-python
+          ref: ${{ github.base_ref || github.ref }}
 
       - name: Post-checkout
         run: |
@@ -282,6 +285,7 @@ jobs:
         with:
           repository: hse-project/hse-python
           path: subprojects/hse-python
+          ref: ${{ github.base_ref || github.ref }}
 
       - name: Post-checkout
         run: |
@@ -339,6 +343,7 @@ jobs:
         with:
           repository: hse-project/hse-python
           path: subprojects/hse-python
+          ref: ${{ github.base_ref || github.ref }}
 
       - name: Post-checkout
         run: |
@@ -393,6 +398,7 @@ jobs:
         with:
           repository: hse-project/hse-python
           path: subprojects/hse-python
+          ref: ${{ github.base_ref || github.ref }}
 
       - name: Post-checkout
         run: |


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>

This is essentially a reverse cherry-pick from my v2.1 PR earlier today which was approved by both Nabeel and Bhavesh. This code path in the CI had not really been tested up until Nabeel's v2.1 PR, but this is _apparently_ the fix.