### PR TITLE
Rename hse.pid to kvdb.pid in gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,9 @@
 
 # https://github.com/github/linguist/blob/master/docs/overrides.md
 
-hse.pid            linguist-language=JSON
 hse.conf           linguist-language=JSON
 kvdb.conf          linguist-language=JSON
 kvdb.meta          linguist-language=JSON
+kvdb.pid           linguist-language=JSON
 *.subr             linguist-language=Shell
 subprojects/*.wrap linguist-language=INI


### PR DESCRIPTION
I don't even know the name of the file apparently. Very smart.

Signed-off-by: Tristan Partin <tpartin@micron.com>
