### PR TITLE
First cut route map API changes to support node split and join

### DIFF
--- a/lib/cn/cn_tree_internal.h
+++ b/lib/cn/cn_tree_internal.h
@@ -199,6 +199,7 @@ struct cn_tree_node {
     uint                 tn_cgen;
     struct list_head     tn_kvset_list; /* head = newest kvset */
     struct cn_tree *     tn_tree;
+    struct route_node   *tn_route_node;
     struct cn_tree_node *tn_parent;
     struct cn_tree_node *tn_childv[];
 };

--- a/lib/cn/route.h
+++ b/lib/cn/route.h
@@ -18,13 +18,14 @@ struct kvs_cparams;
 
 /**
  * struct route_node - tracks an edge key in the routing table
- * @rtn_node:    rb tree linkage
- * @rtn_refcnt:  reference count
- * @rtn_keylen:  edge key length
- * @rtn_tnode:   cn_tree_node pointer
- * @rtn_next:    ptr to the next route_node with larger edge key
- * @rtn_keybufp: ptr to the inline or an externally allocated edge key
- * @rtn_keybuf:  the edge key
+ * @rtn_node:     rb tree linkage
+ * @rtn_refcnt:   reference count
+ * @rtn_keylen:   edge key length
+ * @rtn_tnode:    cn_tree_node pointer
+ * @rtn_next:     ptr to the next route_node with larger edge key
+ * @rtn_keybufp:  ptr to the inline or an allocated edge key
+ * @rtn_keybufsz: size of the allocated edge key
+ * @rtn_keybuf:   the edge key
  *
  * Notes;
  *   1) rtn_tnode is currently used only to optimize tree-node lookups
@@ -42,7 +43,8 @@ struct route_node {
     bool               rtn_islast;
     void              *rtn_tnode;
     uint8_t           *rtn_keybufp;
-    uint8_t            rtn_keybuf[72];
+    size_t             rtn_keybufsz;
+    uint8_t            rtn_keybuf[64];
 };
 
 /*

--- a/lib/cn/route.h
+++ b/lib/cn/route.h
@@ -6,8 +6,6 @@
 #ifndef HSE_ROUTE_H
 #define HSE_ROUTE_H
 
-/* MTF_MOCK_DECL(route) */
-
 struct cn_tree;
 struct route_map;
 struct kvs_cparams;
@@ -20,19 +18,18 @@ struct kvs_cparams;
 
 /**
  * struct route_node - tracks an edge key in the routing table
- * @rtn_node:   rb tree linkage
- * @rtn_refcnt: reference count
- * @rtn_keylen: edge key length
- * @rtn_child:  index into tn_childv[]
- * @rtn_tnode:  cn_tree_node pointer
- * @rtn_next:   ptr to the next route_node with larger edge key
- * @rtn_keybuf: the edge key
+ * @rtn_node:    rb tree linkage
+ * @rtn_refcnt:  reference count
+ * @rtn_keylen:  edge key length
+ * @rtn_tnode:   cn_tree_node pointer
+ * @rtn_next:    ptr to the next route_node with larger edge key
+ * @rtn_keybufp: ptr to the inline or an externally allocated edge key
+ * @rtn_keybuf:  the edge key
  *
  * Notes;
- *   1) rtn_child will go away after we convert the tree-node array to a list
- *   2) rtn_tnode is currently used only to optimize tree-node lookups
- *   3) rtn_next will be NULL for the last route node (i.e., the rightmost edge)
- *   4) rtn_next is used for free list linkage when node is not in rb tree
+ *   1) rtn_tnode is currently used only to optimize tree-node lookups
+ *   2) rtn_next will be NULL for the last route node (i.e., the rightmost edge)
+ *   3) rtn_next is used for free list linkage when node is not in rb tree
  */
 struct route_node {
     union {
@@ -41,36 +38,58 @@ struct route_node {
     };
     atomic_uint        rtn_refcnt;
     uint16_t           rtn_keylen;
-    uint16_t           rtn_child;
     bool               rtn_isfirst;
     bool               rtn_islast;
     void              *rtn_tnode;
+    uint8_t           *rtn_keybufp;
     uint8_t            rtn_keybuf[72];
 };
 
-
-/**
- * route_map_lookup() - Return a node for which its edge key is greater than or equal to %pfx
- *
- * @map:    Route map handle
- * @pfx:    Prefix being looked up
- * @pfxlen: Length of %pfx
+/*
+ * TODO: The `nodeoff' parameter will be gone when we get rid of static routes
  */
 struct route_node *
-route_map_lookup(struct route_map *map, const void *pfx, uint pfxlen);
+route_map_insert(
+    struct route_map *map,
+    void             *tnode,
+    const void       *edge_key,
+    uint              edge_klen,
+    uint32_t          nodeoff);
+
+void
+route_map_delete(struct route_map *map, struct route_node *node);
 
 /**
- * route_map_lookupGT() - Return a node for which its edge key is strictly greater than %pfx
+ * route_map_lookup() - Return a node for which its edge key is greater than or equal to %key
  *
  * @map:    Route map handle
- * @pfx:    Prefix being looked up
- * @pfxlen: Length of %pfx
+ * @key:    Key being looked up
+ * @keylen: Length of %key
  */
 struct route_node *
-route_map_lookupGT(struct route_map *map, const void *pfx, uint pfxlen);
+route_map_lookup(struct route_map *map, const void *key, uint keylen);
+
+/**
+ * route_map_lookupGT() - Return a node for which its edge key is strictly greater than %key
+ *
+ * @map:    Route map handle
+ * @key:    Key being looked up
+ * @keylen: Length of %key
+ */
+struct route_node *
+route_map_lookupGT(struct route_map *map, const void *key, uint keylen);
 
 struct route_node *
-route_map_get(struct route_map *map, const void *pfx, uint pfxlen);
+route_map_get(struct route_map *map, const void *key, uint keylen);
+
+void
+route_map_put(struct route_map *map, struct route_node *node);
+
+struct route_map *
+route_map_create(const struct kvs_cparams *cp, const char *kvsname);
+
+void
+route_map_destroy(struct route_map *map);
 
 struct route_node *
 route_node_next(struct route_node *node);
@@ -100,25 +119,7 @@ static HSE_ALWAYS_INLINE void
 route_node_keycpy(struct route_node *node, void *kbuf, size_t kbuf_sz, uint *klen)
 {
     *klen = node->rtn_keylen;
-    memcpy(kbuf, node->rtn_keybuf, min_t(size_t, kbuf_sz, node->rtn_keylen));
+    memcpy(kbuf, node->rtn_keybufp, min_t(size_t, kbuf_sz, node->rtn_keylen));
 }
-
-void
-route_map_put(struct route_map *map, struct route_node *node);
-
-struct route_node *
-route_map_insert(struct route_map *map, struct route_node *node);
-
-/* MTF_MOCK */
-struct route_map *
-route_map_create(const struct kvs_cparams *cp, const char *kvsname, struct cn_tree *tree);
-
-/* MTF_MOCK */
-void
-route_map_destroy(struct route_map *map);
-
-#if HSE_MOCKING
-#include "route_ut.h"
-#endif /* HSE_MOCKING */
 
 #endif /* HSE_ROUTE_H */

--- a/lib/mpool/src/mpool.c
+++ b/lib/mpool/src/mpool.c
@@ -415,7 +415,7 @@ mpool_destroy(const char *home, const struct mpool_dparams *dparams)
     if (!home || !dparams)
         return merr(EINVAL);
 
-    mpdwq = alloc_workqueue("hse_mp_destroy", 0, 1, MP_DESTROY_THREADS);
+    mpdwq = alloc_workqueue("hse_mp_destroy", 0, MP_DESTROY_THREADS, MP_DESTROY_THREADS);
     ev(!mpdwq);
 
     for (int i = HSE_MCLASS_COUNT - 1; i >= HSE_MCLASS_BASE; i--) {

--- a/tests/unit/cn/route_test.c
+++ b/tests/unit/cn/route_test.c
@@ -1,0 +1,163 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2022 Micron Technology, Inc.  All rights reserved.
+ */
+
+#include <mtf/conditions.h>
+#include <mtf/framework.h>
+#include <mock/api.h>
+
+#include <hse_util/inttypes.h>
+
+#include <hse_ikvdb/cn.h>
+
+#include <cn/route.h>
+#include <cn/cn_tree_internal.h>
+
+MTF_BEGIN_UTEST_COLLECTION(route_test)
+
+MTF_DEFINE_UTEST(route_test, route_api_test)
+{
+    struct kvs_cparams cp = kvs_cparams_defaults();
+    const char *kvsname = "KVS-non-existent-routemap"; /* non-existent routemap file */
+    struct route_map *map;
+    struct cn_tree_node tn;
+    static const uint fanout = 16;
+    struct route_node *rnodev[2 * fanout], *rnode;
+    char ekbuf[2 * fanout][sizeof(rnode->rtn_keybuf)];
+    uint eklen = 5, idx;
+    char ekbuf_large[sizeof(rnode->rtn_keybuf) + 1];
+
+    cp.fanout = fanout;
+
+    map = route_map_create(NULL, kvsname);
+    ASSERT_EQ(NULL, map);
+
+    map = route_map_create(&cp, NULL);
+    ASSERT_EQ(NULL, map);
+
+    map = route_map_create(&cp, kvsname);
+    ASSERT_NE(NULL, map);
+
+    for (int i = 0; i < 2 * fanout; i++) {
+        uint64_t ekey;
+        uint skip = 1;
+        uint fmtarg = (i + 1) * skip - 1;
+
+        ekey = cpu_to_be64(fmtarg);
+        memcpy(ekbuf[i], (char *)&ekey + (sizeof(ekey) - eklen), eklen);
+    }
+
+    for (int i = 0; i < 2 * fanout; i++) {
+        char kbuf[sizeof(rnode->rtn_keybuf)];
+        uint klen;
+
+        /* Test both paths in route_node_key_set() */
+        if (i % 2) {
+            rnodev[i] = route_map_insert(map, &tn, NULL, 0, i);
+            ASSERT_NE(NULL, rnodev[i]);
+        } else {
+            rnodev[i] = route_map_insert(map, &tn, ekbuf[i], eklen, i);
+            ASSERT_NE(NULL, rnodev[i]);
+        }
+
+        ASSERT_EQ(true, route_node_isfirst(rnodev[0]));
+        ASSERT_EQ(true, route_node_islast(rnodev[i]));
+        if (i > 0) {
+            ASSERT_EQ(false, route_node_islast(rnodev[0]));
+            ASSERT_EQ(false, route_node_isfirst(rnodev[i]));
+        }
+
+        ASSERT_EQ(&tn, route_node_tnode(rnodev[i]));
+
+        route_node_keycpy(rnodev[i], kbuf, sizeof(rnode->rtn_keybuf), &klen);
+        ASSERT_EQ(0, memcmp(kbuf, ekbuf[i], eklen));
+        ASSERT_EQ(eklen, klen);
+    }
+
+    rnode = route_map_insert(map, &tn, NULL, 0, 0);
+    ASSERT_EQ(NULL, rnode);
+
+    rnode = route_map_insert(map, &tn, ekbuf[0], eklen, 0);
+    ASSERT_EQ(NULL, rnode);
+
+    /* Delete odd numbered nodes */
+    for (int i = 1; i < 2 * fanout; i += 2) {
+        rnode = route_map_lookup(map, ekbuf[i], eklen);
+        ASSERT_EQ(rnode, rnodev[i]);
+
+        route_map_delete(map, rnode);
+    }
+
+    /* Reinsert odd numbered nodes */
+    for (int i = 1; i < 2 * fanout; i += 2) {
+        rnodev[i] = route_map_insert(map, &tn, ekbuf[i], eklen, i);
+        ASSERT_NE(NULL, rnodev[i]);
+    }
+
+    /* Insert a node with large edge key when the node cache is empty */
+    memset(ekbuf_large, 0xff, sizeof(ekbuf_large));
+    rnode = route_map_insert(map, &tn, ekbuf_large, sizeof(ekbuf_large), 0);
+    ASSERT_NE(NULL, rnode);
+    route_map_delete(map, rnode);
+
+    rnode = route_map_get(map, ekbuf[0], eklen);
+    ASSERT_EQ(rnode, rnodev[0]);
+    route_map_put(map, rnode);
+
+    idx = 5;
+    rnode = route_map_lookup(map, ekbuf[idx], eklen); /* same as edge key */
+    ASSERT_EQ(rnode, rnodev[idx]);
+
+    ekbuf[idx][6] = 0xff;
+    rnode = route_map_lookup(map, ekbuf[idx], eklen + 1); /* longer than edge key */
+    ASSERT_EQ(rnode, rnodev[idx + 1]);
+
+    ekbuf[idx][7] = 0xff;
+    rnode = route_map_lookup(map, ekbuf[idx], eklen + 2);
+    ASSERT_EQ(rnode, rnodev[idx + 1]);
+
+    rnode = route_map_lookup(map, ekbuf[idx], eklen - 1); /* shorter than edge key */
+    ASSERT_EQ(rnode, rnodev[0]);
+
+    ekbuf[idx][eklen - 2] = 0xff;
+    rnode = route_map_lookup(map, ekbuf[idx], eklen - 1);
+    ASSERT_EQ(rnode, rnodev[2 * fanout - 1]);
+    ekbuf[idx][eklen - 2] = 0x00;
+
+    route_map_delete(NULL, rnodev[0]);
+    route_map_delete(map, NULL);
+
+    rnode = route_map_get(map, ekbuf[0], eklen);
+    ASSERT_EQ(rnode, rnodev[0]);
+    /* Intentionally skip put */
+
+    rnode = route_map_lookup(map, ekbuf[0], eklen);
+    ASSERT_EQ(route_node_next(rnode), rnodev[1]);
+    ASSERT_EQ(route_node_prev(rnode), NULL);
+
+    rnode = route_map_lookup(map, ekbuf[fanout - 1], eklen);
+    ASSERT_EQ(route_node_next(rnode), rnodev[fanout]);
+    ASSERT_EQ(route_node_prev(rnode), rnodev[fanout - 2]);
+
+    rnode = route_map_lookup(map, ekbuf[(2 * fanout) - 1], eklen);
+    ASSERT_EQ(route_node_next(rnode), NULL);
+    ASSERT_EQ(route_node_prev(rnode), rnodev[(2 * fanout) - 2]);
+
+    for (int i = 0; i < 2 * fanout; i++) {
+        route_map_delete(map, rnodev[i]);
+
+        if (i == 0)
+            route_map_put(map, rnodev[i]);
+    }
+
+    /* Insert a node with large edge key when the node cache is non-empty */
+    memset(ekbuf_large, 0xff, sizeof(ekbuf_large));
+    rnode = route_map_insert(map, &tn, ekbuf_large, sizeof(ekbuf_large), 0);
+    ASSERT_NE(NULL, rnode);
+    route_map_delete(map, rnode);
+
+    route_map_destroy(map);
+}
+
+MTF_END_UTEST_COLLECTION(route_test);

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -66,6 +66,7 @@ components = {
                 meson.current_source_dir() / 'cn/merge-test-cases',
             ],
         },
+        'route_test': {},
         'vblock_builder_test': {},
         'vblock_reader_test': {},
         'wbt_iterator_test': {


### PR DESCRIPTION
Signed-off-by: Nabeel M Mohamed <50154757+nabeelmmd@users.noreply.github.com>

- Support dynamic allocation of route map nodes
- Add route_map_delete() API
- Change cn_tree code to use route_map_insert()/delete() for adding/removing edges
- Add a route map unit test