### PR TITLE
Rework how -Dbindings=auto is handled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -313,28 +313,7 @@ elif 'none' in get_option('bindings')
 elif 'auto' in get_option('bindings')
     assert(get_option('bindings').length() == 1, 'The -Dbindings=auto option cannot have additional values')
 
-    # Determine whether we can build hse-java
-    if meson.version().version_compare('>=0.62.0')
-        if add_languages('java', native: false, required: false)
-            javac = meson.get_compiler('java')
-            if javac.version().version_compare('>=1.8.0')
-                bindings += 'java'
-            endif
-        endif
-    endif
-
-    # Determine whether we can build hse-ython
-    cython_verison_res = run_command(
-        python,
-        '-c',
-        'from Cython.Compiler.Version import version; print(version)',
-        check: false
-    )
-    if cython_verison_res.returncode() == 0
-        if cython_verison_res.stdout().strip().version_compare('>=0.29.21')
-            bindings += 'python'
-        endif
-    endif
+    bindings = get_option('bindings')
 else
     bindings = get_option('bindings')
 endif
@@ -376,50 +355,30 @@ subdir('docs')
 # Environment in which various run_targets and tests will run in
 run_env = environment()
 
-if 'python' in bindings
-    hse_python = subproject(
-        'hse-python',
-        default_options: [
-            'tests=@0@'.format(get_option('tests')),
-        ]
-    )
-
-    hse_python_depends = hse_python.get_variable('extension_modules')
-    run_env.prepend('PYTHONPATH', hse_python.get_variable('project_build_root'))
-
-    run_target(
-        'python-repl',
-        command: [
-            python,
-        ],
-        depends: hse_python_depends,
-        env: run_env,
-    )
-else
-    hse_python_depends = disabler()
-endif
-
-if 'java' in bindings
+hse_java_depends = disabler()
+if 'java' in bindings or 'auto' in bindings
     hse_java = subproject(
         'hse-java',
+        required: 'java' in bindings,
         default_options: [
+            'docs=disabled',
             'tests=@0@'.format(get_option('tests')),
         ]
     )
 
-    hsejni = hse_java.get_variable('hsejni')
-    hse_jar = hse_java.get_variable('hse_jar')
+    if hse_java.found()
+        hsejni = hse_java.get_variable('hsejni')
+        hse_jar = hse_java.get_variable('hse_jar')
 
-    hse_java_depends = [
-        hsejni,
-        hse_jar,
-    ]
+        hse_java_depends = [
+            hsejni,
+            hse_jar,
+        ]
 
-    run_env.prepend('LD_LIBRARY_PATH', fs.parent(hsejni.full_path()))
-    run_env.prepend('CLASSPATH', hse_jar.full_path())
+        run_env.prepend('LD_LIBRARY_PATH', fs.parent(hsejni.full_path()))
+        run_env.prepend('CLASSPATH', hse_jar.full_path())
 
-    jshell = find_program('jshell', required: false)
-    if jshell.found()
+        jshell = find_program('jshell', required: false, disabler: true)
         run_target(
             'jshell',
             command: [
@@ -429,8 +388,31 @@ if 'java' in bindings
             env: run_env
         )
     endif
-else
-    hse_java_depends = disabler()
+endif
+
+hse_python_depends = disabler()
+if 'python' in bindings or 'auto' in bindings
+    hse_python = subproject(
+        'hse-python',
+        required: 'python' in bindings,
+        default_options: [
+            'tests=@0@'.format(get_option('tests')),
+        ]
+    )
+
+    if hse_python.found()
+        hse_python_depends = hse_python.get_variable('extension_modules')
+        run_env.prepend('PYTHONPATH', hse_python.get_variable('project_build_root'))
+
+        run_target(
+            'python-repl',
+            command: [
+                python,
+            ],
+            depends: hse_python_depends,
+            env: run_env,
+        )
+    endif
 endif
 
 if get_option('db_bench') and get_option('experimental')


### PR DESCRIPTION
Now we use subproject(required:) to determine whether a subproject can
be built or not. This takes away all the custom logic we had previously.
More maintainable since all the logic of whether or not a subproject is
buildable is self-contained within said subproject.

Signed-off-by: Tristan Partin <tpartin@micron.com>
