### PR TITLE
Remove workqueue from REST subsystem

### DIFF
--- a/lib/kvdb/kvdb_rest.c
+++ b/lib/kvdb/kvdb_rest.c
@@ -85,6 +85,7 @@ rest_kvdb_get(
     struct ikvdb *      ikvdb = context;
     merr_t              err;
     struct yaml_context yc = { 0 };
+    char buf[4096];
 
     /* verify that the request was exact */
     if (strcmp(path, url) != 0)
@@ -92,8 +93,8 @@ rest_kvdb_get(
 
     yc.yaml_indent = 0;
     yc.yaml_offset = 0;
-    yc.yaml_buf = info->buf;
-    yc.yaml_buf_sz = info->buf_sz;
+    yc.yaml_buf = buf;
+    yc.yaml_buf_sz = sizeof(buf);
     yc.yaml_emit = NULL;
 
     err = get_kvs_list(ikvdb, info->resp_fd, &yc);
@@ -410,8 +411,8 @@ rest_kvdb_compact_status_get(
     const char *                   p = path + strlen(url);
     const char *                   action;
     size_t                         b, buf_off;
-    char *                         buf = info->buf;
-    size_t                         bufsz = info->buf_sz;
+    char                           buf[4096];
+    size_t                         bufsz = sizeof(buf);
 
     if (ev(*p == 0))
         return merr(EINVAL);
@@ -824,6 +825,7 @@ rest_kvs_tree(
     bool                list_blkid = true;
     struct yaml_context yc = { 0 };
     int                 fd = info->resp_fd;
+    char buf[4096];
 
     /* verify that the request was exact */
     if (strcmp(path, url) != 0)
@@ -831,8 +833,8 @@ rest_kvs_tree(
 
     yc.yaml_indent = 0;
     yc.yaml_offset = 0;
-    yc.yaml_buf = info->buf;
-    yc.yaml_buf_sz = info->buf_sz;
+    yc.yaml_buf = buf;
+    yc.yaml_buf_sz = sizeof(buf);
     yc.yaml_emit = NULL;
 
     /* HSE_REVISIT: It is not safe to make a ref out of thin air.

--- a/lib/util/include/hse_util/rest_api.h
+++ b/lib/util/include/hse_util/rest_api.h
@@ -20,9 +20,8 @@
 
 enum rest_url_flags {
     URL_FLAG_NONE = 0,
-    URL_FLAG_BINVAL = 1 << 1,
     URL_FLAG_EXACT =
-        1 << 2, /* Whether the registered route should match exactly with the requested route */
+        1 << 1, /* Whether the registered route should match exactly with the requested route */
 };
 
 struct kv_iter;
@@ -32,15 +31,11 @@ struct kv_iter;
  * @resp_fd: write response to this fd
  * @data:    uploaded data, if any
  * @data_sz: size of data
- * @buf:     ptr to a buffer that will exist for the duration of this session
- * @buf_sz:  size of @buf
  */
 struct conn_info {
     int         resp_fd;
     const char *data;
     size_t *    data_sz;
-    char *      buf;
-    size_t      buf_sz;
 };
 
 /* arguments passed as key-value pairs as part of URI */


### PR DESCRIPTION
HTTP can be multiplexed depending on the number of connections. The
workqueue gets in the way of passing information back to the client. The
workqueue in this case was causing file descriptors to get closed and
requests cleaned up before HSE can even interact with the request. Now
requests are blocking, so resources stay active for as long as HSE
needs to process the request.

This commit is similar to some work that I had to do to actually test
writable parameters however long ago that was. No idea why I never
committed the work. Maybe it was because it felt like a large-ish change
and no one ever commented on it.

This commit specifically is really a stop-gap due to leaving the work
struct and thread args struct around, but I really don't want to spend
too much time in this code because I feel like I will rewrite it here
in the near future.

Signed-off-by: Tristan Partin <tpartin@micron.com>

## Description
<!-- Describe the changes in this PR and add any information helpful for reviewing. -->

## Issue(s) Addressed
<!-- Issue number -->
