### PR TITLE
Rename kvset_create() to kvset_open() and kvset_destroy() to kvset_close()

### DIFF
--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -637,7 +637,7 @@ cn_ingest_prep(
     if (ev(err))
         goto done;
 
-    err = kvset_create(cn->cn_tree, kvsetid, &km, kvsetp);
+    err = kvset_open(cn->cn_tree, kvsetid, &km, kvsetp);
 
 done:
     if (err) {
@@ -869,7 +869,7 @@ cn_kvset_cb(struct cndb_cn_ctx *ctx, struct kvset_meta *km, u64 kvsetid)
         map_insert_ptr(ctx->nodemap, km->km_nodeid, node);
     }
 
-    err = kvset_create(cn->cn_tree, kvsetid, km, &kvset);
+    err = kvset_open(cn->cn_tree, kvsetid, km, &kvset);
     if (ev(err))
         return err;
 

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1717,7 +1717,7 @@ cn_comp_commit(struct cn_compaction_work *w)
         km.km_dgen = w->cw_dgen_hi;
         km.km_vused = w->cw_outv[i].bl_vused;
 
-        /* Lend hblk, kblk, and vblk lists to kvset_create().
+        /* Lend hblk, kblk, and vblk lists to kvset_open().
          * Yes, the struct copy is a bit gross, but it works and
          * avoids unnecessary allocations of temporary lists.
          */
@@ -1777,10 +1777,10 @@ cn_comp_commit(struct cn_compaction_work *w)
         w->cw_commitc += ncommitted;
 
         if (use_mbsets) {
-            w->cw_err = kvset_create2(w->cw_tree, w->cw_kvsetidv[i], &km,
+            w->cw_err = kvset_open2(w->cw_tree, w->cw_kvsetidv[i], &km,
                                       w->cw_kvset_cnt, cnts, vecs, &kvsets[i]);
         } else {
-            w->cw_err = kvset_create(w->cw_tree, w->cw_kvsetidv[i], &km, &kvsets[i]);
+            w->cw_err = kvset_open(w->cw_tree, w->cw_kvsetidv[i], &km, &kvsets[i]);
         }
 
         if (ev(w->cw_err))

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -60,7 +60,7 @@ enum kvset_iter_flags {
  * @km_capped:      cn is capped
  * @km_restored:    kvset is being restored from the cndb
  *
- * This structure is passed between the MDC and kvset_create.
+ * This structure is passed between the MDC and kvset_open().
  */
 struct kvset_meta {
     struct kvs_block km_hblk;
@@ -116,7 +116,7 @@ void
 kvset_put_ref(struct kvset *kvset);
 
 /**
- * kvset_create() - Create a kvset
+ * kvset_open() - Open a kvset
  * @tree:  cn tree handle
  * @tag:   cndb tag for this kvset
  * @meta:  kvset_meta data -- what to create
@@ -124,7 +124,7 @@ kvset_put_ref(struct kvset *kvset);
  */
 /* MTF_MOCK */
 merr_t
-kvset_create(struct cn_tree *tree, u64 tag, struct kvset_meta *meta, struct kvset **kvset);
+kvset_open(struct cn_tree *tree, u64 tag, struct kvset_meta *meta, struct kvset **kvset);
 
 /**
  * Preload/discard hblock mcache map pages
@@ -202,7 +202,7 @@ kvset_madvise_vmaps(struct kvset *kvset, int advice);
 
 /* MTF_MOCK */
 merr_t
-kvset_create2(
+kvset_open2(
     struct cn_tree *   tree,
     uint64_t           kvsetid,
     struct kvset_meta *meta,

--- a/tests/mocks/repository/include/mocks/mock_kvset.h
+++ b/tests/mocks/repository/include/mocks/mock_kvset.h
@@ -17,7 +17,7 @@
  * @tripwire:   deliberately inaccessible pages, must be first field
  * @len:        size of mock_kvset
  * @mk_entry:   mock_kvset list linkage
- * @iter_data: kvdata from mock_make_kvi, passed as ds in kvset_create (opt)
+ * @iter_data: kvdata from mock_make_kvi, passed as ds in kvset_open() (opt)
  * @nk:    number of kblk / vblk ids
  * @nv:
  * @dgen:  increments from 1 each call (first call is oldest kvset)

--- a/tests/mocks/repository/lib/mock_kvset.c
+++ b/tests/mocks/repository/lib/mock_kvset.c
@@ -115,7 +115,7 @@ _make_common(
     memset(&tree, 0, sizeof(tree));
     tree.mp = ds;
 
-    err = kvset_create(&tree, 0, km, &kvset);
+    err = kvset_open(&tree, 0, km, &kvset);
     if (err)
         return err;
 
@@ -218,7 +218,7 @@ mock_make_vblocks(struct kv_iterator **kvi, struct kvs_rparams *rp, int nv)
  */
 
 static merr_t
-_kvset_create(struct cn_tree *tree, u64 tag, struct kvset_meta *km, struct kvset **handle)
+_kvset_open(struct cn_tree *tree, u64 tag, struct kvset_meta *km, struct kvset **handle)
 {
     struct mock_kvset *mk;
     size_t             alloc_sz;
@@ -653,7 +653,7 @@ mock_kvset_set(void)
 
     mapi_inject_list_set(inject_list);
 
-    MOCK_SET(kvset, _kvset_create);
+    MOCK_SET(kvset, _kvset_open);
     MOCK_SET(kvset, _kvset_get_nth_vblock_len);
     MOCK_SET(kvset, _kvset_list_add);
     MOCK_SET(kvset, _kvset_list_add_tail);
@@ -680,7 +680,7 @@ mock_kvset_unset(void)
 {
     mapi_inject_list_unset(inject_list);
 
-    MOCK_UNSET(kvset, _kvset_create);
+    MOCK_UNSET(kvset, _kvset_open);
     MOCK_UNSET(kvset, _kvset_get_nth_vblock_len);
     MOCK_UNSET(kvset, _kvset_list_add);
     MOCK_UNSET(kvset, _kvset_list_add_tail);

--- a/tests/unit/cn/cn_ingest_test.c
+++ b/tests/unit/cn/cn_ingest_test.c
@@ -40,7 +40,7 @@ struct injections {
 struct injections injections[] = {
 
     /* kvset */
-    { 0, mapi_idx_kvset_create },
+    { 0, mapi_idx_kvset_open },
     { 0, mapi_idx_kvset_put_ref },
     { 0, mapi_idx_kvset_get_ref },
     { 0, mapi_idx_kvset_delete_log_record },
@@ -291,10 +291,10 @@ MTF_DEFINE_UTEST_PRE(cn_ingest_test, fail_cleanup, test_pre)
 
     /* kvset create failure */
     init_mblks(m, n_kvsets, &k, &v);
-    mapi_inject(mapi_idx_kvset_create, merr(EBADF));
+    mapi_inject(mapi_idx_kvset_open, merr(EBADF));
     err = cn_ingestv(cnv, mbv, kvsetidv, NELEM(cnv), U64_MAX, U64_MAX, NULL, NULL);
     ASSERT_EQ(merr_errno(err), EBADF);
-    mapi_inject(mapi_idx_kvset_create, 0);
+    mapi_inject(mapi_idx_kvset_open, 0);
     free_mblks(m, n_kvsets);
 
     cn_tree_destroy(cn.cn_tree);

--- a/tests/unit/cn/csched_sp3_test.c
+++ b/tests/unit/cn/csched_sp3_test.c
@@ -191,7 +191,7 @@ new_kvsets(struct test_tree *tt, int n_kvsets, int lvl, int off)
 
         for (i = 0; i < n_kvsets; i++) {
 
-            err = kvset_create(tt->tree, tt->tag, init_kvset_meta(ttv->dgen--), &kvset);
+            err = kvset_open(tt->tree, tt->tag, init_kvset_meta(ttv->dgen--), &kvset);
             if (err)
                 return err;
 


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>

Let me know if y'all see any other related functions worth renaming.