### PR TITLE
Fix health error handling in c0 and WAL (NFSE-5165)

### DIFF
--- a/cli/hse_cli.c
+++ b/cli/hse_cli.c
@@ -1148,7 +1148,7 @@ cli_hse_storage_add(struct cli_cmd *self, struct cli *cli)
 static int
 cli_hse_storage_info_impl(struct cli *cli, const char *kvdb_home)
 {
-    if (cli_hse_init(cli))
+    if (cli_hse_init_rest(cli))
         return -1;
 
     if (cli->optind != cli->argc) {

--- a/lib/c0/c0sk.c
+++ b/lib/c0/c0sk.c
@@ -759,7 +759,7 @@ c0sk_sync(struct c0sk *handle, const unsigned int flags)
 
     cv_destroy(&waiter.c0skw_cv);
 
-    return 0;
+    return kvdb_health_check(self->c0sk_kvdb_health, KVDB_HEALTH_FLAG_ALL);
 }
 
 static void

--- a/lib/include/hse_ikvdb/kvdb_health.h
+++ b/lib/include/hse_ikvdb/kvdb_health.h
@@ -70,4 +70,11 @@ kvdb_health_check(struct kvdb_health *health, uint event_mask);
 merr_t
 kvdb_health_clear(struct kvdb_health *health, uint event);
 
+/**
+ * kvdb_health_clearall() - clear all the health events for a kvdb
+ * @health: pointer to a kvdb health structure
+ */
+merr_t
+kvdb_health_clearall(struct kvdb_health *health);
+
 #endif

--- a/lib/include/hse_ikvdb/kvdb_rparams.h
+++ b/lib/include/hse_ikvdb/kvdb_rparams.h
@@ -78,6 +78,7 @@ struct kvdb_rparams {
     uint32_t dur_size_bytes;
     bool     dur_enable;
     bool     dur_buf_managed;
+    bool     dur_replay_force;
     uint8_t  dur_throttle_lo_th;
     uint8_t  dur_throttle_hi_th;
     uint8_t  dur_mclass;

--- a/lib/include/hse_ikvdb/wal.h
+++ b/lib/include/hse_ikvdb/wal.h
@@ -44,7 +44,7 @@ struct wal_replay_info {
     uint64_t  gen;
     uint64_t  seqno;
     uint64_t  txhorizon;
-    bool      clean;
+    bool      replay_force;
 };
 
 /* MTF_MOCK */

--- a/lib/kvdb/kvdb_health.c
+++ b/lib/kvdb/kvdb_health.c
@@ -156,3 +156,21 @@ kvdb_health_clear(struct kvdb_health *health, uint event)
 
     return 0;
 }
+
+merr_t
+kvdb_health_clearall(struct kvdb_health *health)
+{
+    uint event, mask = KVDB_HEALTH_FLAG_ALL;
+    merr_t err = 0;
+
+    for (event = 1; mask; event <<= 1) {
+        if (mask & event) {
+            err = kvdb_health_clear(health, event);
+            if (err)
+                break;
+            mask &= ~event;
+        }
+    }
+
+    return err;
+}

--- a/lib/kvdb/kvdb_rparams.c
+++ b/lib/kvdb/kvdb_rparams.c
@@ -978,6 +978,21 @@ static const struct param_spec pspecs[] = {
         },
     },
     {
+        .ps_name = "durability.replay.force",
+        .ps_description = "Force WAL to attempt a best-effort recovery with potential data loss",
+        .ps_flags = PARAM_FLAG_EXPERIMENTAL,
+        .ps_type = PARAM_TYPE_BOOL,
+        .ps_offset = offsetof(struct kvdb_rparams, dur_replay_force),
+        .ps_size = PARAM_SZ(struct kvdb_rparams, dur_replay_force),
+        .ps_convert = param_default_converter,
+        .ps_validate = param_default_validator,
+        .ps_stringify = param_default_stringify,
+        .ps_jsonify = param_default_jsonify,
+        .ps_default_value = {
+            .as_bool = false,
+        },
+    },
+    {
         .ps_name = "durability.size_bytes",
         .ps_description = "Maximum amount of application data lost in the event of a crash",
         .ps_flags = PARAM_FLAG_EXPERIMENTAL,

--- a/lib/wal/wal.h
+++ b/lib/wal/wal.h
@@ -94,4 +94,7 @@ wal_fset(struct wal *wal);
 struct wal_mdc *
 wal_mdc(struct wal *wal);
 
+struct kvdb_health *
+wal_health(struct wal *wal);
+
 #endif /* WAL_INTERNAL_H */

--- a/tests/functional/cli/storage/info/home-dne.sh
+++ b/tests/functional/cli/storage/info/home-dne.sh
@@ -6,4 +6,6 @@
 
 . common.subr
 
-cmd -e hse storage info /does-not-exist
+output=$(cmd -e hse storage info /does-not-exist 2>&1)
+
+echo "$output" | cmd grep -F "No such KVDB (/does-not-exist)"

--- a/tests/functional/cli/storage/info/success.sh
+++ b/tests/functional/cli/storage/info/success.sh
@@ -18,9 +18,7 @@ echo "$output" | cmd grep -F "USED_BYTES"
 echo "$output" | cmd grep -F "PATH"
 
 echo "$output" | cmd grep -F "capacity"
-echo "$output" | cmd grep -F "staging"
-echo "$output" | cmd grep -F "pmem"
 
 echo "$output" | cmd grep -F "$home/capacity"
 
-cmd test "$(echo "$output" | cmd wc -l)" -eq 4
+cmd test "$(echo "$output" | cmd wc -l)" -eq 2

--- a/tests/unit/kvdb/kvdb_rparams_test.c
+++ b/tests/unit/kvdb/kvdb_rparams_test.c
@@ -454,6 +454,23 @@ MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, durability_interval, test_pre)
     ASSERT_EQ(HSE_WAL_DUR_MS_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
+MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, durability_replay_force, test_pre)
+{
+    const struct param_spec *ps = ps_get("durability.replay.force");
+
+    ASSERT_NE(NULL, ps);
+    ASSERT_NE(NULL, ps->ps_description);
+    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
+    ASSERT_EQ(PARAM_TYPE_BOOL, ps->ps_type);
+    ASSERT_EQ(offsetof(struct kvdb_rparams, dur_replay_force), ps->ps_offset);
+    ASSERT_EQ(sizeof(bool), ps->ps_size);
+    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
+    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
+    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
+    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
+    ASSERT_EQ(false, params.dur_replay_force);
+}
+
 MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, durability_size, test_pre)
 {
     const struct param_spec *ps = ps_get("durability.size_bytes");


### PR DESCRIPTION
- Check health errors in c0sk_sync() and ikvdb_kvs_prefix_delete()
- Prevent out of order ingests in c0sk_ingest_worker() during a health error
- Fix c0sk_ingest_worker() to invoke cn_ingestv() and the wal ingest cb only in the success path
- Treat health error as an ungraceful shutdown and do not write close record in WAL MDC
- Add a force WAL replay mode in which wal replays as much data as possible to bring the affected KVDB online in a consistent state
- Allocate WAL flush workqueue with max threads
- Fix "hse storage info" to display stats only for the configured media classes

Signed-off-by: Nabeel M Mohamed <50154757+nabeelmmd@users.noreply.github.com>