### PR TITLE
Add vblock id to KMD for vtype_val and vtype_cval

### DIFF
--- a/docs/cn_omf.md
+++ b/docs/cn_omf.md
@@ -1,19 +1,23 @@
 # OMF descriptions
 
-## KBlocks (Key blocks)
+## KBlocks (Key Blocks)
 
-KBlocks are mblocks that hold keys in sorted order. See cn/omf.h for the structures associated with the various omf components. All the on-media elements are stored in little endian ordering.
+KBlocks are mblocks that hold keys in sorted order. See cn/omf.h for the
+structures associated with the various omf components. All the on-media elements
+are stored in little endian ordering.
 
-    +--------+--------+-------+--------+----------+
-    |        |        |       |        |          |
-    | KBlock | WBTree | PTree | Bloom  | Hyperlog |
-    | Header |        |       | Filter |          |
-    |        |        |       |        |          |
-    +--------+--------+-------+--------+----------+
+    +--------+--------+--------+-------------+
+    |        |        |        |             |
+    | Kblock | WBTree | Bloom  | HyperLogLog |
+    | Header |        | Filter |             |
+    |        |        |        |             |
+    +--------+--------+--------+-------------+
 
-### KBlock header
+### Kblock Header
 
-The kblock header contains information about where the other components of the kblock are located and some other metadata. It also stores the smallest and largest keys in the kblock as well as the smallest and largest sequence numbers.
+The kblock header contains information about where the other components of the
+kblock are located and some other metadata. It also stores the smallest and
+largest keys in the kblock as well as the smallest and largest sequence numbers.
 
 note: max keylen == 1350 bytes
 
@@ -182,9 +186,9 @@ The `vblock index` stored in kmd is an index within the vgroup specified by `vgr
 
 This portion has the same format as the main WBTree.  A PTree can exist only in the last kblock of a kvset.
 
-### Bloom filter
+### Bloom Filter
 
-Bloom Header
+#### Bloom Header
 
     +-------------------+
     | u32 bh_magic      |
@@ -201,18 +205,141 @@ Bloom Header
 
 This is followed by the bloom filter.
 
+## Vblocks (Value Blocks)
+
+VBlocks consist of values followed by a trailer. The offset of a specific value
+and its length are obtained from the kmd entry for this value which is linked to
+the corresponding key.
+
+### Vblock Trailer
+
+Placed at the end of vblock - 4K bytes.
+
+    +---------------------+
+    | u32 vbh_magic       |
+    | u32 vbh_version     |
+    | u32 vbh_min_key_off | Offset of the min key
+    | u32 vbh_min_key_len | Length of the min key
+    | u32 vbh_max_key_off | Offset of the max key
+    | u32 vbh_max_key_len | Length of the max key
+    |---------------------|
+    | min_key             | 1344 bytes is reserved at all times
+    |---------------------|
+    | max_key             | 1344 bytes is reserved at all times
+    +---------------------+
+
+## Hblocks (Header blocks)
+
+    +----------+--------+-------------+-------+
+    |          |        |             |       |
+    | Metadata | Vblock | HyperLogLog | PTree |
+    |  Header  | Index  |             |       |
+    |          | Adjust |             |       |
+    +----------+--------+-------------+-------+
+
+### Hblock Header
+
+    +---------------------------+
+    | u32 hbh_magic             |
+    | u32 hbh_version           |
+    | u32 hbh_num_kblocks       | Number of kblocks within the kvset
+    | u32 hbh_num_vblocks       | Number of vblocks within the kvset
+    | u32 hbh_num_vgroups       | Number of vgroups within the kvset
+    | u8  hbh_kblk_trim_type    | Enum representing no trim, start trim, or end trim
+    | u16 hbh_kblk_trim_pg      | WBTree leaf node of trim key
+    | u16 hbh_kblk_trim_off     | Trim key offset within node
+    | u32 hbh_hlog_off_pg       | Offset of the hlog
+    | u32 hbh_hlog_len_pg       | Length of the hlog (constant 20K)
+    | u32 hbh_ptree_hdr_off     | Offset of the ptree header
+    | u32 hbh_ptree_hdr_len     | Length of the ptree header
+    | u32 hbh_ptree_data_off_pg | Offset of the ptree data
+    | u32 hbh_ptree_data_len_pg | Offset of the ptree data
+    | u32 hbh_vblk_idx_adj_off  | Offset of the vblock index adjust
+    | u32 hbh_vblk_idx_adj_len  | Length of the vblock index adjust
+    +---------------------------+
+
+### Kblock Trim
+
+Kblock trim masks parts of a kblock's data. During a kvset split, a portion of
+a kblock will be hidden. Each segment is the trim associated with 1 kblock. The
+range represented is inclusive. The only kblocks that can have trim are the
+first or last kblock within a kvset. The first kblock will trim from page 0,
+offset 0 to `hbh_kblk_trim_pg`, `hbh_kblk_trim_off`. The last kblock will trim
+from `hbh_kblk_trim_pg`, `hbh_kblk_trim_off` to the last page, last key.
+
+### Vblock Index Adjust
+
+The index indicates that from the previous index + 1 to the current index, all
+index adjustments must be subtracted by the accompanying adjustment value.
+
+    +-------------------+
+    | ...               |
+    +-------------------+
+    | u32 vbia_vblk_idx | Barrier vblock index
+    | u32 vbia_adj      | Adjustment value
+    +-------------------+
+    | ...               |
+    +-------------------+
+
 ### HyperLogLog
 
-This region does not have a separate header, just the hyperloglog (hlog) bytes.  The offset and length in the KBlock header points to this region.  Each kblock stores its hlog bytes and the kvset's hlog can be composed using the individual kblock hlogs.
+Composite hlog of the entire keyspace contained within the kvset.
 
-## VBlocks (Value blocks)
+### PTree
 
-VBlocks consist of a header followed by all the values.  The offset of a specifc value and its length are obtained from the kmd entry for this value which is linked to the corresponding key.
+This portion has the same format as a regular WBTree. This stores prefix
+tombstone data rather than key data however.
 
-### VBlock header
+## Examples
 
-    +-------------------+
-    | u32 vbh_magic     |
-    | u32 vbh_version   |
-    | u64 vbh_vgroup    |
-    +-------------------+
+### Kvset Split
+
+Given a key to split on, we have to find the kblock to mask and the vblocks
+to split.
+
+Given two destination kvsets, left and right, add all kblocks which are less
+than the split key and completely contained within the new range of the left
+kvset to said kvset. When the kblock containing the split key has been iterated
+to, we need to add it to both the left and the right kvset, but it will have a
+different mask depending on which kvset you are looking at.
+
+On the left kvset, set `hbh_kblk_trim_type` to `KBLOCK_TRIM_START`. In the event
+the split key is the end of a WBTree leaf node, set `hbh_kblk_trim_pg` to the
+next WBTree leaf node index, and set `hbh_kblk_trim_off` to `0`. Otherwise, set
+`hbh_kblk_trim_pg` to the WBTree lead node index that includes the split key,
+and set `hbh_kblk_trim_off` to the offset of the split key `+ 1`.
+
+On the right kvset, set `hbh_kblk_trim_type` to `KBLOCK_TRIM_END`, set
+`hbh_kblk_trim_pg` to the WBTree leaf node index containing the split key, and
+set `hbh_kblk_trim_off` to the offset of the split key within
+`hbh_kblk_trim_pg`.
+
+From this point, we can iterate over the rest of the kblocks while adding them
+to the right kvset.
+
+Onto the vblocks. Iterate over all the vblocks. When the keyspace containing
+the vblock fits within either the left or the right kvset, add it to the
+determined kvset. In the event a vblock's keyspace spans across the split key,
+make a copy of the vblock for one of the kvsets and move the original vblock
+into the other. Keep track of the vblock indexes for vblocks that span the split
+key.
+
+Once you have collected all the vblock indices, we can construct the
+[vblock index adjust](#vblock-index-adjust). Say we have vblock indicies 0-4.
+Vblock 2 must be split becauses its keyspace runs through the split key. Let's
+say vblocks 0 and 1 belong to the left kvset while 3 and 4 belong to the right
+kvset. The vblock index adjust for the left and right kvsets will look like the
+following:
+
+__LEFT__: (2, 0)
+
+All indices less than or equal to 2 must be subtracted by 0 to get the new
+vblock index in the left kvset.
+
+__RIGHT__: (4, 2)
+
+All indices less than or equal to 4 must be subtracted by 2 to get the new
+vblock index in the right kvset.
+
+The vblock index adjust is most useful when getting the vblock index out of a
+KMD entry.

--- a/lib/cn/kcompact.c
+++ b/lib/cn/kcompact.c
@@ -148,6 +148,7 @@ kcompact(struct cn_compaction_work *w)
     merr_t            err;
 
     enum kmd_vtype vtype;
+    u64            vbid;
     uint           vbidx, vboff, vlen, complen;
     const void *   vdata;
 
@@ -214,7 +215,7 @@ get_values:
 
     while (horizon &&
            kvset_iter_next_vref(
-               w->cw_inputv[curr.src], &curr.vctx, &seq, &vtype, &vbidx, &vboff,
+               w->cw_inputv[curr.src], &curr.vctx, &seq, &vtype, &vbid, &vbidx, &vboff,
                &vdata, &vlen, &complen))
     {
         bool should_emit = false;
@@ -264,7 +265,7 @@ get_values:
                 case vtype_val:
                 case vtype_cval:
                     err = kvset_builder_add_vref(
-                        w->cw_child[0], seq, vbidx + w->cw_vbmap.vbm_map[curr.src],
+                        w->cw_child[0], seq, vbid, vbidx + w->cw_vbmap.vbm_map[curr.src],
                         vboff, vlen, complen);
                     break;
                 case vtype_zval:

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -3352,6 +3352,7 @@ kvset_iter_next_vref(
     struct kvset_iter_vctx *vc,
     u64 *                   seq,
     enum kmd_vtype *        vtype,
+    u64 *                   vbid,
     uint *                  vbidx,
     uint *                  vboff,
     const void **           vdata,
@@ -3379,10 +3380,10 @@ kvset_iter_next_vref(
     kmd_type_seq(vc->kmd, &vc->off, vtype, seq);
     switch (*vtype) {
         case vtype_val:
-            kmd_val(vc->kmd, &vc->off, vbidx, vboff, vlen);
+            kmd_val(vc->kmd, &vc->off, vbid, vbidx, vboff, vlen);
             break;
         case vtype_cval:
-            kmd_cval(vc->kmd, &vc->off, vbidx, vboff, vlen, complen);
+            kmd_cval(vc->kmd, &vc->off, vbid, vbidx, vboff, vlen, complen);
             break;
         case vtype_ival:
             kmd_ival(vc->kmd, &vc->off, vdata, vlen);

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -469,6 +469,7 @@ kvset_iter_next_vref(
     struct kvset_iter_vctx *vc,
     u64 *                   seq,
     enum kmd_vtype *        vtype,
+    u64 *                   vbid,
     uint *                  vbidx,
     uint *                  vboff,
     const void **           vdata,

--- a/lib/cn/kvset_builder.c
+++ b/lib/cn/kvset_builder.c
@@ -215,9 +215,9 @@ kvset_builder_add_val(
         self->key_stats.c0_vlen += omlen;
 
         if (complen)
-            kmd_add_cval(self->main.kmd, &self->main.kmd_used, seq, vbidx, vboff, vlen, complen);
+            kmd_add_cval(self->main.kmd, &self->main.kmd_used, seq, vbid, vbidx, vboff, vlen, complen);
         else
-            kmd_add_val(self->main.kmd, &self->main.kmd_used, seq, vbidx, vboff, vlen);
+            kmd_add_val(self->main.kmd, &self->main.kmd_used, seq, vbid, vbidx, vboff, vlen);
 
         /* stats (and space amp) use on-media length */
         self->vused += omlen;
@@ -254,6 +254,7 @@ merr_t
 kvset_builder_add_vref(
     struct kvset_builder   *self,
     u64                     seq,
+    u64                     vbid,
     uint                    vbidx,
     uint                    vboff,
     uint                    vlen,
@@ -265,9 +266,9 @@ kvset_builder_add_vref(
         return merr(ev(ENOMEM));
 
     if (complen > 0)
-        kmd_add_cval(self->main.kmd, &self->main.kmd_used, seq, vbidx, vboff, vlen, complen);
+        kmd_add_cval(self->main.kmd, &self->main.kmd_used, seq, vbid, vbidx, vboff, vlen, complen);
     else
-        kmd_add_val(self->main.kmd, &self->main.kmd_used, seq, vbidx, vboff, vlen);
+        kmd_add_val(self->main.kmd, &self->main.kmd_used, seq, vbid, vbidx, vboff, vlen);
 
     self->vused += om_len;
     self->key_stats.tot_vlen += om_len;

--- a/lib/cn/kvset_checker.c
+++ b/lib/cn/kvset_checker.c
@@ -273,10 +273,11 @@ check_vref(
     u32 *              last_vbidx,
     u32 *              last_vboff)
 {
+    u64  vbid;
     u32  vbidx, vlen, vboff;
     bool err = false;
 
-    kmd_val(kb_info->kmd, off, &vbidx, &vboff, &vlen);
+    kmd_val(kb_info->kmd, off, &vbid, &vbidx, &vboff, &vlen);
 
     if (*last_vboff > 0 && vbidx == *last_vbidx && vboff < *last_vboff) {
         err = true;

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -348,6 +348,7 @@ cn_spill(struct cn_compaction_work *w)
                 const void *   vdata = NULL;
                 bool           should_emit = false;
                 enum kmd_vtype vtype;
+                u64            vbid;
                 u32            vbidx;
                 u32            vboff;
                 bool           direct;
@@ -355,7 +356,7 @@ cn_spill(struct cn_compaction_work *w)
                 if (tstart > 0)
                     tstart = get_time_ns();
 
-                if (!kvset_iter_next_vref(w->cw_inputv[curr.src], &curr.vctx, &seq, &vtype, &vbidx,
+                if (!kvset_iter_next_vref(w->cw_inputv[curr.src], &curr.vctx, &seq, &vtype, &vbid, &vbidx,
                                           &vboff, &vdata, &vlen, &complen))
                     break;
 

--- a/lib/cn/wbt_reader.c
+++ b/lib/cn/wbt_reader.c
@@ -35,6 +35,7 @@ void
 wbt_read_kmd_vref(const void *kmd, size_t *off, u64 *seq, struct kvs_vtuple_ref *vref)
 {
     enum kmd_vtype vtype;
+    u64            vbid = 0;
     uint           vbidx = 0;
     uint           vboff = 0;
     uint           vlen = 0;
@@ -45,23 +46,25 @@ wbt_read_kmd_vref(const void *kmd, size_t *off, u64 *seq, struct kvs_vtuple_ref 
 
     switch (vtype) {
         case vtype_val:
-            kmd_val(kmd, off, &vbidx, &vboff, &vlen);
+            kmd_val(kmd, off, &vbid, &vbidx, &vboff, &vlen);
             /* assert no truncation */
             assert(vbidx <= U16_MAX);
             assert(vboff <= U32_MAX);
             assert(vlen <= U32_MAX);
+            vref->vb.vr_id = vbid;
             vref->vb.vr_index = vbidx;
             vref->vb.vr_off = vboff;
             vref->vb.vr_len = vlen;
             vref->vb.vr_complen = 0;
             break;
         case vtype_cval:
-            kmd_cval(kmd, off, &vbidx, &vboff, &vlen, &complen);
+            kmd_cval(kmd, off, &vbid, &vbidx, &vboff, &vlen, &complen);
             /* assert no truncation */
             assert(vbidx <= U16_MAX);
             assert(vboff <= U32_MAX);
             assert(vlen <= U32_MAX);
             assert(complen <= U32_MAX);
+            vref->vb.vr_id = vbid;
             vref->vb.vr_index = vbidx;
             vref->vb.vr_off = vboff;
             vref->vb.vr_len = vlen;

--- a/lib/include/hse_ikvdb/kvset_builder.h
+++ b/lib/include/hse_ikvdb/kvset_builder.h
@@ -81,6 +81,7 @@ merr_t
 kvset_builder_add_vref(
     struct kvset_builder   *self,
     u64                     seq,
+    u64                     vbid,
     uint                    vbidx,
     uint                    vboff,
     uint                    vlen,

--- a/lib/include/hse_ikvdb/omf_kmd.h
+++ b/lib/include/hse_ikvdb/omf_kmd.h
@@ -133,13 +133,14 @@ kmd_add_ival(void *kmd, size_t *off, u64 seq, const void *vdata, u8 vlen)
 }
 
 static inline void
-kmd_add_val(void *kmd, size_t *off, u64 seq, uint vbidx, uint vboff, uint vlen)
+kmd_add_val(void *kmd, size_t *off, u64 seq, u64 vbid, uint vbidx, uint vboff, uint vlen)
 {
     __be32 val32;
 
     ((u8 *)kmd)[*off] = vtype_val;
     *off += 1;
     encode_hg64(kmd, off, seq);
+    encode_hg64(kmd, off, vbid);
     encode_hg16_32k(kmd, off, vbidx);
     val32 = cpu_to_be32(vboff);
     memcpy(kmd + *off, &val32, sizeof(val32));
@@ -148,13 +149,14 @@ kmd_add_val(void *kmd, size_t *off, u64 seq, uint vbidx, uint vboff, uint vlen)
 }
 
 static inline void
-kmd_add_cval(void *kmd, size_t *off, u64 seq, uint vbidx, uint vboff, uint vlen, uint complen)
+kmd_add_cval(void *kmd, size_t *off, u64 seq, u64 vbid, uint vbidx, uint vboff, uint vlen, uint complen)
 {
     __be32 val32;
 
     ((u8 *)kmd)[*off] = vtype_cval;
     *off += 1;
     encode_hg64(kmd, off, seq);
+    encode_hg64(kmd, off, vbid);
     encode_hg16_32k(kmd, off, vbidx);
     val32 = cpu_to_be32(vboff);
     memcpy(kmd + *off, &val32, sizeof(val32));
@@ -178,10 +180,11 @@ kmd_type_seq(const void *kmd, size_t *off, enum kmd_vtype *vtype, u64 *seq)
 }
 
 static inline void
-kmd_val(const void *kmd, size_t *off, uint *vbidx, uint *vboff, uint *vlen)
+kmd_val(const void *kmd, size_t *off, u64 *vbid, uint *vbidx, uint *vboff, uint *vlen)
 {
     __be32 val32;
 
+    *vbid = decode_hg64(kmd, off);
     *vbidx = decode_hg16_32k(kmd, off);
     memcpy(&val32, kmd + *off, sizeof(val32));
     *vboff = be32_to_cpu(val32);
@@ -190,10 +193,11 @@ kmd_val(const void *kmd, size_t *off, uint *vbidx, uint *vboff, uint *vlen)
 }
 
 static inline void
-kmd_cval(const void *kmd, size_t *off, uint *vbidx, uint *vboff, uint *vlen, uint *complen)
+kmd_cval(const void *kmd, size_t *off, u64 *vbid, uint *vbidx, uint *vboff, uint *vlen, uint *complen)
 {
     __be32 val32;
 
+    *vbid = decode_hg64(kmd, off);
     *vbidx = decode_hg16_32k(kmd, off);
     memcpy(&val32, kmd + *off, sizeof(val32));
     *vboff = be32_to_cpu(val32);

--- a/lib/include/hse_ikvdb/tuple.h
+++ b/lib/include/hse_ikvdb/tuple.h
@@ -75,6 +75,7 @@ struct kvs_vtuple_ref {
     enum kmd_vtype vr_type;
     union {
         struct {
+            uint64_t vr_id;
             uint16_t vr_index;
             uint32_t vr_off;
             uint32_t vr_len;

--- a/tests/mocks/repository/lib/mock_kvset.c
+++ b/tests/mocks/repository/lib/mock_kvset.c
@@ -547,6 +547,7 @@ _kvset_iter_next_vref(
     struct kvset_iter_vctx *vc,
     u64 *                   seq,
     enum kmd_vtype *        vtype,
+    u64 *                   vbid,
     uint *                  vbidx,
     uint *                  vboff,
     const void **           vdata,
@@ -566,6 +567,7 @@ _kvset_iter_next_vref(
 
     entry += vc->off;
     *seq = 1;
+    *vbid = iter->src;
     *vbidx = iter->src;
     *vboff = 0;
 

--- a/tests/unit/cn/kcompact_test.c
+++ b/tests/unit/cn/kcompact_test.c
@@ -164,7 +164,7 @@ _kvset_builder_add_key(struct kvset_builder *builder, const struct key_obj *kobj
 }
 
 static merr_t
-_kvset_builder_add_vref(struct kvset_builder *self, u64 seq,
+_kvset_builder_add_vref(struct kvset_builder *self, u64 seq, u64 vbid,
     uint vbidx, uint vboff, uint vlen, uint complen)
 {
     VERIFY_EQ_RET(st.have.nvals, 0, __LINE__);

--- a/tests/unit/cn/kvset_builder_test.c
+++ b/tests/unit/cn/kvset_builder_test.c
@@ -157,7 +157,7 @@ MTF_DEFINE_UTEST_PREPOST(test, t_kvset_builder_add_entry1, pre, post)
     /*
      * One flavor for add_vref
      */
-    err = kvset_builder_add_vref(bld, seq2, 1, 2, 3, 0);
+    err = kvset_builder_add_vref(bld, seq2, 1, 1, 2, 3, 0);
     ASSERT_EQ(err, 0);
 
     /*
@@ -209,6 +209,7 @@ MTF_DEFINE_UTEST_PREPOST(test, t_reserve_kmd1, pre, post)
 {
     merr_t err;
     u64    seq = 0x1122334455667788ULL;
+    u64    vbid = 1;
     uint   vbidx = 300;
     uint   vboff = 128 * 1000 * 1000;
     uint   vlen = 1000 * 1000;
@@ -222,7 +223,7 @@ MTF_DEFINE_UTEST_PREPOST(test, t_reserve_kmd1, pre, post)
 
     /* Add entries to exercise kmd growth */
     for (i = 0; i < 100; i++) {
-        err = kvset_builder_add_vref(bld, seq, vbidx, vboff, vlen, 0);
+        err = kvset_builder_add_vref(bld, seq, vbid, vbidx, vboff, vlen, 0);
         ASSERT_EQ(err, 0);
     }
 
@@ -235,6 +236,7 @@ MTF_DEFINE_UTEST_PREPOST(test, t_reserve_kmd2, pre, post)
     u32    api;
     merr_t err;
     u64    seq = 0x1122334455667788ULL;
+    u64    vbid = 1;
     uint   vbidx = 300;
     uint   vboff = 128 * 1000 * 1000;
     uint   vlen = 1000 * 1000;
@@ -251,7 +253,7 @@ MTF_DEFINE_UTEST_PREPOST(test, t_reserve_kmd2, pre, post)
 
     /* Add entries to kmd, eventually we should get an ENOMEM. */
     for (i = 0; i < 100; i++) {
-        err = kvset_builder_add_vref(bld, seq, vbidx, vboff, vlen, 0);
+        err = kvset_builder_add_vref(bld, seq, vbid, vbidx, vboff, vlen, 0);
         if (err)
             break;
     }

--- a/tests/unit/cn/merge_test.c
+++ b/tests/unit/cn/merge_test.c
@@ -767,6 +767,7 @@ static merr_t
 _kvset_builder_add_vref(
     struct kvset_builder *self,
     u64                   seq,
+    u64                   vbid_kvset_node,
     uint                  vbidx_kvset_node,
     uint                  vboff_nth_key,
     uint                  vlen_nth_val,
@@ -890,6 +891,7 @@ _kvset_iter_next_vref(
     struct kvset_iter_vctx *vc,
     u64 *                   seq,
     enum kmd_vtype *        vtype,
+    u64 *                   vbid,
     uint *                  vbidx,
     uint *                  vboff,
     const void **           vdata,
@@ -925,6 +927,7 @@ _kvset_iter_next_vref(
              *   vlen_out == nth_val
              * See also _kvset_builder_add_vref(), which unpacks this data.
              */
+            *vbid = kvset_node;
             *vbidx = kvset_node;
             *vboff = nth_key;
             *vlen_out = nth_val;

--- a/tools/cn_kbdump/cn_kbdump.c
+++ b/tools/cn_kbdump/cn_kbdump.c
@@ -429,6 +429,7 @@ print_blm(struct blk *blk)
 struct kmd_vref {
     enum kmd_vtype vtype;
     size_t         vtype_off;
+    u64            vbid;
     uint           vbidx;
     uint           vboff;
     uint           vlen;
@@ -454,11 +455,12 @@ val_get_next(void *kmd, size_t *off, struct kmd_vref *vref)
 
     switch (vref->vtype) {
         case vtype_val:
-            kmd_val(kmd, off, &vref->vbidx, &vref->vboff, &vref->vlen);
+            kmd_val(kmd, off, &vref->vbid, &vref->vbidx, &vref->vboff, &vref->vlen);
             snprintf(
                 vref->vinfo,
                 sizeof(vref->vinfo),
-                "type=v %u/%u/%u",
+                "type=v %lu/%u/%u/%u",
+                vref->vbid,
                 vref->vbidx,
                 vref->vboff,
                 vref->vlen);


### PR DESCRIPTION
This is a step in enabling the movement of vblocks from one node/kvset
to another in terms of node splits and joins.

Signed-off-by: Tristan Partin <tpartin@micron.com>
