### PR TITLE
Fix arg validation in hse_kvs_prefix_probe API (NFSE-5166)

### DIFF
--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -971,7 +971,7 @@ hse_kvs_prefix_probe(
         err = merr(EINVAL);
     else if (!pfx_len)
         err = merr(ENOENT);
-    else if (pfx_len > HSE_KVS_PFX_LEN_MAX)
+    else if (pfx_len > HSE_KVS_KEY_LEN_MAX)
         err = merr(ENAMETOOLONG);
     else if (keybuf_sz != HSE_KVS_KEY_LEN_MAX)
         err = merr(EINVAL);

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -476,10 +476,10 @@ cn_spill(struct cn_compaction_work *w)
 
                 bg_val = (seq <= w->cw_horizon);
 
-                /* Set ptomb context and annihilate keys irrespective of bg_val */
-                if (pt_set && seq < pt_seq)
+                if (bg_val && pt_set && seq < pt_seq)
                     break; /* drop val */
 
+                /* Set ptomb context irrespective of bg_val for tombstone propagation */
                 if (HSE_CORE_IS_PTOMB(vdata)) {
                     pt_set = true;
                     pt_kobj = curr.kobj;

--- a/tests/functional/api/kvs_api_test.c
+++ b/tests/functional/api/kvs_api_test.c
@@ -875,7 +875,7 @@ MTF_DEFINE_UTEST(kvs_api_test, prefix_probe_pfx_len_too_long)
         0,
         NULL,
         (void *)-1,
-        HSE_KVS_PFX_LEN_MAX + 1,
+        HSE_KVS_KEY_LEN_MAX + 1,
         (enum hse_kvs_pfx_probe_cnt *)-1,
         (void *)-1,
         HSE_KVS_KEY_LEN_MAX,


### PR DESCRIPTION
- Fix arg validation in hse_kvs_prefix_probe API
- Fix ptomb annihilation check in spill

Signed-off-by: Nabeel M Mohamed <50154757+nabeelmmd@users.noreply.github.com>