### PR TITLE
Set depth in wrap-git subprojects to 1

### DIFF
--- a/subprojects/hse-python.wrap
+++ b/subprojects/hse-python.wrap
@@ -1,3 +1,4 @@
 [wrap-git]
 url = https://github.com/hse-project/hse-python.git
 revision = master
+depth = 1


### PR DESCRIPTION
If someone is wanting a full checkout, that is available to them. This
just makes the common case faster.

Signed-off-by: Tristan Partin <tpartin@micron.com>
