### PR TITLE
Remove "|| exit $?" when calling various common.subr functions

### DIFF
--- a/tests/functional/smoke/compaction.sh
+++ b/tests/functional/smoke/compaction.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: test cn tree spill, k-compaction and kv-compaction
 
@@ -14,7 +14,7 @@ kvdb_create
 counter=0
 
 setup () {
-    kvs=$(kvs_create "smoke-$counter") || exit $?
+    kvs=$(kvs_create "smoke-$counter")
     counter=$((counter+1))
 
     # first 6 kvsets have keys 0..999

--- a/tests/functional/smoke/cursor_test1.sh
+++ b/tests/functional/smoke/cursor_test1.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 . common.subr
 
@@ -10,7 +10,7 @@ trap kvdb_drop EXIT
 kvdb_create
 
 # add a KVS to the KVDB
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 # 1. Create 10000 cursors spread across 20 threads - each thread gets a few
 #    cursors

--- a/tests/functional/smoke/cursor_test2.sh
+++ b/tests/functional/smoke/cursor_test2.sh
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0 prefix.length=8) || $?
+kvs=$(kvs_create smoke-0 prefix.length=8)
 
 # Load
 nthread=$(($(nproc) / 4 + 3))

--- a/tests/functional/smoke/droptomb1.sh
+++ b/tests/functional/smoke/droptomb1.sh
@@ -13,7 +13,7 @@ kvdb_create
 
 keys=10
 
-kvs=$(kvs_create smoke-0) || $?
+kvs=$(kvs_create smoke-0)
 
 sp='[[:space:]]'
 

--- a/tests/functional/smoke/kbdump.sh
+++ b/tests/functional/smoke/kbdump.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: cn_kbdump test
 
@@ -20,7 +20,7 @@ trap cleanup EXIT
 kvdb_create
 
 keys=1000
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 cmd simple_client "$home" "$kvs" -c "$keys" -v
 
 kbid=$(cn_metrics "$home" "$kvs" | awk '$1 == "k" {print $16}')

--- a/tests/functional/smoke/key-imm-disc.sh
+++ b/tests/functional/smoke/key-imm-disc.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: test edges of key_immediate and key_disc
 
@@ -24,7 +24,7 @@ key_formats=(
 counter=0
 
 for fmt in "${key_formats[@]}"; do
-    kvs=$(kvs_create "smoke-$counter") || $?
+    kvs=$(kvs_create "smoke-$counter")
     counter=$((counter+1))
     cmd kmt -s1 -c -f "$fmt" -j3 -i16 -t30 "$home" "$kvs"
     cmd kmt -s1 -c -f "$fmt" "$home" "$kvs"

--- a/tests/functional/smoke/kmt-ins-1g.sh
+++ b/tests/functional/smoke/kmt-ins-1g.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: kmt/kvdb insert test: 1 billion 20-byte keys with 50-byte values
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || $?
+kvs=$(kvs_create smoke-0)
 
 threads=$(( 2 * $(nproc) ))
 keys=1g

--- a/tests/functional/smoke/kmt1.sh
+++ b/tests/functional/smoke/kmt1.sh
@@ -14,10 +14,10 @@ kvdb_create
 jobs=$(($(nproc) / 4 + 3))
 recmax=$((128 * jobs))
 
-kvs1=$(kvs_create smoke-0) || $?
-kvs2=$(kvs_create smoke-1) || $?
-kvs3=$(kvs_create smoke-2) || $?
-kvs4=$(kvs_create smoke-3) || $?
+kvs1=$(kvs_create smoke-0)
+kvs2=$(kvs_create smoke-1)
+kvs3=$(kvs_create smoke-2)
+kvs4=$(kvs_create smoke-3)
 
 cmd kmt -i "$recmax" -t10 -c -j"$jobs" -w50 "$home" "$kvs1"
 cmd kmt -t10 -cD -j"$jobs" -w50 "$home" "$kvs1" kvs-oparms cn_verify=true

--- a/tests/functional/smoke/kmtc0.sh
+++ b/tests/functional/smoke/kmtc0.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: quick kvdb/c0 read performance test using kmt (60s)
 
@@ -13,5 +13,5 @@ kvdb_create
 
 seconds=60
 
-kvs=$(kvs_create smoke-0) || $?
+kvs=$(kvs_create smoke-0)
 cmd kmt -i1000 "-t$seconds" -bcDOR -w0 "-j$(nproc)" -s1 "$home" "$kvs"

--- a/tests/functional/smoke/kmtw05.sh
+++ b/tests/functional/smoke/kmtw05.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: quick kvdb/cn performance test using kmt (60s, 5% writes)
 
@@ -14,6 +14,6 @@ kvdb_create
 w=5
 seconds=60
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 cmd kmt -i20m "-t$seconds" -bcDR -s1 "-w$w" "-j$(nproc)" "$home" "$kvs"

--- a/tests/functional/smoke/kmtw20.sh
+++ b/tests/functional/smoke/kmtw20.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: quick kvdb/cn performance test using kmt (60s, 20% writes)
 
@@ -14,6 +14,6 @@ kvdb_create
 w=20
 seconds=60
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 cmd kmt -i20m "-t$seconds" -bcDR -s1 "-w$w" "-j$(nproc)" "$home" "$kvs"

--- a/tests/functional/smoke/kmtw50.sh
+++ b/tests/functional/smoke/kmtw50.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: quick kvdb/cn performance test using kmt (60s, 50% writes)
 
@@ -14,6 +14,6 @@ kvdb_create
 w=50
 seconds=60
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 cmd kmt -i20m "-t$seconds" -bcDR -s1 "-w$w" "-j$(nproc)" "$home" "$kvs"

--- a/tests/functional/smoke/kvs-max.sh
+++ b/tests/functional/smoke/kvs-max.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: ensure we can create 256 KVSs
 
@@ -15,7 +15,7 @@ typeset -i i=256
 
 while (( i>0 )) ; do
     i=$((i-1))
-    kvs_create "kvs$i" || exit $?
+    kvs_create "kvs$i"
 done
 
 cmd kmt -i1k -t5 -cx -s1 "$home" "kvs$i"

--- a/tests/functional/smoke/kvsdrop.sh
+++ b/tests/functional/smoke/kvsdrop.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: test to verify kvs drop functionality, specifically testing the edge condition where the last transactions are completely removed.
 
@@ -13,8 +13,8 @@ kvdb_create
 
 keys=10
 
-kvs=$(kvs_create smoke-0) || exit $?
-kvs2=$(kvs_create smoke-1) || exit $?
+kvs=$(kvs_create smoke-0)
+kvs2=$(kvs_create smoke-1)
 
 cmd putbin "-c$keys" "$home" "$kvs"
 cmd putbin "-c$keys" "$home" "$kvs2"
@@ -23,7 +23,7 @@ cmd putbin "-c$keys" "$home" "$kvs2"
 cmd putbin -V "-c$keys" "$home" "$kvs"
 cmd putbin -V "-c$keys" "$home" "$kvs2"
 
-kvs_drop "$kvs2" || exit $?
+kvs_drop "$kvs2"
 
 # validate cndb and that cnid 1 keys exist
 cmd putbin -V "-c$keys" "$home" "$kvs"

--- a/tests/functional/smoke/large-values1.sh
+++ b/tests/functional/smoke/large-values1.sh
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 # This test depends on having 1MiB values in vblocks at offsets that are not
 # page-aligned.  Using a small number of value lengths make that a frequent

--- a/tests/functional/smoke/lcp_test.sh
+++ b/tests/functional/smoke/lcp_test.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 # Check cursor behaviour with corner cases.
 # Note that this test depends on the
@@ -14,7 +14,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 nkeys=1000
 

--- a/tests/functional/smoke/longtest-cursor.sh
+++ b/tests/functional/smoke/longtest-cursor.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: quick longtest focused on cn cursors
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 threads=4
 keys=100000

--- a/tests/functional/smoke/longtest-sync-cursor.sh
+++ b/tests/functional/smoke/longtest-sync-cursor.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: 60s longtest with sync with cursors
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 keys=$((1*1000*1000))
 threads=4

--- a/tests/functional/smoke/longtest-sync.sh
+++ b/tests/functional/smoke/longtest-sync.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: 60s longtest with sync without cursors
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 keys=$((1*1000*1000))
 threads=4

--- a/tests/functional/smoke/longtest60.sh
+++ b/tests/functional/smoke/longtest60.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: 60s longtest
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 keys=$((20*1000*1000))
 threads=$(nproc)

--- a/tests/functional/smoke/longtestc0.sh
+++ b/tests/functional/smoke/longtestc0.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: quick longtest focused on c0
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 threads=1
 keys=5000

--- a/tests/functional/smoke/longtestcn.sh
+++ b/tests/functional/smoke/longtestcn.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: quick longtest focused on cn
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 threads=4
 keys=100000

--- a/tests/functional/smoke/longtestcn2.sh
+++ b/tests/functional/smoke/longtestcn2.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: quick longtest focused on cn
 
@@ -11,8 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-# add 3 KVSes to the KVDB
-kvs=$(kvs_create smoke-1) || exit $?
+kvs=$(kvs_create smoke-0)
 
 threads=4
 keys=100000

--- a/tests/functional/smoke/longtestkvmax.sh
+++ b/tests/functional/smoke/longtestkvmax.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: quick longtest focused on key/val max
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 threads=4
 keys=100

--- a/tests/functional/smoke/prefix-basic.sh
+++ b/tests/functional/smoke/prefix-basic.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 # This test creates a small kvs in which all keys start with an "x"
 # (the primary prefix) followed by one of 13 secondary prefixes,
@@ -16,7 +16,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 typeset -i pfxmax=12
 typeset -i total=0

--- a/tests/functional/smoke/prefix-spill.sh
+++ b/tests/functional/smoke/prefix-spill.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: use putbin to spill and test get
 
@@ -12,9 +12,9 @@ trap kvdb_drop EXIT
 kvdb_create
 
 # add 3 KVSes to the KVDB
-kvs0=$(kvs_create smoke-0) || exit $?
-kvs1=$(kvs_create smoke-1 prefix.length=2) || exit $?
-kvs2=$(kvs_create smoke-2 prefix.length=3) || exit $?
+kvs0=$(kvs_create smoke-0)
+kvs1=$(kvs_create smoke-1 prefix.length=2)
+kvs2=$(kvs_create smoke-2 prefix.length=3)
 
 keys=70000
 

--- a/tests/functional/smoke/prefix-tree-shape1.sh
+++ b/tests/functional/smoke/prefix-tree-shape1.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 # Prefix trees switch from prefix spilling to full key spilling when
 # spilling from a level with at least 1024 nodes;
@@ -68,7 +68,7 @@ for fanout in 2 4 8 16; do
         *) exit 2;;
     esac
 
-    kvs=$(kvs_create smoke-"$fanout" prefix.length=4 fanout="$fanout") || exit $?
+    kvs=$(kvs_create smoke-"$fanout" prefix.length=4 fanout="$fanout")
 
 
     cmd kmt -j32 -f 'xxxx%016lx' "-l$vlen:$vlen" -s1 "-i$nkeys" "$home" "$kvs" "${oparms[@]}"

--- a/tests/functional/smoke/probe-test.sh
+++ b/tests/functional/smoke/probe-test.sh
@@ -11,7 +11,7 @@ kvdb_create
 
 # add a KVS to the KVDB
 # fanout=16 for a smaller pivot level
-kvs=$(kvs_create smoke-0 fanout=16 prefix.length=8 suffix.length=8) || exit $?
+kvs=$(kvs_create smoke-0 fanout=16 prefix.length=8 suffix.length=8)
 
 typeset -i p=100
 typeset -i c=50

--- a/tests/functional/smoke/ptree-test.sh
+++ b/tests/functional/smoke/ptree-test.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: test ptree semantics
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0 prefix.length=8) || exit $?
+kvs=$(kvs_create smoke-0 prefix.length=8)
 
 # Test 1: Should result in 2 kblocks
 keys=1300000

--- a/tests/functional/smoke/putget1.sh
+++ b/tests/functional/smoke/putget1.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: simple putgetdel test
 
@@ -12,6 +12,6 @@ trap kvdb_drop EXIT
 kvdb_create
 
 keys=10000
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 cmd putgetdel "$home" "$kvs" -c "$keys"

--- a/tests/functional/smoke/putget2.sh
+++ b/tests/functional/smoke/putget2.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: simple putgetdel test on a KVDB kvs
 
@@ -15,10 +15,10 @@ keys=10000
 t=4   #threads
 
 # add 4 KVSes to the KVDB
-kvs1=$(kvs_create smoke-1) || exit $?
-kvs2=$(kvs_create smoke-2) || exit $?
-kvs3=$(kvs_create smoke-3) || exit $?
-kvs4=$(kvs_create smoke-4) || exit $?
+kvs1=$(kvs_create smoke-0)
+kvs2=$(kvs_create smoke-1)
+kvs3=$(kvs_create smoke-2)
+kvs4=$(kvs_create smoke-3)
 
 kvs_list="$kvs1,$kvs2,$kvs3,$kvs4"
 

--- a/tests/functional/smoke/seqno_order.sh
+++ b/tests/functional/smoke/seqno_order.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 . common.subr
 
@@ -10,5 +10,5 @@ trap kvdb_drop EXIT
 kvdb_create
 
 # one thread does transactional PUTs while another periodically calls flush
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 cmd txput_flush "$home" "$kvs"

--- a/tests/functional/smoke/simple_client1.sh
+++ b/tests/functional/smoke/simple_client1.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: simple_client test
 
@@ -12,5 +12,5 @@ trap kvdb_drop EXIT
 kvdb_create
 
 keys=1000
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 cmd simple_client "$home" "$kvs" -c "$keys"

--- a/tests/functional/smoke/txn1.sh
+++ b/tests/functional/smoke/txn1.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: simple transaction test on a KVDB kvs
 
@@ -11,7 +11,7 @@
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs1=$(kvs_create smoke-0) || exit $?
+kvs1=$(kvs_create smoke-0)
 
 cmd ctxn_validation "$home" "$kvs1"
 cmd ctxn_validation -i7 "$home" "$kvs1"

--- a/tests/functional/smoke/txn_thrash.sh
+++ b/tests/functional/smoke/txn_thrash.sh
@@ -2,14 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 . common.subr
 
 trap kvdb_drop EXIT
 kvdb_create
 
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 # Single threaded large transaction
 cmd txn_thrash "$home" "$kvs" -j1 -c500000

--- a/tests/functional/smoke/zlenval1.sh
+++ b/tests/functional/smoke/zlenval1.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 #doc: use putgetdel to test zero-length values
 
@@ -12,7 +12,7 @@ trap kvdb_drop EXIT
 kvdb_create
 
 keys=100
-kvs=$(kvs_create smoke-0) || exit $?
+kvs=$(kvs_create smoke-0)
 
 # Six step test:
 # - Put keys with 0-byte values


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
