### PR TITLE
Fix path wildcard for shellcheck ignore workflow

### DIFF
--- a/.github/workflows/shellcheck.ignore.yaml
+++ b/.github/workflows/shellcheck.ignore.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
-      - "**/*.sh"
+      - "**.sh"
       - "scripts/git-hooks/*"
       - .github/workflows/shellcheck.yaml
       - .shellcheckrc


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
