### PR TITLE
Restrict permissions in CI workflows

### DIFF
--- a/.github/workflows/abicheck.ignore.yaml
+++ b/.github/workflows/abicheck.ignore.yaml
@@ -14,6 +14,8 @@ on:
       - .shellcheckrc
       - LICENSE
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/abicheck.yaml
+++ b/.github/workflows/abicheck.yaml
@@ -16,6 +16,8 @@ on:
       - .shellcheckrc
       - LICENSE
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/builds.ignore.yaml
+++ b/.github/workflows/builds.ignore.yaml
@@ -30,6 +30,8 @@ on:
       - .shellcheckrc
       - LICENSE
 
+permissions: {}
+
 jobs:
   ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -30,6 +30,8 @@ on:
       - .shellcheckrc
       - LICENSE
 
+permissions: {}
+
 env:
   MESON_TESTTHREADS: 1
 

--- a/.github/workflows/checkoss.yaml
+++ b/.github/workflows/checkoss.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.ignore.yaml
+++ b/.github/workflows/docs.ignore.yaml
@@ -6,7 +6,10 @@ on:
     paths-ignore:
       - "docs/**"
       - "include/**/*.h"
+      - "include/**/*.h.in"
       - .github/workflows/docs.yml
+
+permissions: {}
 
 jobs:
   docs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,10 @@ on:
     paths:
       - "docs/**"
       - "include/**/*.h"
+      - "include/**/*.h.in"
       - .github/workflows/docs.yaml
+
+permissions: {}
 
 jobs:
   docs:

--- a/.github/workflows/nightly_testing.yaml
+++ b/.github/workflows/nightly_testing.yaml
@@ -8,6 +8,8 @@ on:
         required: true
         default: "master"
 
+permissions: {}
+
 env:
   MESON_TESTTHREADS: 1
 

--- a/.github/workflows/shellcheck.ignore.yaml
+++ b/.github/workflows/shellcheck.ignore.yaml
@@ -9,6 +9,8 @@ on:
       - .github/workflows/shellcheck.yaml
       - .shellcheckrc
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -9,6 +9,8 @@ on:
       - .github/workflows/shellcheck.yaml
       - .shellcheckrc
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Best practices indicate that we should be restrictive by default in what
the GITHUB_TOKEN defined in our CI workflows is allowed to do.

Signed-off-by: Tristan Partin <tpartin@micron.com>
