### PR TITLE
Rework CN tree and node structs for hse-3

### DIFF
--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -967,7 +967,6 @@ cn_open(
     }
 
     map_insert_ptr(ctx.nodemap, 0, cn->cn_tree->ct_root);
-    cn->cn_tree->ct_root->tn_childc += 0;
 
     /* [HSE_REVISIT] Delete this block once we have splits. cn_kvset_cb() will populate the nodemap,
      * and then for each node in the map, fetch the max key and call route_map_insert() with it.
@@ -989,11 +988,9 @@ cn_open(
             }
 
             tn->tn_nodeid = ++n;
-            tn->tn_parent = cn->cn_tree->ct_root;
             map_insert_ptr(ctx.nodemap, tn->tn_nodeid, tn);
 
-            cn->cn_tree->ct_root->tn_childv[i] = tn;
-            cn->cn_tree->ct_root->tn_childc += 1;
+            list_add(&tn->tn_link, &cn->cn_tree->ct_leaves);
 
             if (cn->cn_tree->ct_route_map) {
                 char ekbuf[HSE_KVS_KEY_LEN_MAX];
@@ -1153,10 +1150,7 @@ cn_periodic(struct cn *cn, u64 now)
 
     now /= NSEC_PER_SEC;
     if (now >= cn->cn_pc_shape_next) {
-
-        cn_tree_perfc_shape_report(
-            cn->cn_tree, &cn->cn_pc_shape_rnode, &cn->cn_pc_shape_inode, &cn->cn_pc_shape_lnode);
-
+        cn_tree_perfc_shape_report(cn->cn_tree, &cn->cn_pc_shape_rnode, &cn->cn_pc_shape_lnode);
         cn->cn_pc_shape_next = now + 60;
     }
 }

--- a/lib/cn/cn_internal.h
+++ b/lib/cn/cn_internal.h
@@ -50,7 +50,6 @@ struct cn {
 
     uint             cn_pc_shape_next;
     struct perfc_set cn_pc_shape_rnode;
-    struct perfc_set cn_pc_shape_inode;
     struct perfc_set cn_pc_shape_lnode;
     struct perfc_set cn_pc_capped;
 

--- a/lib/cn/cn_perfc.c
+++ b/lib/cn/cn_perfc.c
@@ -129,7 +129,6 @@ cn_perfc_alloc(struct cn *cn, uint prio)
     perfc_alloc(cn_perfc_compact, group, "kcompact", prio, &cn->cn_pc_kcompact);
     perfc_alloc(cn_perfc_compact, group, "kvcompact", prio, &cn->cn_pc_kvcompact);
     perfc_alloc(cn_perfc_shape, group, "rnode", prio, &cn->cn_pc_shape_rnode);
-    perfc_alloc(cn_perfc_shape, group, "inode", prio, &cn->cn_pc_shape_inode);
     perfc_alloc(cn_perfc_shape, group, "lnode", prio, &cn->cn_pc_shape_lnode);
     perfc_alloc(cn_perfc_capped, group, "capped", prio, &cn->cn_pc_capped);
 }
@@ -143,7 +142,6 @@ cn_perfc_free(struct cn *cn)
     perfc_free(&cn->cn_pc_kcompact);
     perfc_free(&cn->cn_pc_kvcompact);
     perfc_free(&cn->cn_pc_shape_rnode);
-    perfc_free(&cn->cn_pc_shape_inode);
     perfc_free(&cn->cn_pc_shape_lnode);
     perfc_free(&cn->cn_pc_capped);
 }

--- a/lib/cn/cn_tree_iter.h
+++ b/lib/cn/cn_tree_iter.h
@@ -26,27 +26,11 @@ cn_tree_walk_callback_fn(
     struct kvset *       kvset);
 
 struct tree_iter {
-    struct cn_tree_node *prev;
     struct cn_tree_node *next;
-    struct cn_tree_node *end;
-    bool                 topdown;
 };
 
-/* TOPDOWN:  Pre-order traversal, visit parents before children.
- * BOTTOMUP: Post-order traversal, visit children before parents.
- */
-#define TRAVERSE_TOPDOWN 0
-#define TRAVERSE_BOTTOMUP 1
-
 void
-tree_iter_init_node(
-    struct cn_tree *     tree,
-    struct tree_iter *   iter,
-    int                  traverse_order,
-    struct cn_tree_node *node);
-
-void
-tree_iter_init(struct cn_tree *tree, struct tree_iter *iter, int traverse_order);
+tree_iter_init(struct cn_tree *tree, struct tree_iter *iter);
 
 struct cn_tree_node *
 tree_iter_next(struct cn_tree *tree, struct tree_iter *iter);

--- a/lib/cn/cn_tree_stats.h
+++ b/lib/cn/cn_tree_stats.h
@@ -18,7 +18,6 @@ void
 cn_tree_perfc_shape_report(
     struct cn_tree *  tree,
     struct perfc_set *rnode,
-    struct perfc_set *inode,
     struct perfc_set *lnode);
 
 #if HSE_MOCKING

--- a/tests/unit/cn/csched_sp3_test.c
+++ b/tests/unit/cn/csched_sp3_test.c
@@ -155,8 +155,6 @@ new_tree(uint fanout)
 
     ttc++;
 
-    tt->tree->ct_root->tn_childc = fanout;
-
     for (int i = 0; i < fanout; i++) {
         struct cn_tree_node *tn;
 
@@ -164,8 +162,7 @@ new_tree(uint fanout)
         if (!tn)
             return NULL;
 
-        tn->tn_parent = tt->tree->ct_root;
-        tt->tree->ct_root->tn_childv[i] = tn;
+        list_add(&tn->tn_link, &tt->tree->ct_leaves);
     }
 
     return tt;
@@ -279,7 +276,7 @@ sp3_work_mock(
     w->cw_mark = list_last_entry(&tn->tn_kvset_list, typeof(*le), le_link);
     w->cw_kvset_cnt = cn_ns_kvsets(&tn->tn_ns);
 
-    if (!tn->tn_parent) {
+    if (cn_node_isroot(tn)) {
 
         w->cw_action = CN_ACTION_SPILL;
         comptype = "rspill";

--- a/tests/unit/cn/merge_test.c
+++ b/tests/unit/cn/merge_test.c
@@ -1162,9 +1162,8 @@ run_testcase(struct mtf_test_info *lcl_ti, int mode, const char *info)
         ASSERT_NE(tree, NULL);
 
         cn_tree_setup(tree, NULL, NULL, &rp, NULL, 1234, 0);
-        tree->ct_root->tn_childc = cp.fanout;
 
-        for (i = 0; i < tree->ct_root->tn_childc; i++) {
+        for (i = 0; i < cp.fanout; i++) {
             struct cn_tree_node *tn;
             char ekbuf[HSE_KVS_KEY_LEN_MAX];
             size_t eklen;
@@ -1174,8 +1173,7 @@ run_testcase(struct mtf_test_info *lcl_ti, int mode, const char *info)
 
             eklen = snprintf(ekbuf, sizeof(ekbuf), "a.%08d", i);
             tn->tn_route_node = route_map_insert(tree->ct_route_map, tn, ekbuf, eklen);
-            tn->tn_parent = tree->ct_root;
-            tree->ct_root->tn_childv[i] = tn;
+            list_add(&tn->tn_link, &tree->ct_leaves);
         }
 
         init_work(


### PR DESCRIPTION
- Remove parent/child pointers from node struct (parent/child relationships are
  now maintained by the tree's route map).
- Added linked list of leaf nodes to tree struct.  This list is not maintained
  in key order (the ordering is maintained by the route map)
- Reworked tree iterator to work w/ new list of nodes.
- Removed some stats related to internal nodes

Signed-off-by: Alex Tomlinson <4172734+alexttx@users.noreply.github.com>
