### PR TITLE
greg/NFSE-5232-defer-kcompact

### DIFF
--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -437,7 +437,6 @@ tn_samp_clear(struct cn_tree_node *tn)
     memset(&tn->tn_ns, 0, sizeof(tn->tn_ns));
     memset(&tn->tn_samp, 0, sizeof(tn->tn_samp));
 
-    tn->tn_biggest_kvset = 0;
     tn->tn_update_incr_dgen = 0;
 }
 
@@ -458,9 +457,6 @@ tn_samp_update_incr(struct cn_tree_node *tn, struct kvset *kvset, bool force)
     if (tn->tn_update_incr_dgen < dgen)
         tn->tn_update_incr_dgen = dgen;
 
-    if (tn->tn_biggest_kvset < cn_ns_keys(&tn->tn_ns))
-        tn->tn_biggest_kvset = cn_ns_keys(&tn->tn_ns);
-
     return true;
 }
 
@@ -479,9 +475,7 @@ tn_samp_update_finish(struct cn_tree_node *tn)
      */
     if (tn->tn_hlog) {
         s->ns_keys_uniq = hlog_card(tn->tn_hlog);
-        if (s->ns_keys_uniq < tn->tn_biggest_kvset)
-            s->ns_keys_uniq = tn->tn_biggest_kvset;
-        else if (s->ns_keys_uniq > num_keys)
+        if (s->ns_keys_uniq > num_keys)
             s->ns_keys_uniq = num_keys;
     } else {
         s->ns_keys_uniq = num_keys;

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -45,7 +45,8 @@ enum cn_comp_rule {
     CN_CR_LSHORT_LW,      /* short leaf, light weight */
     CN_CR_LSHORT_IDLE,    /* short leaf, idle */
     CN_CR_LSHORT_IDLE_VG, /* short leaf, idle, vblk groups */
-    CN_CR_VGMAX,          /* too many vgroups */
+    CN_CR_LSCATF,         /* vgroup scatter remediation (full node) */
+    CN_CR_LSCATP,         /* vgroup scatter remediation (partial node) */
     CN_CR_END,
 };
 
@@ -96,8 +97,10 @@ cn_comp_rule2str(enum cn_comp_rule rule)
             return "idle";
         case CN_CR_LSHORT_IDLE_VG:
             return "idlevg";
-        case CN_CR_VGMAX:
-            return "vgmax";
+        case CN_CR_LSCATF:
+            return "lscatf";
+        case CN_CR_LSCATP:
+            return "lscatp";
     }
 
     return "unknown_rule";

--- a/lib/cn/cn_tree_internal.h
+++ b/lib/cn/cn_tree_internal.h
@@ -141,10 +141,6 @@ struct cn_tree {
  * @tn_busycnt:      count of jobs and kvsets being compacted/spilled
  * @tn_destroy_work: used for async destroy
  * @tn_hlog:         hyperloglog structure
- * @tn_add_cntr:
- * @tn_rem_cntr:
- * @tn_stats_add_cntr:
- * @tn_stats_rem_cntr:
  * @tn_ns:           metrics about node to guide node compaction decisions
  * @tn_loc:          location of node within tree
  * @tn_pfx_spill:    true if spills/scans from this node use the prefix hash
@@ -157,7 +153,6 @@ struct cn_tree_node {
     struct mutex     tn_rspills_lock;
     struct list_head tn_rspills;
     bool             tn_rspills_wedged;
-    uint16_t         tn_childc;
     atomic_int       tn_compacting;
     atomic_uint      tn_busycnt;
 
@@ -172,9 +167,9 @@ struct cn_tree_node {
     u64                  tn_size_max;
     u64                  tn_update_incr_dgen;
 
-    uint64_t             tn_nodeid;
-
     struct cn_node_loc   tn_loc HSE_L1D_ALIGNED;
+    uint64_t             tn_nodeid;
+    uint16_t             tn_childc;
     uint                 tn_cgen;
     struct list_head     tn_kvset_list; /* head = newest kvset */
     struct cn_tree *     tn_tree;

--- a/lib/cn/cn_tree_internal.h
+++ b/lib/cn/cn_tree_internal.h
@@ -156,7 +156,6 @@ struct cn_tree {
 struct cn_tree_node {
     struct mutex     tn_rspills_lock;
     struct list_head tn_rspills;
-    u64              tn_biggest_kvset; /* key count */
     bool             tn_rspills_wedged;
     uint16_t         tn_childc;
     atomic_int       tn_compacting;

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -913,7 +913,10 @@ sp3_scatter(const struct cn_tree_node *tn)
     list_for_each_entry(le, &tn->tn_kvset_list, le_link) {
         uint vgroups = kvset_get_vgroups(le->le_kvset);
 
-        if (vgroups > 1)
+        /* Include the youngest kvsets with no scatter, but exclude
+         * the oldest contiguous kvsets with no scatter.
+         */
+        if (scatter + vgroups > 1)
             scatter += vgroups;
     }
 

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -905,7 +905,7 @@ static_assert(NELEM(((struct sp3_node *)0)->spn_rbe) == RBT_MAX,
  * completely eliminates scatter, returning the measurement to 1.
  */
 static uint
-sp3_scatter(struct cn_tree_node *tn)
+sp3_scatter(const struct cn_tree_node *tn)
 {
     struct kvset_list_entry *le;
     uint scatter = 0;

--- a/lib/cn/csched_sp3.h
+++ b/lib/cn/csched_sp3.h
@@ -14,7 +14,7 @@
 
 /* MTF_MOCK_DECL(csched_sp3) */
 
-#define RBT_MAX 4
+#define RBT_MAX 5
 #define CN_THROTTLE_MAX (THROTTLE_SENSOR_SCALE_MED + 50)
 
 struct kvdb_rparams;

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -345,7 +345,7 @@ sp3_work_leaf_scatter(
 
     kvsets = cn_ns_kvsets(&tn->tn_ns);
 
-    /* Find the oldest kvset which has vgroup scatter...
+    /* Find the oldest kvset which has vgroup scatter.
      */
     list_for_each_entry_reverse(le, head, le_link) {
         if (kvset_get_vgroups(le->le_kvset) > 1) {
@@ -370,13 +370,18 @@ sp3_work_leaf_scatter(
         --kvsets;
     }
 
-    /* Trim the youngest kvsets that don't have any scatter...
+    /* Trim the youngest kvsets that don't have any scatter.  If there
+     * are no kvsets then likely what happened is that a GC operation
+     * got in ahead of us and eliminated all the scatter.
      */
-    list_for_each_entry(le, head, le_link) {
-        if (kvset_get_vgroups(le->le_kvset) > 1)
-            break;
+    if (kvsets > 1) {
+        list_for_each_entry(le, head, le_link) {
+            if (kvset_get_vgroups(le->le_kvset) > 1)
+                break;
 
-        --kvsets;
+            assert(le != *mark);
+            --kvsets;
+        }
     }
 
     return min_t(uint, kvsets, thresh->lcomp_kvsets_max);

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -324,6 +324,65 @@ sp3_work_leaf_garbage(
 }
 
 static uint
+sp3_work_leaf_scatter(
+    struct sp3_node *         spn,
+    struct sp3_thresholds *   thresh,
+    struct kvset_list_entry **mark,
+    enum cn_action *          action,
+    enum cn_comp_rule *       rule)
+{
+    struct kvset_list_entry *le;
+    struct cn_tree_node *tn;
+    struct list_head *head;
+    uint kvsets;
+
+    tn = spn2tn(spn);
+
+    head = &tn->tn_kvset_list;
+    *mark = list_last_entry(head, typeof(*le), le_link);
+    *action = CN_ACTION_COMPACT_KV;
+    *rule = CN_CR_LSCATF;
+
+    kvsets = cn_ns_kvsets(&tn->tn_ns);
+
+    /* Find the oldest kvset which has vgroup scatter...
+     */
+    list_for_each_entry_reverse(le, head, le_link) {
+        if (kvset_get_vgroups(le->le_kvset) > 1) {
+            uint compc = kvset_get_compc(le->le_kvset);
+
+            *mark = le;
+
+            /* Include older kvsets which have the same compc
+             * (to prevent compc misordering).
+             */
+            while (( le = list_next_entry_or_null(le, le_link, head) )) {
+                if (kvset_get_compc(le->le_kvset) > compc)
+                    break;
+
+                *mark = le;
+                ++kvsets;
+            }
+            break;
+        }
+
+        *rule = CN_CR_LSCATP;
+        --kvsets;
+    }
+
+    /* Trim the youngest kvsets that don't have any scatter...
+     */
+    list_for_each_entry(le, head, le_link) {
+        if (kvset_get_vgroups(le->le_kvset) > 1)
+            break;
+
+        --kvsets;
+    }
+
+    return min_t(uint, kvsets, thresh->lcomp_kvsets_max);
+}
+
+static uint
 sp3_work_leaf_len(
     struct sp3_node *         spn,
     struct sp3_thresholds *   thresh,
@@ -332,24 +391,21 @@ sp3_work_leaf_len(
     enum cn_comp_rule *       rule)
 {
     struct cn_tree_node *tn = spn2tn(spn);
-    struct cn_node_stats stats;
-    uint node_kvsets;
-    uint runlen = 0;
     uint runlen_min = thresh->llen_runlen_min;
     uint runlen_max = thresh->llen_runlen_max;
+    uint kvsets;
 
-    cn_node_stats_get(tn, &stats);
-
-    node_kvsets = cn_ns_kvsets(&stats);
+    kvsets = cn_ns_kvsets(&tn->tn_ns);
 
     /* Start from old kvsets, find first run of 'runlen_min' kvsets with
      * the same 'compc' value, then k-compact those kvsets and up to
      * 'runlen_max' newer.
      */
-    if (node_kvsets >= runlen_min) {
+    if (kvsets >= runlen_min) {
         struct kvset_list_entry *le;
         struct list_head *head;
         uint compc = UINT_MAX;
+        uint runlen = 0;
         uint tmp;
 
         head = &tn->tn_kvset_list;
@@ -368,26 +424,14 @@ sp3_work_leaf_len(
             }
         }
 
-        if (runlen >= runlen_min) {
-            if (compc > 0) {
-                uint64_t clen = cn_ns_clen(&stats);
+        if (runlen >= runlen_min)
+            return runlen;
 
-                /* Mitigate creation of ginormous kvsets while we await
-                 * a leaf spill as they clog up the spill pipeline.
-                 */
-                if (clen > tn->tn_size_max && list_is_last(&(*mark)->le_link, head)) {
-                    runlen = max(runlen_min / 2, 2u);
-                } else {
-                    runlen = runlen_min;
-                }
-            }
-        } else if (node_kvsets > runlen_min && cn_ns_vblks(&stats) < node_kvsets) {
-
-            /* Don't let lightweight nodes grow too long.  For the most part
-             * this only applies to "index" nodes (i.e., nodes where the values
-             * are much smaller than the keys).
-             */
-
+        /* Don't let lightweight nodes grow too long.  For the most part
+         * this only applies to "index" nodes (i.e., nodes where the values
+         * are much smaller than the keys).
+         */
+        if (kvsets > runlen_min && cn_ns_vblks(&tn->tn_ns) < kvsets) {
             le = list_last_entry(head, typeof(*le), le_link);
             compc = kvset_get_compc(le->le_kvset);
             runlen = 0;
@@ -406,33 +450,11 @@ sp3_work_leaf_len(
             }
 
             *rule = CN_CR_LSHORT_LW;
-            runlen = runlen_min;
-        }
-
-
-        /* If the resulting kvset would exceed max_vgroups, convert
-         * the k-compaction to a kv-compaction.
-         */
-        if (runlen > 0) {
-            uint vgroups = 0;
-
-            le = *mark;
-
-            for (uint i = 0; i < runlen; i++) {
-                vgroups += kvset_get_vgroups(le->le_kvset);
-
-                if (vgroups > thresh->max_vgroups) {
-                    *action = CN_ACTION_COMPACT_KV;
-                    *rule = CN_CR_VGMAX;
-                    break;
-                }
-
-                le = list_prev_entry(le, le_link);
-            }
+            return runlen_min;
         }
     }
 
-    return runlen;
+    return 0;
 }
 
 /**
@@ -513,6 +535,10 @@ sp3_work(
 
         case wtype_leaf_garbage:
             n_kvsets = sp3_work_leaf_garbage(spn, thresh, &mark, &action, &rule);
+            break;
+
+        case wtype_leaf_scatter:
+            n_kvsets = sp3_work_leaf_scatter(spn, thresh, &mark, &action, &rule);
             break;
 
         case wtype_node_len:

--- a/lib/cn/csched_sp3_work.h
+++ b/lib/cn/csched_sp3_work.h
@@ -23,6 +23,7 @@ enum sp3_work_type {
     wtype_node_len,     /* all nodes: number of kvsets */
     wtype_node_idle,    /* internal+leaf nodes: kcompact/kvcompact */
     wtype_leaf_garbage, /* leaf nodes: garbage */
+    wtype_leaf_scatter, /* leaf nodes: vgroup scatter */
     wtype_leaf_size,    /* leaf nodes: size */
 };
 

--- a/lib/include/hse_ikvdb/csched.h
+++ b/lib/include/hse_ikvdb/csched.h
@@ -28,6 +28,7 @@ enum sp3_qnum {
     SP3_QNUM_ROOT,
     SP3_QNUM_LLEN,
     SP3_QNUM_LGARB,
+    SP3_QNUM_LSCAT,
     SP3_QNUM_LSIZE,
     SP3_QNUM_SHARED,
     SP3_QNUM_MAX
@@ -39,6 +40,7 @@ enum sp3_qnum {
     ((5ul << (8 * SP3_QNUM_ROOT)) |             \
      (5ul << (8 * SP3_QNUM_LLEN)) |             \
      (1ul << (8 * SP3_QNUM_LGARB)) |            \
+     (1ul << (8 * SP3_QNUM_LSCAT)) |            \
      (1ul << (8 * SP3_QNUM_LSIZE)) |            \
      (2ul << (8 * SP3_QNUM_SHARED)))
 

--- a/lib/kvdb/kvdb_rparams.c
+++ b/lib/kvdb/kvdb_rparams.c
@@ -806,7 +806,7 @@ static const struct param_spec pspecs[] = {
         .ps_stringify = param_default_stringify,
         .ps_jsonify = param_default_jsonify,
         .ps_default_value = {
-            .as_uscalar = 32,
+            .as_uscalar = 64,
         },
         .ps_bounds = {
             .as_uscalar = {


### PR DESCRIPTION
- Create a new csched work queue for scatter remediation.
- Remove invalid bounds check on cn node uniq key count..
- Reorganiz struct cn_tree_node to improve cacheline efficiency...
- Fix sp3_work_leaf_scatter() to deal with zero scatter (i.e., the node was gc'd ahead of time).
- Avoid unnecessary kcompactions if a scatter kv-compaction is eminent.
