### PR TITLE
Finish split key determination

### DIFF
--- a/lib/cn/hblock_builder.c
+++ b/lib/cn/hblock_builder.c
@@ -118,8 +118,8 @@ hbb_add_ptomb(
 
     assert(stats->nptombs > 0);
 
-    err = wbb_add_entry(bld->ptree, kobj, stats->nptombs, kmd, kmd_len, bld->max_size / PAGE_SIZE,
-        &bld->ptree_pgc, &added);
+    err = wbb_add_entry(bld->ptree, kobj, stats->nptombs, 0, kmd, kmd_len,
+        bld->max_size / PAGE_SIZE, &bld->ptree_pgc, &added);
 
     bld->nptombs += stats->nptombs;
 

--- a/lib/cn/kblock_builder.c
+++ b/lib/cn/kblock_builder.c
@@ -579,6 +579,7 @@ kblock_add_entry(
         kblk->wbtree,
         kobj,
         stats->nvals,
+        stats->tot_vlen,
         kmd,
         kmd_len,
         kblk->wbt_pgc + available_pgc(kblk),

--- a/lib/cn/node_split.c
+++ b/lib/cn/node_split.c
@@ -8,9 +8,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <hse_ikvdb/kvset_view.h>
 #include <hse_util/element_source.h>
 #include <hse_util/event_counter.h>
 #include <hse_util/hse_err.h>
+#include <hse_util/assert.h>
 #include <hse_util/keycmp.h>
 
 #include "cn_tree_internal.h"
@@ -18,28 +20,41 @@
 #include "kvset_internal.h"
 
 struct reverse_kblk_iterator {
-    struct kvset *oi_ks;
-    struct element_source oi_es;
-    bool oi_eof;
-    uint32_t oi_offset;
+    struct kvset *ks;
+    struct element_source es;
+    bool eof;
+    uint32_t offset;
+};
+
+struct forward_wbt_leaf_iterator {
+    struct kvset *ks;
+    struct element_source es;
+    bool eof;
+    struct {
+        uint32_t kblk_idx;
+        uint32_t leaf_idx;
+    } offset;
 };
 
 static bool
-next(struct element_source *source, void **data)
+reverse_kblk_iterator_next(struct element_source *source, void **data)
 {
-    struct reverse_kblk_iterator *iter = container_of(source, struct reverse_kblk_iterator, oi_es);
+    struct reverse_kblk_iterator *iter = container_of(source, struct reverse_kblk_iterator, es);
 
-    if (iter->oi_eof)
+    INVARIANT(source);
+    INVARIANT(data);
+
+    if (iter->eof)
         return false;
 
-    assert(iter->oi_offset > 0);
+    assert(iter->offset > 0);
 
-    *data = &iter->oi_ks->ks_kblks[--iter->oi_offset];
+    *data = &iter->ks->ks_kblks[--iter->offset];
 
-    if (iter->oi_offset == 0)
-        iter->oi_eof = true;
+    if (iter->offset == 0)
+        iter->eof = true;
 
-    return iter->oi_eof;
+    return true;
 }
 
 static merr_t
@@ -49,16 +64,19 @@ reverse_kblk_iterator_create(
 {
     struct reverse_kblk_iterator *tmp;
 
+    INVARIANT(ks);
+    INVARIANT(iter);
+
     *iter = NULL;
 
     tmp = calloc(1, sizeof(*tmp));
     if (ev(!tmp))
         return merr(ENOMEM);
 
-    tmp->oi_ks = ks;
+    tmp->ks = ks;
     /* Using prefix decrement in next, so this is fine */
-    tmp->oi_offset = ks->ks_st.kst_kblks;
-    tmp->oi_es = es_make(next, NULL, NULL);
+    tmp->offset = ks->ks_st.kst_kblks;
+    tmp->es = es_make(reverse_kblk_iterator_next, NULL, NULL);
 
     *iter = tmp;
 
@@ -76,28 +94,37 @@ kblk_compare(const void *const a, const void *const b)
 {
     const struct kvset_kblk *kblk_a = a, *kblk_b = b;
 
+    INVARIANT(a);
+    INVARIANT(b);
+
     /* Return the kblock with the largest min key. */
     return -1 * keycmp(kblk_a->kb_koff_min, kblk_a->kb_klen_min, kblk_b->kb_koff_min,
         kblk_b->kb_klen_min);
 }
 
-merr_t
-cn_tree_node_get_split_key(
+static merr_t
+find_inflection_point(
     const struct cn_tree_node *const node,
-    void *const key_buf,
-    const size_t key_buf_sz,
-    uint16_t *const key_len)
+    uint64_t *const seen_kvlen,
+    uint32_t *const offsets)
 {
     merr_t err;
     struct bin_heap2 *bh;
     struct kvset_list_entry *le;
     struct kvset_kblk *kblk;
-    struct reverse_kblk_iterator **iters = NULL;
-    struct element_source **srcs = NULL;
+    struct reverse_kblk_iterator **iters;
+    struct element_source **srcs;
+    void *buf = NULL;
+    uint64_t num_kvsets;
+    uint64_t total_kvlen = 0;
     uint64_t kvset_idx = 0;
-    uint64_t wlen = 0;
-    const uint64_t num_kvsets = cn_ns_kvsets(&node->tn_ns);
-    const uint64_t total_wlen = cn_ns_wlen(&node->tn_ns);
+    uint64_t kvlen = 0;
+
+    INVARIANT(node);
+    INVARIANT(seen_kvlen);
+    INVARIANT(offsets);
+
+    num_kvsets = cn_ns_kvsets(&node->tn_ns);
 
     err = bin_heap2_create(num_kvsets, kblk_compare, &bh);
     if (ev(err))
@@ -106,22 +133,28 @@ cn_tree_node_get_split_key(
     /* Forgive me for I have sinned; allocate all necessary memory for managing
      * iterators and element sources in one go.
      */
-    iters = calloc(1, sizeof(void *) * 2 * num_kvsets);
-    if (ev(!iters)) {
+    buf = calloc(1, sizeof(void *) * 2 * num_kvsets);
+    if (ev(!buf)) {
         err = merr(ENOMEM);
         goto out;
     }
 
-    srcs = (struct element_source **)(iters + num_kvsets);
+    iters = buf;
+    srcs = buf + num_kvsets * sizeof(*iters);
 
     list_for_each_entry(le, &node->tn_kvset_list, le_link) {
-        struct reverse_kblk_iterator *iter = *(iters + kvset_idx);
+        struct kvset_metrics metrics;
+        struct reverse_kblk_iterator *iter = iters[kvset_idx];
+
+        kvset_get_metrics(le->le_kvset, &metrics);
+
+        total_kvlen += metrics.tot_key_bytes + metrics.tot_val_bytes;
 
         err = reverse_kblk_iterator_create(le->le_kvset, &iter);
         if (err)
             goto out;
 
-        *(srcs + kvset_idx) = &iter->oi_es;
+        srcs[kvset_idx] = &iter->es;
 
         kvset_idx++;
     }
@@ -133,27 +166,227 @@ cn_tree_node_get_split_key(
         goto out;
 
     while (bin_heap2_pop(bh, (void **)&kblk)) {
-        wlen += kblk->kb_metrics.tot_key_bytes + kblk->kb_metrics.tot_val_bytes;
-        if (wlen >= total_wlen / 2)
+        kvlen += kblk->kb_metrics.tot_key_bytes + kblk->kb_metrics.tot_val_bytes;
+        if (kvlen >= total_kvlen / 2)
             break;
     }
 
-    if (key_buf) {
-        const size_t copy_len = kblk->kb_klen_min < key_buf_sz ? kblk->kb_klen_min : key_buf_sz;
+    *seen_kvlen = kvlen;
 
-        memcpy(key_buf, kblk->kb_koff_min, copy_len);
-    }
-    if (key_len)
-        *key_len = kblk->kb_klen_min;
+    /* Gather the offsets we ended at for each kvset. These will seed the
+     * starting positions of the element sources in the next bin heap.
+     */
+    for (uint64_t i = 0; i < num_kvsets; i++)
+        offsets[i] = iters[i]->offset;
 
 out:
-    if (iters) {
+    if (buf) {
         for (uint64_t i = 0; i < num_kvsets; i++)
-            reverse_kblk_iterator_destroy(*(iters + i));
+            reverse_kblk_iterator_destroy(iters[i]);
     }
 
-    free(iters);
+    free(buf);
     bin_heap2_destroy(bh);
 
+    return err;
+}
+
+static bool
+forward_wbt_leaf_iterator_next(struct element_source *source, void **data)
+{
+    struct kvset_kblk *kblk;
+    struct wbt_desc *desc;
+    struct forward_wbt_leaf_iterator *iter = container_of(source, struct forward_wbt_leaf_iterator, es);
+
+    INVARIANT(source);
+    INVARIANT(data);
+
+    if (iter->eof)
+        return false;
+
+    assert(iter->offset.kblk_idx < iter->ks->ks_st.kst_kblks);
+
+    kblk = &iter->ks->ks_kblks[iter->offset.kblk_idx];
+    desc = &kblk->kb_wbt_desc;
+
+    assert(iter->offset.leaf_idx < desc->wbd_leaf_cnt);
+
+    *data = kblk->kb_kblk_desc.map_base + PAGE_SIZE *
+        (desc->wbd_first_page + iter->offset.leaf_idx);
+
+    assert(((struct wbt_node_hdr_omf *)(*data))->wbn_magic == WBT_LFE_NODE_MAGIC);
+
+    if (iter->offset.leaf_idx == desc->wbd_leaf_cnt) {
+        iter->offset.kblk_idx++;
+        if (iter->offset.kblk_idx == iter->ks->ks_st.kst_kblks)
+            iter->eof = true;
+    }
+
+    return true;
+}
+
+static merr_t
+forward_wbt_leaf_iterator_create(
+    struct kvset *const ks,
+    const uint32_t kblk_idx,
+    struct forward_wbt_leaf_iterator **const iter)
+{
+    struct forward_wbt_leaf_iterator *tmp;
+
+    INVARIANT(ks);
+    INVARIANT(iter);
+
+    *iter = NULL;
+
+    tmp = calloc(1, sizeof(*tmp));
+    if (ev(!tmp))
+        return merr(ENOMEM);
+
+    tmp->ks = ks;
+    /* Using prefix decrement in next, so this is fine */
+    tmp->offset.kblk_idx = kblk_idx;
+    tmp->es = es_make(forward_wbt_leaf_iterator_next, NULL, NULL);
+
+    *iter = tmp;
+
     return 0;
+}
+
+static void
+forward_wbt_leaf_iterator_destroy(struct forward_wbt_leaf_iterator *const iter)
+{
+    free(iter);
+}
+
+static merr_t
+find_split_key(
+    const struct cn_tree_node *const node,
+    uint64_t seen_kvlen,
+    const uint32_t *const offsets,
+    void *const key_buf,
+    const size_t key_buf_sz,
+    unsigned int *const key_len)
+{
+    merr_t err;
+    struct bin_heap2 *bh;
+    struct kvset_list_entry *le;
+    uint64_t num_kvsets;
+    struct forward_wbt_leaf_iterator **iters;
+    struct element_source **srcs;
+    struct wbt_node_hdr_omf *leaf;
+    const struct wbt_lfe_omf *lfe;
+    struct key_obj key;
+    void *buf = NULL;
+    uint64_t total_kvlen = 0;
+    uint64_t kvset_idx = 0;
+    uint16_t len = 0;
+
+    INVARIANT(node);
+    INVARIANT(offsets);
+
+    num_kvsets = cn_ns_kvsets(&node->tn_ns);
+
+    assert(seen_kvlen >= total_kvlen / 2);
+
+    err = bin_heap2_create(num_kvsets, kblk_compare, &bh);
+    if (ev(err))
+        return err;
+
+    /* Forgive me for I have sinned; allocate all necessary memory for managing
+     * iterators and element sources in one go.
+     */
+    buf = calloc(1, sizeof(void *) * 2 * num_kvsets);
+    if (ev(!buf)) {
+        err = merr(ENOMEM);
+        goto out;
+    }
+
+    iters = buf;
+    srcs = buf + num_kvsets * sizeof(*iters);
+
+    list_for_each_entry(le, &node->tn_kvset_list, le_link) {
+        struct kvset_metrics metrics;
+        struct forward_wbt_leaf_iterator *iter = iters[kvset_idx];
+
+        kvset_get_metrics(le->le_kvset, &metrics);
+
+        total_kvlen += metrics.tot_key_bytes + metrics.tot_val_bytes;
+
+        err = forward_wbt_leaf_iterator_create(le->le_kvset, offsets[kvset_idx], &iter);
+        if (err)
+            goto out;
+
+        srcs[kvset_idx] = &iter->es;
+
+        kvset_idx++;
+    }
+
+    assert(kvset_idx == num_kvsets);
+
+    err = bin_heap2_prepare(bh, num_kvsets, srcs);
+    if (ev(err))
+        goto out;
+
+    while (bin_heap2_pop(bh, (void **)&leaf)) {
+        seen_kvlen -= leaf->wbn_kvlen;
+        if (seen_kvlen <= total_kvlen / 2)
+            break;
+    }
+
+    assert(leaf->wbn_num_keys > 0);
+
+    /* Get first leaf node entry */
+    lfe = (void *)(leaf + 1) + leaf->wbn_pfx_len;
+
+    assert(len <= HSE_KVS_KEY_LEN_MAX);
+
+    key.ko_pfx = leaf + 1;
+    key.ko_pfx_len = leaf->wbn_pfx_len;
+    key.ko_sfx = (void *)leaf + lfe->lfe_koff;
+    key.ko_sfx_len = WBT_NODE_SIZE - lfe->lfe_koff;
+
+    if (key_buf)
+        key_obj_copy(key_buf, key_buf_sz, key_len, &key);
+    if (key_len)
+        *key_len = len;
+
+out:
+    if (buf) {
+        for (uint64_t i = 0; i < num_kvsets; i++)
+            forward_wbt_leaf_iterator_destroy(iters[i]);
+    }
+
+    free(buf);
+    bin_heap2_destroy(bh);
+
+    return err;
+}
+
+merr_t
+cn_tree_node_get_split_key(
+    const struct cn_tree_node *const node,
+    void *const key_buf,
+    const size_t key_buf_sz,
+    unsigned int *const key_len)
+{
+    merr_t err;
+    uint64_t kvlen = 0;
+    uint32_t *offsets = NULL;
+
+    offsets = malloc(cn_ns_kvsets(&node->tn_ns) * sizeof(*offsets));
+    if (ev(!offsets))
+        return merr(ENOMEM);
+
+    err = find_inflection_point(node, &kvlen, offsets);
+    if (err)
+        goto out;
+
+    err = find_split_key(node, kvlen, offsets, key_buf, key_buf_sz, key_len);
+    if (err)
+        goto out;
+
+out:
+    free(offsets);
+
+    return err;
 }

--- a/lib/cn/node_split.h
+++ b/lib/cn/node_split.h
@@ -33,6 +33,6 @@ cn_tree_node_get_split_key(
     const struct cn_tree_node *node,
     void *key_buf,
     size_t key_buf_sz,
-    uint16_t *key_len) HSE_NONNULL(1);
+    unsigned int *key_len) HSE_NONNULL(1);
 
 #endif

--- a/lib/cn/omf.h
+++ b/lib/cn/omf.h
@@ -61,6 +61,7 @@ struct wbt_node_hdr_omf {
     uint16_t wbn_magic;    /* magic number, distinguishes INEs from LFEs */
     uint16_t wbn_num_keys; /* number of keys in node */
     uint32_t wbn_kmd;      /* offset in kmd region to this node's kmd */
+    uint64_t wbn_kvlen;    /* total key and value data referenced by this node */
     uint16_t wbn_pfx_len;  /* length of the longest common prefix */
     uint16_t wbn_padding;  /* unused padding */
 } HSE_PACKED;
@@ -68,6 +69,7 @@ struct wbt_node_hdr_omf {
 OMF_SETGET(struct wbt_node_hdr_omf, wbn_magic, 16)
 OMF_SETGET(struct wbt_node_hdr_omf, wbn_num_keys, 16)
 OMF_SETGET(struct wbt_node_hdr_omf, wbn_kmd, 32)
+OMF_SETGET(struct wbt_node_hdr_omf, wbn_kvlen, 64)
 OMF_SETGET(struct wbt_node_hdr_omf, wbn_pfx_len, 16)
 
 /* WBT internal node entry (v6) */

--- a/lib/cn/wbt_builder.h
+++ b/lib/cn/wbt_builder.h
@@ -43,6 +43,8 @@ wbb_entries(struct wbb *wbb);
  * wbb_add_entry() - add an entry to a wbtree
  * @wbb: builder handle
  * @kobj: key to be added
+ * @nvals: number of values
+ * @vlen: Total length of all the values
  * @key_kmd, @key_kmd_len: encoded key metadata
  * @max_pgc: (in) max allowable size of wbtree in pages
  * @wbt_pgc: (in/out) actual size (in pages) of wbtree creation
@@ -59,6 +61,7 @@ wbb_add_entry(
     struct wbb *          wbb,
     const struct key_obj *kobj,
     uint                  nvals,
+    uint64_t              vlen,
     const void *          key_kmd,
     uint                  key_kmd_len,
     uint                  max_pgc,

--- a/tests/unit/cn/wbt_test.c
+++ b/tests/unit/cn/wbt_test.c
@@ -160,7 +160,7 @@ tree_construct(struct mtf_test_info *lcl_ti, void **tree_out, struct wbt_hdr_omf
 
         /* [HSE_REVISIT] mapi break initialization of added.
          */
-        wbb_add_entry(wbb, &ko, 1, kmd, kmd_used, max_pgc, &wbt_pgc, &added);
+        err = wbb_add_entry(wbb, &ko, 1, 0, kmd, kmd_used, max_pgc, &wbt_pgc, &added);
         ASSERT_TRUE_RET(added, 1);
         kmd_used = 0;
         k = key_iter_next(k);
@@ -510,7 +510,7 @@ MTF_DEFINE_UTEST_PREPOST(wbt_test, small_last_key, pre_test, post_test)
 {
     int              i, rc;
     char             buf[HSE_KVS_KEY_LEN_MAX];
-    size_t           nkeys = 3000;
+    size_t           nkeys = 2000;
     size_t           large_klen = HSE_KVS_KEY_LEN_MAX;
     const int        keys_per_node = 4;
     struct key_list *ql = &key_list; /* query list */


### PR DESCRIPTION
Once we have found the kblock where we pass the 50% mark, we take all
the reverse kblock iterator offsets to create new forward leaf
iterators, where we march forward until we pass the 50% mark again. When
that point is reached, return the first key of that leaf node to the
caller.

Signed-off-by: Tristan Partin <tpartin@micron.com>
