### PR TITLE
Report Latencies in range read

### DIFF
--- a/tests/functional/smoke/cursor_test2.sh
+++ b/tests/functional/smoke/cursor_test2.sh
@@ -13,14 +13,12 @@ kvdb_create
 
 kvs=$(kvs_create smoke-0 prefix.length=8) || $?
 
-range_read_logs="$home/range_read_logs"
-
 # Load
 nthread=128
 vlen=1024
 npfx=8
 nsfx=200000 # (npfx * nsfx) keys total
-cmd range_read "$home" "$kvs" -f "$range_read_logs" -l "-j$nthread" "-v$vlen" "-p$npfx" "-s$nsfx" kvs-oparms cn_node_size_lo=32 cn_node_size_hi=32
+cmd range_read "$home" "$kvs" -l "-j$nthread" "-v$vlen" "-p$npfx" "-s$nsfx" kvs-oparms cn_node_size_lo=32 cn_node_size_hi=32
 
 cmd kvck "$home"
 
@@ -28,5 +26,5 @@ cmd kvck "$home"
 nthread=32
 duration=20 # seconds
 range=10
-cmd range_read "$home" "$kvs" -f "$range_read_logs" -e "-b$range" "-j$nthread" "-v$vlen" "-p$npfx" "-s$nsfx" "-d$duration" -V
-cmd range_read "$home" "$kvs" -f "$range_read_logs" -e "-b$range" "-j$nthread" "-v$vlen" "-p$npfx" "-s$nsfx" "-d$duration" -V
+cmd range_read "$home" "$kvs" -e -w "-b$range" "-j$nthread" "-v$vlen" "-p$npfx" "-s$nsfx" "-d$duration" -V
+cmd range_read "$home" "$kvs" -e -w "-b$range" "-j$nthread" "-v$vlen" "-p$npfx" "-s$nsfx" "-d$duration" -V

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -238,6 +238,12 @@ tools = {
             'kvs_helper.c',
             'parm_groups.c',
         ),
+        'c_args': [
+            '-DHDR_HISTOGRAM_C_FROM_SUBPROJECT=@0@'.format(get_variable('HdrHistogram_c_from_subproject', 0)),
+        ],
+        'dependencies': [
+            HdrHistogram_c_dep,
+        ],
     },
     'simple_client': {
         'sources': files(

--- a/tools/range_read/range_read.c
+++ b/tools/range_read/range_read.c
@@ -18,6 +18,7 @@
 #include <getopt.h>
 #include <libgen.h>
 #include <sysexits.h>
+#include <stdlib.h>
 #include <sys/resource.h>
 
 #include <cli/param.h>
@@ -268,9 +269,7 @@ cursor(void *arg)
         fatal(ENOMEM, "Failed to allocate resources for cursor thread");
 
     if (opts.use_update) {
-        int i;
-
-        for (i = 0; i < opts.npfx; i++) {
+        for (int i = 0; i < opts.npfx; i++) {
             *p = htobe64(i);
             cur[i] = kh_cursor_create(targ->kvs, 0, NULL, kbuf, sizeof(*p));
         }
@@ -654,7 +653,7 @@ main(
     if (opts.phase & EXEC) {
         struct lat_hist *lat;
 
-        lat = malloc(opts.threads * sizeof(*lat));
+        lat = aligned_alloc(HSE_ACP_LINESIZE, sizeof(*lat) * opts.threads);
         if (!lat)
             fatal(ENOMEM, "Cannot allocate mmeory for histogram data");
 


### PR DESCRIPTION
Signed-off-by: Gaurav Ramdasi <10132364+gsramdasi@users.noreply.github.com>

## Description
Range read uses hdr_histogram to collect latency data and reports at the end of runs:

![image](https://user-images.githubusercontent.com/10132364/155363644-d1a11559-4a88-42f8-bd7f-66eb59fbda6c.png)


## Issue(s) Addressed
NFSE-5154
