### PR TITLE
Update to lz4 version 1.9.3

### DIFF
--- a/subprojects/lz4.wrap
+++ b/subprojects/lz4.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = lz4-1.9.2
+directory = lz4-1.9.3
 
-source_url = https://github.com/lz4/lz4/archive/v1.9.2.tar.gz
-source_filename = lz4-1.9.2.tgz
-source_hash = 658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc
+source_url = https://github.com/lz4/lz4/archive/refs/tags/v1.9.3.tar.gz
+source_filename = lz4-1.9.3.tar.gz
+source_hash = 030644df4611007ff7dc962d981f390361e6c97a34e5cbc393ddfbe019ffe2c1
 
 patch_directory=lz4
 


### PR DESCRIPTION
This version came out 2 years ago, and has been a solid enough release
that lz4 hasn't felt the need to make another release since.

Comes with many bug fixes and build improvements.

Signed-off-by: Tristan Partin <tpartin@micron.com>
