### PR TITLE
Fix the the CLI symlink when generated as a subproject

### DIFF
--- a/cli/meson.build
+++ b/cli/meson.build
@@ -50,7 +50,7 @@ hse_cli_symlink = custom_target(
         '--force',
         '--symbolic',
         fs.name(hse_cli.full_path()),
-        meson.project_build_root() / '@OUTPUT@',
+        '@OUTPUT@',
     ],
     output: meson.project_name(),
 )


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
