### PR TITLE
Update to xxHash 0.8.1

### DIFF
--- a/subprojects/xxhash.wrap
+++ b/subprojects/xxhash.wrap
@@ -1,11 +1,12 @@
 [wrap-file]
-directory = xxHash-0.8.0
-source_url = https://github.com/Cyan4973/xxHash/archive/v0.8.0.tar.gz
-source_filename = xxHash-0.8.0.tar.gz
-source_hash = 7054c3ebd169c97b64a92d7b994ab63c70dd53a06974f1f630ab782c28db0f4f
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/xxhash/0.8.0/1/get_zip
-patch_filename = xxhash-0.8.0-1-wrap.zip
-patch_hash = 4dc9ad204498272757c2a11e2889d9ede8cd790f20816d0c25ef3adbb91efb50
+directory = xxHash-0.8.1
+source_url = https://github.com/Cyan4973/xxHash/archive/v0.8.1.tar.gz
+source_filename = xxHash-0.8.1.tar.gz
+source_hash = 3bb6b7d6f30c591dd65aaaff1c8b7a5b94d81687998ca9400082c739a690436c
+patch_filename = xxhash_0.8.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/xxhash_0.8.1-1/get_patch
+patch_hash = 4928a01f9c118852ff9f2dc073d383160e5ae53fcd3ad1d6ea3963151068a851
 
 [provide]
 libxxhash = xxhash_dep
+


### PR DESCRIPTION
Some Meson build improvements from the Meson wrap. Other details can be
found here:

https://github.com/Cyan4973/xxHash/releases/tag/v0.8.1

Signed-off-by: Tristan Partin <tpartin@micron.com>
