### PR TITLE
Gate mongo-c-driver version to be less than 1.21.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -182,7 +182,7 @@ libbsd_dep = dependency(
 )
 liblz4_dep = dependency(
     'liblz4',
-    version: '>=1.9.2',
+    version: ['>=1.9.2', '<2.0.0'],
     default_options: [
         'default_library=static',
         'warning_level=0',
@@ -202,7 +202,7 @@ xxhash_dep = dependency(
 )
 cjson_dep = dependency(
     'libcjson',
-    version: '>=1.7.14',
+    version: ['>=1.7.14', '<2.0.0'],
     default_options: [
         'default_library=static',
         'warning_level=0',
@@ -264,8 +264,8 @@ if cmake.found() and get_option('tools').allowed() and (not HdrHistogram_c_dep.f
     HdrHistogram_c_proj = cmake.subproject('HdrHistogram_c', options: HdrHistogram_c_options)
     HdrHistogram_c_dep = HdrHistogram_c_proj.dependency('hdr_histogram_static')
 endif
-libmongoc_dep = dependency('libmongoc-1.0', version: '>=1.17.3', required: false)
-libbson_dep = dependency('libbson-1.0', version: '>=1.17.3', required: false)
+libmongoc_dep = dependency('libmongoc-1.0', version: ['>=1.17.3', '<1.21.0'], required: false)
+libbson_dep = dependency('libbson-1.0', version: ['>=1.17.3', '<1.21.0'], required: false)
 mongo_c_driver_force_fallback = get_option('wrap_mode') == 'forcefallback' or 'mongo-c-driver' in get_option('force_fallback_for')
 if cmake.found() and get_option('tools').allowed() and (not libmongoc_dep.found()
         or not libbson_dep.found() or mongo_c_driver_force_fallback)
@@ -279,7 +279,6 @@ if cmake.found() and get_option('tools').allowed() and (not libmongoc_dep.found(
         'ENABLE_BSON': not libbson_dep.found() or mongo_c_driver_force_fallback ? 'ON' : 'OFF',
         'ENABLE_STATIC': 'ON',
         'ENABLE_AUTOMATIC_INIT_AND_CLEANUP': false,
-        'BUILD_VERSION': '1.17.3',
     })
     mongo_c_driver_options.set_override_option('werror', 'false')
     mongo_c_driver_options.set_override_option('warning_level', '0')

--- a/subprojects/mongo-c-driver.wrap
+++ b/subprojects/mongo-c-driver.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
-directory = mongo-c-driver-1.17.3
+directory = mongo-c-driver-1.20.1
 
-source_url = https://github.com/mongodb/mongo-c-driver/archive/1.17.3.tar.gz
-source_filename = 1.17.3.tar.gz
-source_hash = 31b94c8aadd5d163b08e6998202e53601b1a21b9f08c1b94f7a4a446fd0738fc
+source_url = https://github.com/mongodb/mongo-c-driver/releases/download/1.20.1/mongo-c-driver-1.20.1.tar.gz
+source_filename = mongo-c-driver-1.20.1.tar.gz
+source_hash = c2e17ed23dc6aae72c8da8a81ad34957c35c270f7b56349c107865afeaf10d65


### PR DESCRIPTION
1.21.0 dropped support for the version of Mongo HSE supports, so our
tooling no longer works, like kmt. On systems where the mongo-c-driver
is too new, Meson will now automatically fallback to the subproject.

Bonus, I have gated other dependencies now that seem to follow semantic
versioning.

Signed-off-by: Tristan Partin <tpartin@micron.com>
