### PR TITLE
Update test-runner to account for java tests

### DIFF
--- a/tests/functional/cli/meson.build
+++ b/tests/functional/cli/meson.build
@@ -109,7 +109,7 @@ foreach t, params : tests
             hse_cli_symlink,
         ],
         env: environment({
-            'HSE_TEST_RUNNER_RUNNER': 'shell',
+            'HSE_TEST_RUNNER_RUNNER': 'bash',
         }),
         suite: ['functional', 'cli']
     )

--- a/tests/functional/smoke/meson.build
+++ b/tests/functional/smoke/meson.build
@@ -281,7 +281,7 @@ foreach t, params : tests
             params.get('depends', []),
         ],
         env: environment({
-            'HSE_TEST_RUNNER_RUNNER': 'shell',
+            'HSE_TEST_RUNNER_RUNNER': 'bash',
         })
     )
 endforeach

--- a/tests/test-runner
+++ b/tests/test-runner
@@ -33,12 +33,14 @@ class Test(abc.ABC):
 
         if runner is None:
             return PlainTest(program, *args)
-        elif runner == "shell":
-            return ShellTest(program, *args)
+        elif runner == "bash":
+            return BashTest(program, *args)
         elif runner == "python":
             return PythonTest(program, *args)
         elif runner == "pytest":
             return PytestTest(program, *args)
+        elif runner == "java":
+            return JavaTest(program, *args)
         else:
             raise NotImplementedError()
 
@@ -69,7 +71,7 @@ class PythonTest(Test):
         return [str(self._program), self._args[0], "-C", str(home), *self._args[1:]]
 
 
-class ShellTest(Test):
+class BashTest(Test):
     def __init__(self, program: pathlib.Path, *args: str) -> None:
         super().__init__(program, *args)
 
@@ -96,6 +98,22 @@ class PytestTest(Test):
 
     def command_line(self, home: str) -> List[str]:
         return [str(self._program), *self._args, "-C", str(home)]
+
+
+class JavaTest(Test):
+    def __init__(self, program: pathlib.Path, *args: str) -> None:
+        super().__init__(program, *args)
+
+    @property
+    def name(self) -> str:
+        for a in self._args:
+            if a.startswith("-Dtest=com.micron.hse."):
+                return a[len("-Dtest=com.micron.hse."):]
+
+        return "java"
+
+    def command_line(self, home: str) -> List[str]:
+        return [str(self._program), *self._args, f"-Dhome={home}"]
 
 
 class Args(argparse.Namespace):


### PR DESCRIPTION
This is a direct copy of the test-runner in the hse-java repo.

Signed-off-by: Tristan Partin <tpartin@micron.com>
