### PR TITLE
Precursor cleanup for kvset split

### DIFF
--- a/lib/c0/c0_ingest_work.h
+++ b/lib/c0/c0_ingest_work.h
@@ -47,6 +47,7 @@ struct c0_ingest_work {
     struct element_source   *c0iw_lc_sourcev[LC_SOURCE_CNT_MAX];
     struct kvset_builder    *c0iw_bldrs[HSE_KVS_COUNT_MAX];
     struct kvset_mblocks     c0iw_mblocks[HSE_KVS_COUNT_MAX];
+    uint64_t                 c0iw_kvsetidv[HSE_KVS_COUNT_MAX];
     struct c0_kvmultiset    *c0iw_c0kvms;
     u32                      c0iw_kvms_iterc;
     u32                      c0iw_lc_iterc;

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -65,8 +65,6 @@
 #include "cn_perfc.h"
 #include "kvset_internal.h"
 
-#define VMA_SIZE_MAX 30
-
 struct tbkt;
 struct mclass_policy;
 
@@ -1447,22 +1445,6 @@ u64
 cn_mpool_dev_zone_alloc_unit_default(struct cn *cn, enum hse_mclass mclass)
 {
     return cn->cn_mpool_props.mclass[mclass].mc_mblocksz;
-}
-
-/*
- * [HSE_REVISIT]: Fix the callers to pass a correct mclass rather than blindly
- * passing HSE_MCLASS_CAPACITY. For now, assume a default mblock size of 32MiB
- * for all the media classes. This needs to be fixed in future when we want
- * KVDB to operate on media classes with varying mblock sizes.
- */
-u64
-cn_vma_mblock_max(struct cn *cn)
-{
-    u64 vma_size_max;
-
-    vma_size_max = 1ul << VMA_SIZE_MAX;
-
-    return vma_size_max / MPOOL_MBLOCK_SIZE_DEFAULT;
 }
 
 #if HSE_MOCKING

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -349,14 +349,14 @@ cn_tree_destroy(struct cn_tree *tree)
 void
 cn_tree_setup(
     struct cn_tree *    tree,
-    struct mpool *      ds,
+    struct mpool *      mp,
     struct cn *         cn,
     struct kvs_rparams *rp,
     struct cndb *       cndb,
     u64                 cnid,
     struct cn_kvdb *    cn_kvdb)
 {
-    tree->ds = ds;
+    tree->mp = mp;
     tree->cn = cn;
     tree->rp = rp;
     tree->cndb = cndb;
@@ -377,9 +377,9 @@ cn_tree_get_cnkvdb(const struct cn_tree *tree)
 }
 
 struct mpool *
-cn_tree_get_ds(const struct cn_tree *tree)
+cn_tree_get_mp(const struct cn_tree *tree)
 {
-    return tree->ds;
+    return tree->mp;
 }
 
 struct kvs_rparams *

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1370,18 +1370,15 @@ cn_tree_prepare_compaction(struct cn_compaction_work *w)
         n_outs = 1;
 
     ins = calloc(w->cw_kvset_cnt, sizeof(*ins));
-    outs = calloc(n_outs, sizeof(*outs));
-
+    outs = calloc(n_outs, sizeof(*outs) + sizeof(*(w->cw_kvsetidv)) +
+                                                 sizeof(w->cw_output_nodev[0]));
     if (ev(!ins || !outs)) {
         err = merr(ENOMEM);
         goto err_exit;
     }
 
-    w->cw_output_nodev = calloc(n_outs, sizeof(w->cw_output_nodev[0]));
-    if (!w->cw_output_nodev) {
-        err = merr(ENOMEM);
-        goto err_exit;
-    }
+    w->cw_kvsetidv = (void *)(outs + n_outs);
+    w->cw_output_nodev = (void *)(w->cw_kvsetidv + n_outs);
 
     vra_wq = cn_get_maint_wq(node->tn_tree->cn);
 
@@ -1446,7 +1443,6 @@ err_exit:
         free(vbm.vbm_blkv);
     }
     free(outs);
-    free(w->cw_output_nodev);
 
     return err;
 }
@@ -1714,7 +1710,6 @@ cn_comp_commit(struct cn_compaction_work *w)
 
     for (i = 0; i < w->cw_outc; i++) {
         struct kvset_meta km = {};
-        uint64_t kvsetid;
         uint64_t nodeid;
         uint ncommitted;
 
@@ -1766,11 +1761,9 @@ cn_comp_commit(struct cn_compaction_work *w)
 
         /* CNDB: Log kvset add records.
          */
-        kvsetid = cndb_kvsetid_mint(w->cw_tree->cndb);
-
         w->cw_err = cndb_record_kvset_add(
                         w->cw_tree->cndb, w->cw_cndb_txn, w->cw_tree->cnid,
-                        nodeid, &km, kvsetid, km.km_hblk.bk_blkid,
+                        nodeid, &km, w->cw_kvsetidv[i], km.km_hblk.bk_blkid,
                         w->cw_outv[i].kblks.n_blks, (uint64_t *)w->cw_outv[i].kblks.blks,
                         w->cw_outv[i].vblks.n_blks, (uint64_t *)w->cw_outv[i].vblks.blks,
                         &cookiev[i]);
@@ -1790,10 +1783,10 @@ cn_comp_commit(struct cn_compaction_work *w)
         w->cw_commitc += ncommitted;
 
         if (use_mbsets) {
-            w->cw_err = kvset_create2(w->cw_tree, kvsetid, &km,
+            w->cw_err = kvset_create2(w->cw_tree, w->cw_kvsetidv[i], &km,
                                       w->cw_kvset_cnt, cnts, vecs, &kvsets[i]);
         } else {
-            w->cw_err = kvset_create(w->cw_tree, kvsetid, &km, &kvsets[i]);
+            w->cw_err = kvset_create(w->cw_tree, w->cw_kvsetidv[i], &km, &kvsets[i]);
         }
 
         if (ev(w->cw_err))
@@ -1886,7 +1879,6 @@ cn_comp_cleanup(struct cn_compaction_work *w)
 
     free(w->cw_vbmap.vbm_blkv);
     free(w->cw_cookie);
-    free(w->cw_output_nodev);
     if (w->cw_outv) {
         for (i = 0; i < w->cw_outc; i++) {
             blk_list_free(&w->cw_outv[i].kblks);

--- a/lib/cn/cn_tree.h
+++ b/lib/cn/cn_tree.h
@@ -91,6 +91,7 @@ cn_tree_get_mp(const struct cn_tree *tree);
 struct kvs_rparams *
 cn_tree_get_rp(const struct cn_tree *tree);
 
+/* MTF_MOCK */
 struct cndb *
 cn_tree_get_cndb(const struct cn_tree *tree);
 

--- a/lib/cn/cn_tree.h
+++ b/lib/cn/cn_tree.h
@@ -86,7 +86,7 @@ struct cn_kvdb *
 cn_tree_get_cnkvdb(const struct cn_tree *tree);
 
 struct mpool *
-cn_tree_get_ds(const struct cn_tree *tree);
+cn_tree_get_mp(const struct cn_tree *tree);
 
 struct kvs_rparams *
 cn_tree_get_rp(const struct cn_tree *tree);

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -218,6 +218,7 @@ struct cn_compaction_work {
     uint                  cw_level;
     uint                  cw_outc;
     bool                  cw_drop_tombs;
+    uint64_t             *cw_kvsetidv;
     struct kvset_mblocks *cw_outv;
     struct kv_iterator ** cw_inputv;
     struct kvset_vblk_map cw_vbmap;
@@ -228,7 +229,6 @@ struct cn_compaction_work {
     uint                  cw_commitc;
     bool                  cw_keep_vblks;
     void                **cw_cookie;
-    struct kvset_builder *cw_child[CN_FANOUT_MAX];
 
     /* used in cleanup if debug enabled */
     u64  cw_t0_enqueue;

--- a/lib/cn/cn_tree_create.h
+++ b/lib/cn/cn_tree_create.h
@@ -53,7 +53,7 @@ cn_tree_destroy(struct cn_tree *tree);
 /**
  * cn_tree_setup() - Initialize cn tree with resources.
  * @tree: tree created with cn_tree_create()
- * @ds:   dataset
+ * @mp:   mpool
  * @cn:   cn handle
  * @rp:   runtime parameters
  * @cndb: cndb handle
@@ -63,7 +63,7 @@ cn_tree_destroy(struct cn_tree *tree);
 void
 cn_tree_setup(
     struct cn_tree *    tree,
-    struct mpool *      ds,
+    struct mpool *      mp,
     struct cn *         cn,
     struct kvs_rparams *rp,
     struct cndb *       cndb,

--- a/lib/cn/cn_tree_internal.h
+++ b/lib/cn/cn_tree_internal.h
@@ -98,7 +98,7 @@ struct cn_tree {
     u16                  ct_sfx_len;
     bool                 ct_nospace;
     struct cn *          cn;
-    struct mpool *       ds;
+    struct mpool *       mp;
     struct kvs_rparams * rp;
 
     struct route_map  *ct_route_map;

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -616,7 +616,7 @@ sp3_work(
 
     w->cw_node = tn;
     w->cw_tree = tn->tn_tree;
-    w->cw_ds = tn->tn_tree->ds;
+    w->cw_ds = tn->tn_tree->mp;
     w->cw_rp = tn->tn_tree->rp;
     w->cw_cp = tn->tn_tree->ct_cp;
     w->cw_pfx_len = tn->tn_tree->ct_cp->pfx_len;

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -200,14 +200,6 @@ kvset_madvise_capped(struct kvset *kvset, int advice);
 void
 kvset_madvise_vmaps(struct kvset *kvset, int advice);
 
-/**
- * kvset_purge_vmaps() - Purge kvset vblock mcache map
- * @kvset:    kvset pointer
- */
-/* MTF_MOCK */
-void
-kvset_purge_vmaps(struct kvset *kvset);
-
 /* MTF_MOCK */
 merr_t
 kvset_create2(

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -71,7 +71,7 @@ struct kvset {
     struct kvset_list_entry ks_entry; /* kvset list linkage */
 
     u64           ks_dgen; /* relative age of entries */
-    struct mpool *ks_ds;
+    struct mpool *ks_mp;
     u32           ks_pfx_len; /* cn tree pfx_len */
     u32           ks_sfx_len; /* cn tree sfx_len */
     u16           ks_node_level;
@@ -110,7 +110,7 @@ struct kvset {
     struct mpool_mcache_map *ks_hmap; /* hblock mcache map */
 
     const u8 *                ks_klarge; /* large key cache */
-    struct mpool_mcache_map **ks_kmapv;
+    struct mpool_mcache_map  *ks_kmap;
     struct mbset **           ks_vbsetv;
     uint                      ks_vbsetc;
 

--- a/lib/cn/vblock_reader.c
+++ b/lib/cn/vblock_reader.c
@@ -74,7 +74,7 @@ vbr_desc_update(
     u64  vgroup = vblk_desc->vbd_vgroup;
     uint i;
 
-    /* Map omf vgroup IDs (i.e., dgens) to a monotonically increasing
+    /* Map omf vgroup IDs (i.e., kvset ids) to a monotonically increasing
      * sequence starting from 1.  The resulting packed indices are
      * used by vbr_readahead() to minimize history table collisions.
      */

--- a/lib/include/hse_ikvdb/cn.h
+++ b/lib/include/hse_ikvdb/cn.h
@@ -222,10 +222,6 @@ cn_get_flags(const struct cn *handle);
 
 /* MTF_MOCK */
 u64
-cn_vma_mblock_max(struct cn *cn);
-
-/* MTF_MOCK */
-u64
 cn_mpool_dev_zone_alloc_unit_default(struct cn *cn, enum hse_mclass mclass);
 
 #if HSE_MOCKING

--- a/lib/include/hse_ikvdb/cn.h
+++ b/lib/include/hse_ikvdb/cn.h
@@ -143,6 +143,7 @@ merr_t
 cn_ingestv(
     struct cn **           cn,
     struct kvset_mblocks **mbv,
+    uint64_t              *kvsetidv,
     uint                   ingestc,
     u64                    ingestid,
     u64                    txhorizon,

--- a/tests/functional/smoke/kbdump.sh
+++ b/tests/functional/smoke/kbdump.sh
@@ -23,6 +23,6 @@ keys=1000
 kvs=$(kvs_create smoke-0)
 cmd simple_client "$home" "$kvs" -c "$keys" -v
 
-kbid=$(cn_metrics "$home" "$kvs" | awk '$1 == "k" {print $21}')
+kbid=$(cn_metrics "$home" "$kvs" | awk '$1 == "k" {print $22}')
 cmd cn_kbdump -w "$home" "$home/capacity" "${kbid}" "${kbid}"
 cmd cn_kbdump -r "$home/K000.${kbid}.gz"

--- a/tests/mocks/repository/lib/mock_kvset.c
+++ b/tests/mocks/repository/lib/mock_kvset.c
@@ -113,7 +113,7 @@ _make_common(
     merr_t                   err;
 
     memset(&tree, 0, sizeof(tree));
-    tree.ds = ds;
+    tree.mp = ds;
 
     err = kvset_create(&tree, 0, km, &kvset);
     if (err)
@@ -261,7 +261,7 @@ _kvset_create(struct cn_tree *tree, u64 tag, struct kvset_meta *km, struct kvset
     mk->stats.kst_vulen = km->km_vused;
 
     mk->dgen = km->km_dgen;
-    mk->iter_data = tree->ds;
+    mk->iter_data = tree->mp;
     mk->ref = 1; /* as in reality, kvsets are minted ref 1 */
 
     mk->ids[i++] = km->km_hblk.bk_blkid;

--- a/tests/unit/c0/c0sk_test.c
+++ b/tests/unit/c0/c0sk_test.c
@@ -20,6 +20,7 @@
 #include <hse_ikvdb/cursor.h>
 #include <hse_ikvdb/throttle.h>
 #include <hse_ikvdb/kvdb_rparams.h>
+#include <hse_ikvdb/cndb.h>
 
 #include "cn_mock.h"
 #include <tools/key_generation.h>
@@ -90,6 +91,7 @@ static struct mapi_injection inject_list[] = {
     { mapi_idx_kvset_builder_add_vref, MAPI_RC_SCALAR, 0},
     { mapi_idx_kvset_builder_destroy, MAPI_RC_SCALAR, 0},
     { mapi_idx_kvset_mblocks_destroy, MAPI_RC_SCALAR, 0},
+    { mapi_idx_cndb_kvsetid_mint, MAPI_RC_SCALAR, 1},
     { -1 }
 };
 

--- a/tests/unit/c0/cn_mock.c
+++ b/tests/unit/c0/cn_mock.c
@@ -57,6 +57,7 @@ merr_t
 _cn_ingestv(
     struct cn **           cn,
     struct kvset_mblocks **mbv,
+    uint64_t              *kvsetidv,
     uint                   ingestc,
     u64                    ingestid,
     u64                    txhorizon,

--- a/tests/unit/cn/cn_ingest_test.c
+++ b/tests/unit/cn/cn_ingest_test.c
@@ -240,6 +240,7 @@ MTF_DEFINE_UTEST_PRE(cn_ingest_test, worker, test_pre)
     struct cn *           cnv[1] = { &cn };
     struct kvset_mblocks *mbv[1] = { &m[0] };
     struct kvs_cparams    cp;
+    uint64_t kvsetidv[1] = { 1 };
 
     rp = kvs_rparams_defaults();
     cn.rp = &rp;
@@ -255,7 +256,7 @@ MTF_DEFINE_UTEST_PRE(cn_ingest_test, worker, test_pre)
     /* The kblocks contain no keys, so the ingest should fail.
      */
     init_mblks(m, n_kvsets, &k, &v);
-    err = cn_ingestv(cnv, mbv, NELEM(cnv), U64_MAX, U64_MAX, NULL, NULL);
+    err = cn_ingestv(cnv, mbv, kvsetidv, NELEM(cnv), U64_MAX, U64_MAX, NULL, NULL);
     ASSERT_NE(0, err);
     free_mblks(m, n_kvsets);
 
@@ -275,6 +276,7 @@ MTF_DEFINE_UTEST_PRE(cn_ingest_test, fail_cleanup, test_pre)
 
     struct cn *           cnv[1] = { &cn };
     struct kvset_mblocks *mbv[1] = { &m[0] };
+    uint64_t kvsetidv[1] = { 1 };
 
     rp = kvs_rparams_defaults();
     cn.rp = &rp;
@@ -290,7 +292,7 @@ MTF_DEFINE_UTEST_PRE(cn_ingest_test, fail_cleanup, test_pre)
     /* kvset create failure */
     init_mblks(m, n_kvsets, &k, &v);
     mapi_inject(mapi_idx_kvset_create, merr(EBADF));
-    err = cn_ingestv(cnv, mbv, NELEM(cnv), U64_MAX, U64_MAX, NULL, NULL);
+    err = cn_ingestv(cnv, mbv, kvsetidv, NELEM(cnv), U64_MAX, U64_MAX, NULL, NULL);
     ASSERT_EQ(merr_errno(err), EBADF);
     mapi_inject(mapi_idx_kvset_create, 0);
     free_mblks(m, n_kvsets);

--- a/tests/unit/cn/csched_sp3_test.c
+++ b/tests/unit/cn/csched_sp3_test.c
@@ -305,7 +305,7 @@ sp3_work_mock(
     w->cw_debug = 1;
     w->cw_tree = tn->tn_tree;
     w->cw_node = tn;
-    w->cw_ds = tn->tn_tree->ds;
+    w->cw_ds = tn->tn_tree->mp;
     w->cw_rp = tn->tn_tree->rp;
     w->cw_pfx_len = tn->tn_tree->ct_cp->pfx_len;
 

--- a/tests/unit/kvdb/ikvdb_test.c
+++ b/tests/unit/kvdb/ikvdb_test.c
@@ -69,6 +69,7 @@ test_pre(struct mtf_test_info *ti)
 
     mapi_inject(mapi_idx_cndb_record_kvs_del, 0);
     mapi_inject(mapi_idx_cndb_replay, 0);
+    mapi_inject(mapi_idx_cndb_kvsetid_mint, 1);
 
     mapi_inject(mapi_idx_c0_get_pfx_len, 0);
     mapi_inject(mapi_idx_mpool_mclass_props_get, ENOENT);
@@ -92,6 +93,7 @@ test_post(struct mtf_test_info *ti)
     mapi_inject_unset(mapi_idx_cn_get_sfx_len);
 
     mapi_inject(mapi_idx_cndb_record_kvs_del, 0);
+    mapi_inject(mapi_idx_cndb_kvsetid_mint, 0);
     mapi_inject_unset(mapi_idx_c0_get_pfx_len);
     mapi_inject_unset(mapi_idx_mpool_mclass_props_get);
     mapi_inject_unset(mapi_idx_mpool_open);


### PR DESCRIPTION
- Eliminate the maximum mblock limit in a mcache map
- Use kvset ID as vgroup ID instead of get_time_ns()/dgen_hi