### PR TITLE
Remove mpool_mblock_abort()

### DIFF
--- a/lib/cn/blk_list.c
+++ b/lib/cn/blk_list.c
@@ -1,10 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
-#include "blk_list.h"
-
+#include <hse_ikvdb/blk_list.h>
 #include <hse_util/logging.h>
 #include <hse_util/hse_err.h>
 #include <hse_util/event_counter.h>
@@ -13,27 +12,19 @@
 
 #include <mpool/mpool.h>
 
-void
-abort_mblocks(struct mpool *dataset, struct blk_list *blks)
-{
-    if (!blks)
-        return;
-
-    for (uint i = 0; i < blks->n_blks; i++)
-        abort_mblock(dataset, &blks->blks[i]);
-}
+#include "blk_list.h"
 
 merr_t
-commit_mblock(struct mpool *dataset, struct kvs_block *blk)
+commit_mblock(struct mpool *mp, struct kvs_block *blk)
 {
     merr_t err;
 
     assert(blk);
     assert(blk->bk_blkid);
 
-    err = mpool_mblock_commit(dataset, blk->bk_blkid);
+    err = mpool_mblock_commit(mp, blk->bk_blkid);
     if (ev(err)) {
-        log_errx("commit_mblock failed: @@e, blkid 0x%lx", err, (ulong)blk->bk_blkid);
+        log_errx("commit_mblock failed: @@e, blkid 0x%lx", err, blk->bk_blkid);
         return err;
     }
 
@@ -41,34 +32,30 @@ commit_mblock(struct mpool *dataset, struct kvs_block *blk)
 }
 
 merr_t
-abort_mblock(struct mpool *dataset, struct kvs_block *blk)
-{
-    merr_t err;
-
-    assert(blk);
-
-    err = mpool_mblock_abort(dataset, blk->bk_blkid);
-    if (ev(err)) {
-        log_errx("abort_mblock failed: @@e, blkid 0x%lx", err, (ulong)blk->bk_blkid);
-    } else {
-        blk->bk_blkid = 0;
-    }
-
-    return err;
-}
-
-merr_t
-delete_mblock(struct mpool *dataset, struct kvs_block *blk)
+delete_mblock(struct mpool *mp, struct kvs_block *blk)
 {
     merr_t err = 0;
 
-    err = mpool_mblock_delete(dataset, blk->bk_blkid);
+    if (!blk->bk_blkid)
+        return 0;
+
+    err = mpool_mblock_delete(mp, blk->bk_blkid);
     if (ev(err)) {
-        log_errx("delete_mblock failed: @@e, blkid 0x%lx", err, (ulong)blk->bk_blkid);
+        log_errx("delete_mblock failed: @@e, blkid 0x%lx", err, blk->bk_blkid);
     } else {
         blk->bk_blkid = 0;
     }
     return err;
+}
+
+void
+delete_mblocks(struct mpool *mp, struct blk_list *blks)
+{
+    if (!mp || !blks)
+        return;
+
+    for (uint32_t i = 0; i < blks->n_blks; i++)
+        mpool_mblock_delete(mp, blks->blks[i].bk_blkid);
 }
 
 void

--- a/lib/cn/blk_list.h
+++ b/lib/cn/blk_list.h
@@ -9,24 +9,21 @@
 #include <hse_util/inttypes.h>
 #include <hse_util/hse_err.h>
 
-#include <hse_ikvdb/blk_list.h>
-
-struct mpool;
+struct blk_list;
+struct kvs_block;
 struct mblock_props;
+struct mpool;
 
 #define BLK_LIST_PRE_ALLOC 64
 
 merr_t
-abort_mblock(struct mpool *dataset, struct kvs_block *blk);
+delete_mblock(struct mpool *mp, struct kvs_block *blk);
 
 void
-abort_mblocks(struct mpool *dataset, struct blk_list *blks);
+delete_mblocks(struct mpool *mp, struct blk_list *blk);
 
 merr_t
-delete_mblock(struct mpool *dataset, struct kvs_block *blk);
-
-merr_t
-commit_mblock(struct mpool *dataset, struct kvs_block *blk);
+commit_mblock(struct mpool *mp, struct kvs_block *blk);
 
 void
 blk_list_init(struct blk_list *blkl);

--- a/lib/cn/cn_mblocks.h
+++ b/lib/cn/cn_mblocks.h
@@ -1,10 +1,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_KVS_CN_MBLOCKS_H
 #define HSE_KVS_CN_MBLOCKS_H
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+#include <hse_util/hse_err.h>
 
 /* MTF_MOCK_DECL(cn_mblocks) */
 
@@ -32,7 +37,7 @@ enum cn_mutation {
 
 /* MTF_MOCK */
 size_t
-cn_mb_est_alen(size_t max_captgt, size_t alloc_unit, size_t payload, uint flags);
+cn_mb_est_alen(size_t max_captgt, size_t alloc_unit, size_t payload, unsigned int flags);
 
 /**
  * cn_mblocks_commit()
@@ -47,7 +52,6 @@ cn_mb_est_alen(size_t max_captgt, size_t alloc_unit, size_t payload, uint flags)
  *      Ignored if the mutation is CN_MUT_KCOMPACT
  *      Else, number of vblocks already committed.
  *      If NULL, none of the vblocks are already committed.
- * @n_committed:
  * @context:
  * @tags:
  */
@@ -55,19 +59,17 @@ cn_mb_est_alen(size_t max_captgt, size_t alloc_unit, size_t payload, uint flags)
 merr_t
 cn_mblocks_commit(
     struct mpool *        ds,
-    u32                   num_lists,
+    uint32_t              num_lists,
     struct kvset_mblocks *list,
-    enum cn_mutation      mutation,
-    u32 *                 n_committed);
+    enum cn_mutation      mutation);
 
 /* MTF_MOCK */
 void
 cn_mblocks_destroy(
     struct mpool *        ds,
-    u32                   num_lists,
+    uint32_t              num_lists,
     struct kvset_mblocks *list,
-    bool                  kcompact,
-    u32                   n_committed);
+    bool                  kcompact);
 
 #if HSE_MOCKING
 #include "cn_mblocks_ut.h"

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1704,7 +1704,6 @@ cn_comp_commit(struct cn_compaction_work *w)
 
     for (i = 0; i < w->cw_outc; i++) {
         struct kvset_meta km = {};
-        uint ncommitted;
 
         /* [HSE_REVISIT] there may be vblks to delete!!! */
         if (!w->cw_outv[i].hblk.bk_blkid) {
@@ -1776,13 +1775,11 @@ cn_comp_commit(struct cn_compaction_work *w)
         }
 
         w->cw_err = cn_mblocks_commit(w->cw_ds, 1, &w->cw_outv[i],
-                                      kcompact ? CN_MUT_KCOMPACT : CN_MUT_OTHER, &ncommitted);
+                                      kcompact ? CN_MUT_KCOMPACT : CN_MUT_OTHER);
         if (ev(w->cw_err)) {
             kvdb_health_error(hp, w->cw_err);
             goto done;
         }
-
-        w->cw_commitc += ncommitted;
 
         if (use_mbsets) {
             w->cw_err = kvset_open2(w->cw_tree, w->cw_kvsetidv[i], &km,
@@ -1876,7 +1873,7 @@ cn_comp_cleanup(struct cn_compaction_work *w)
             w->cw_tree->ct_nospace = true;
 
         if (w->cw_outv)
-            cn_mblocks_destroy(w->cw_ds, w->cw_outc, w->cw_outv, kcompact, w->cw_commitc);
+            cn_mblocks_destroy(w->cw_ds, w->cw_outc, w->cw_outv, kcompact);
     }
 
     free(w->cw_vbmap.vbm_blkv);

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -153,7 +153,6 @@ struct cn_work_est {
  *                       kvsets during k-compaction
  * @cw_drop_tombs:   if true, then tombstones can be dropped in the merge loop
  * @cw_work_txid:    the cndb transaction id
- * @cw_commitc:      keeps track of how many output mblocks have been committed
  * @cw_keep_vblks:   indicates whether or not vblocks should be deleted or
  *                   if they should transferred from input kvsets to
  *                   output kvets (e.g., in k-compaction).
@@ -232,7 +231,6 @@ struct cn_compaction_work {
 
     /* initialized in cn_compaction_worker() */
     struct cndb_txn      *cw_cndb_txn;
-    uint                  cw_commitc;
     bool                  cw_keep_vblks;
     void                **cw_cookie;
 

--- a/lib/cn/hblock_builder.c
+++ b/lib/cn/hblock_builder.c
@@ -284,7 +284,7 @@ hbb_finish(
 out:
     if (err) {
         if (blkid)
-            mpool_mblock_abort(bld->mpool, blkid);
+            mpool_mblock_delete(bld->mpool, blkid);
     }
 
     free(iov);

--- a/lib/cn/kblock_builder.c
+++ b/lib/cn/kblock_builder.c
@@ -944,7 +944,7 @@ kblock_finish(struct kblock_builder *bld)
 
 errout:
     if (blkid)
-        mpool_mblock_abort(bld->ds, blkid);
+        mpool_mblock_delete(bld->ds, blkid);
     free(iov);
 
     /* unconditional reset */
@@ -1017,7 +1017,7 @@ kbb_destroy(struct kblock_builder *bld)
 
     hlog_destroy(bld->composite_hlog);
     kblock_free(&bld->curr);
-    abort_mblocks(bld->ds, &bld->finished_kblks);
+    delete_mblocks(bld->ds, &bld->finished_kblks);
     blk_list_free(&bld->finished_kblks);
     free(bld);
 }

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -11,6 +11,7 @@
 #include <hse_util/list.h>
 #include <hse_util/perfc.h>
 
+#include <hse_ikvdb/blk_list.h>
 #include <hse_ikvdb/kvs_cparams.h>
 #include <hse_ikvdb/tuple.h>
 #include <hse_ikvdb/omf_kmd.h>

--- a/lib/cn/kvset_builder.c
+++ b/lib/cn/kvset_builder.c
@@ -333,12 +333,12 @@ kvset_builder_destroy(struct kvset_builder *bld)
     if (ev(!bld))
         return;
 
-    mpool_mblock_abort(cn_get_dataset(bld->cn), bld->hblk.bk_blkid);
+    mpool_mblock_delete(cn_get_dataset(bld->cn), bld->hblk.bk_blkid);
 
-    abort_mblocks(cn_get_dataset(bld->cn), &bld->kblk_list);
+    delete_mblocks(cn_get_dataset(bld->cn), &bld->kblk_list);
     blk_list_free(&bld->kblk_list);
 
-    abort_mblocks(cn_get_dataset(bld->cn), &bld->vblk_list);
+    delete_mblocks(cn_get_dataset(bld->cn), &bld->vblk_list);
     blk_list_free(&bld->vblk_list);
 
     hbb_destroy(bld->hbb);
@@ -400,7 +400,7 @@ kvset_builder_finish(struct kvset_builder *imp)
     err = kbb_finish(imp->kbb, &imp->kblk_list);
     if (err) {
         if (!adopted_vbs)
-            abort_mblocks(cn_get_dataset(imp->cn), &imp->vblk_list);
+            delete_mblocks(cn_get_dataset(imp->cn), &imp->vblk_list);
 
         return err;
     }
@@ -408,9 +408,9 @@ kvset_builder_finish(struct kvset_builder *imp)
     err = hbb_finish(imp->hbb, &imp->hblk, imp->seqno_min, imp->seqno_max, imp->kblk_list.n_blks,
                      imp->vblk_list.n_blks, imp->vgroups, kbb_get_composite_hlog(imp->kbb));
     if (err) {
-        abort_mblocks(cn_get_dataset(imp->cn), &imp->kblk_list);
+        delete_mblocks(cn_get_dataset(imp->cn), &imp->kblk_list);
         if (!adopted_vbs)
-            abort_mblocks(cn_get_dataset(imp->cn), &imp->vblk_list);
+            delete_mblocks(cn_get_dataset(imp->cn), &imp->vblk_list);
 
         return err;
     }

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -13,6 +13,7 @@
 #include <hse_util/workqueue.h>
 #include <hse_util/key_util.h>
 
+#include <hse_ikvdb/blk_list.h>
 #include <hse_ikvdb/tuple.h>
 #include <hse_ikvdb/omf_kmd.h>
 #include <hse_ikvdb/kvset_view.h>

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -505,9 +505,9 @@ cn_spill(struct cn_compaction_work *w)
             err = kvset_builder_get_mblocks(child, &w->cw_outv[output_nodec]);
             if (err) {
                 while (output_nodec-- > 0) {
-                    abort_mblock(w->cw_ds, &w->cw_outv[output_nodec].hblk);
-                    abort_mblocks(w->cw_ds, &w->cw_outv[output_nodec].kblks);
-                    abort_mblocks(w->cw_ds, &w->cw_outv[output_nodec].vblks);
+                    delete_mblock(w->cw_ds, &w->cw_outv[output_nodec].hblk);
+                    delete_mblocks(w->cw_ds, &w->cw_outv[output_nodec].kblks);
+                    delete_mblocks(w->cw_ds, &w->cw_outv[output_nodec].vblks);
                 }
                 memset(w->cw_outv, 0, w->cw_outc * sizeof(*w->cw_outv));
             } else {

--- a/lib/cn/vblock_builder.c
+++ b/lib/cn/vblock_builder.c
@@ -157,7 +157,7 @@ vblock_start(struct vblock_builder *bld, const struct key_obj *min_kobj)
 
     err = blk_list_append(&bld->vblk_list, blkid);
     if (ev(err)) {
-        mpool_mblock_abort(bld->ds, blkid);
+        mpool_mblock_delete(bld->ds, blkid);
         return err;
     }
 
@@ -310,7 +310,7 @@ vbb_destroy(struct vblock_builder *bld)
     if (ev(!bld))
         return;
 
-    abort_mblocks(bld->ds, &bld->vblk_list);
+    delete_mblocks(bld->ds, &bld->vblk_list);
     blk_list_free(&bld->vblk_list);
 
     vlb_free(bld->wbuf, WBUF_LEN_MAX + sizeof(*bld));

--- a/lib/include/hse_ikvdb/blk_list.h
+++ b/lib/include/hse_ikvdb/blk_list.h
@@ -6,7 +6,7 @@
 #ifndef HSE_IKVDB_BLK_LIST_H
 #define HSE_IKVDB_BLK_LIST_H
 
-#include <hse_util/inttypes.h>
+#include <inttypes.h>
 
 /**
  * struct kvs_block - information about a mblock in a blk_list
@@ -14,26 +14,26 @@
  * @bk_handle: mblock handle
  */
 struct kvs_block {
-    u64  bk_blkid;
+    uint64_t bk_blkid;
 };
 
 struct blk_list {
     struct kvs_block *blks;
-    u32               n_alloc;
-    u32               n_blks;
+    uint32_t n_alloc;
+    uint32_t n_blks;
 };
 
 struct kvset_mblocks {
     struct kvs_block hblk;
     struct blk_list kblks;
     struct blk_list vblks;
-    u64             bl_vused;
-    u64             bl_seqno_max;
-    u64             bl_seqno_min;
+    uint64_t bl_vused;
+    uint64_t bl_seqno_max;
+    uint64_t bl_seqno_min;
 
     void *bl_last_ptomb;
-    u32   bl_last_ptlen;
-    u64   bl_last_ptseq;
+    uint32_t bl_last_ptlen;
+    uint64_t bl_last_ptseq;
 };
 
 #endif

--- a/lib/mpool/include/mpool/mpool.h
+++ b/lib/mpool/include/mpool/mpool.h
@@ -374,20 +374,6 @@ merr_t
 mpool_mblock_commit(struct mpool *mp, uint64_t mbid);
 
 /**
- * mpool_mblock_abort() - abort an mblock
- *
- * @mp:   mpool
- * @mbid: mblock object ID
- *
- * mblock must have been allocated but not yet committed.
- *
- * Return: %0 on success, <%0 on error
- */
-/* MTF_MOCK */
-merr_t
-mpool_mblock_abort(struct mpool *mp, uint64_t mbid);
-
-/**
  * mpool_mblock_delete() - delete an committed mblock
  *
  * @mp:   mpool

--- a/lib/mpool/src/mblock.c
+++ b/lib/mpool/src/mblock.c
@@ -62,23 +62,6 @@ mpool_mblock_commit(struct mpool *mp, uint64_t mbid)
 }
 
 merr_t
-mpool_mblock_abort(struct mpool *mp, uint64_t mbid)
-{
-    struct media_class *mc;
-    enum hse_mclass   mclass;
-
-    if (!mp)
-        return merr(EINVAL);
-
-    mclass = mcid_to_mclass(mclassid(mbid));
-    mc = mpool_mclass_handle(mp, mclass);
-    if (!mc)
-        return merr(ENOENT);
-
-    return mblock_fset_abort(mclass_fset(mc), &mbid, 1);
-}
-
-merr_t
 mpool_mblock_delete(struct mpool *mp, uint64_t mbid)
 {
     struct media_class *mc;

--- a/lib/mpool/src/mblock_file.h
+++ b/lib/mpool/src/mblock_file.h
@@ -213,16 +213,6 @@ merr_t
 mblock_file_commit(struct mblock_file *mbfp, uint64_t *mbidv, int mbidc);
 
 /**
- * mblock_file_abort() - abort a vector of mblock objects
- *
- * @mbfp:  mblock file handle
- * @mbidv  vector of mblock ids
- * @mbidc: count of mblock ids
- */
-merr_t
-mblock_file_abort(struct mblock_file *mbfp, uint64_t *mbidv, int mbidc);
-
-/**
  * mblock_file_delete() - destroy a vector of mblock objects
  *
  * @mbfp:  mblock file handle

--- a/lib/mpool/src/mblock_fset.c
+++ b/lib/mpool/src/mblock_fset.c
@@ -668,22 +668,6 @@ mblock_fset_commit(struct mblock_fset *mbfsp, uint64_t *mbidv, int mbidc)
 }
 
 merr_t
-mblock_fset_abort(struct mblock_fset *mbfsp, uint64_t *mbidv, int mbidc)
-{
-    struct mblock_file *mbfp;
-
-    if (!mbfsp || !mbidv || file_id(*mbidv) > mbfsp->mhdr.fcnt)
-        return merr(EINVAL);
-
-    if (mbidc > 1)
-        return merr(ENOTSUP);
-
-    mbfp = mbfsp->filev[file_index(*mbidv)];
-
-    return mblock_file_abort(mbfp, mbidv, mbidc);
-}
-
-merr_t
 mblock_fset_delete(struct mblock_fset *mbfsp, uint64_t *mbidv, int mbidc)
 {
     struct mblock_file *mbfp;
@@ -881,7 +865,7 @@ mblock_fset_clone(
     return 0;
 
 errout:
-    mblock_fset_abort(mbfsp, &tgt_mbid, 1);
+    mblock_fset_delete(mbfsp, &tgt_mbid, 1);
 
     return err;
 }

--- a/lib/mpool/src/mblock_fset.h
+++ b/lib/mpool/src/mblock_fset.h
@@ -92,16 +92,6 @@ merr_t
 mblock_fset_commit(struct mblock_fset *mbfsp, uint64_t *mbidv, int mbidc);
 
 /**
- * mblock_fset_abort() - abort mblocks
- *
- * @mbfsp: mblock fileset handle
- * @mbidv: mblock id
- * @mbidc: mblock count (support only mbidc == 1)
- */
-merr_t
-mblock_fset_abort(struct mblock_fset *mbfsp, uint64_t *mbidv, int mbidc);
-
-/**
  * mblock_fset_delete() - delete mblocks
  *
  * @mbfsp: mblock fileset handle

--- a/tests/mocks/repository/lib/mock_mpool.c
+++ b/tests/mocks/repository/lib/mock_mpool.c
@@ -152,12 +152,6 @@ _mpool_mblock_commit(struct mpool *mp, uint64_t id)
 }
 
 static merr_t
-_mpool_mblock_abort(struct mpool *mp, uint64_t id)
-{
-    return 0;
-}
-
-static merr_t
 _mpool_mblock_delete(struct mpool *mp, uint64_t id)
 {
     merr_t                err;
@@ -821,7 +815,6 @@ mock_mpool_set(void)
     /* Allow repeated init() w/o intervening unset() */
     mock_mpool_unset();
 
-    MOCK_SET(mpool, _mpool_mblock_abort);
     MOCK_SET(mpool, _mpool_mblock_alloc);
     MOCK_SET(mpool, _mpool_mblock_commit);
     MOCK_SET(mpool, _mpool_mblock_delete);
@@ -854,7 +847,6 @@ mock_mpool_unset(void)
 {
     int i;
 
-    MOCK_UNSET(mpool, _mpool_mblock_abort);
     MOCK_UNSET(mpool, _mpool_mblock_alloc);
     MOCK_UNSET(mpool, _mpool_mblock_commit);
     MOCK_UNSET(mpool, _mpool_mblock_delete);

--- a/tests/unit/cn/blk_list_test.c
+++ b/tests/unit/cn/blk_list_test.c
@@ -36,7 +36,6 @@ pre(struct mtf_test_info *info)
 {
     mapi_inject(mapi_idx_mpool_mblock_delete, 0);
     mapi_inject(mapi_idx_mpool_mblock_commit, 0);
-    mapi_inject(mapi_idx_mpool_mblock_abort, 0);
     return 0;
 }
 
@@ -184,19 +183,19 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_free(&b);
 }
 
-MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_abort_mblocks, pre, post)
+MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblocks, pre, post)
 {
     int             i, N = 5;
     merr_t          err;
     struct blk_list b;
     u32             api;
 
-    abort_mblocks(ds, 0);
+    delete_mblocks(ds, 0);
 
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    abort_mblocks(ds, &b);
+    delete_mblocks(ds, &b);
     blk_list_free(&b);
 
     blk_list_init(&b);
@@ -204,15 +203,15 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_abort_mblocks, pre, post)
         err = blk_list_append(&b, BLK_ID + i);
         ASSERT_EQ(err, 0);
     }
-    abort_mblocks(ds, &b);
+    delete_mblocks(ds, &b);
     blk_list_free(&b);
 
-    api = mapi_idx_mpool_mblock_abort;
+    api = mapi_idx_mpool_mblock_delete;
     mapi_inject(api, merr(EINVAL));
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    abort_mblocks(ds, &b);
+    delete_mblocks(ds, &b);
     blk_list_free(&b);
     mapi_inject(api, 0);
 }

--- a/tests/unit/cn/vblock_builder_test.c
+++ b/tests/unit/cn/vblock_builder_test.c
@@ -547,7 +547,6 @@ run_test_case(struct mtf_test_info *lcl_ti, enum test_case tc, size_t n_vblocks)
 
     mapi_calls_clear(mapi_idx_mpool_mblock_alloc);
     mapi_calls_clear(mapi_idx_mpool_mblock_write);
-    mapi_calls_clear(mapi_idx_mpool_mblock_abort);
     mapi_calls_clear(mapi_idx_mpool_mblock_commit);
     mapi_calls_clear(mapi_idx_mpool_mblock_delete);
 
@@ -586,7 +585,6 @@ run_test_case(struct mtf_test_info *lcl_ti, enum test_case tc, size_t n_vblocks)
 
             ASSERT_EQ_RET(mapi_calls(mapi_idx_mpool_mblock_alloc), n_vblocks, 1);
             ASSERT_GT_RET(mapi_calls(mapi_idx_mpool_mblock_write), 0, 1);
-            ASSERT_EQ_RET(mapi_calls(mapi_idx_mpool_mblock_abort), 0, 1);
             ASSERT_EQ_RET(mapi_calls(mapi_idx_mpool_mblock_commit), 0, 1);
             ASSERT_EQ_RET(mapi_calls(mapi_idx_mpool_mblock_delete), 0, 1);
             break;
@@ -597,7 +595,6 @@ run_test_case(struct mtf_test_info *lcl_ti, enum test_case tc, size_t n_vblocks)
 
             ASSERT_EQ_RET(mapi_calls(mapi_idx_mpool_mblock_alloc), n_vblocks, 1);
             ASSERT_GT_RET(mapi_calls(mapi_idx_mpool_mblock_write), 0, 1);
-            ASSERT_EQ_RET(mapi_calls(mapi_idx_mpool_mblock_abort), n_vblocks, 1);
             ASSERT_EQ_RET(mapi_calls(mapi_idx_mpool_mblock_commit), 0, 1);
             ASSERT_EQ_RET(mapi_calls(mapi_idx_mpool_mblock_delete), 0, 1);
             break;

--- a/tests/unit/mpool/mcache_test.c
+++ b/tests/unit/mpool/mcache_test.c
@@ -296,7 +296,7 @@ MTF_DEFINE_UTEST_PREPOST(mcache_test, mcache_invalid_args, mpool_test_pre, mpool
     err = mblock_unmap(NULL, mbid);
     ASSERT_EQ(EINVAL, merr_errno(err));
 
-    err = mpool_mblock_abort(mp, mbid);
+    err = mpool_mblock_delete(mp, mbid);
     ASSERT_EQ(0, err);
 
     err = mpool_close(mp);


### PR DESCRIPTION
Mpool doesn't track the state of an mblock. This created some strange
state tracking logic in cn, and it made the code harder to follow.
Nabeel realized that mpool_mblock_abort() and mpool_mblock_delete() were
very similar, so now that only mpool_mblock_delete() will be kept, the
state tracking logic in cn can be removed.

Signed-off-by: Tristan Partin <tpartin@micron.com>
