### PR TITLE
Clamp root spill size

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -367,10 +367,19 @@ jobs:
         image-tag: [8, 9]
         toolchain: [gcc, clang]
         buildtype: [release, debug]
-    if: ${{ github.event_name == 'release' }}
 
     steps:
+      - name: To skip or not to skip
+        id: skip
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            echo "SKIP=false" >> "$GITHUB_ENV"
+          else
+            echo "SKIP=true" >> "$GITHUB_ENV"
+          fi
+
       - name: Initialize
+        if: ${{ env.SKIP == 'false' }}
         run: |
           dnf install -y dnf-plugins-core epel-release
           dnf config-manager --set-enabled powertools
@@ -383,10 +392,12 @@ jobs:
           python3 -m pip install meson==0.62.2 Cython
 
       - name: Checkout HSE
+        if: ${{ env.SKIP == 'false' }}
         uses: actions/checkout@v3
 
       - name: Determine branches
         id: determine-branches
+        if: ${{ env.SKIP == 'false' }}
         shell: sh +e {0}
         run: |
           for p in hse-java hse-python; do
@@ -415,6 +426,7 @@ jobs:
           done
 
       - name: Checkout hse-java
+        if: ${{ env.SKIP == 'false' }}
         uses: actions/checkout@v3
         with:
           repository: hse-project/hse-java
@@ -422,6 +434,7 @@ jobs:
           ref: ${{ steps.determine-branches.outputs.hse-java }}
 
       - name: Checkout hse-python
+        if: ${{ env.SKIP == 'false' }}
         uses: actions/checkout@v3
         with:
           repository: hse-project/hse-python
@@ -429,6 +442,7 @@ jobs:
           ref: ${{ steps.determine-branches.outputs.hse-python }}
 
       - name: Cache Meson packagecache
+        if: ${{ env.SKIP == 'false' }}
         uses: actions/cache@v3
         with:
           path: subprojects/packagecache
@@ -436,6 +450,7 @@ jobs:
 
       - name: Setup Java
         id: setup-java
+        if: ${{ env.SKIP == 'false' }}
         uses: actions/setup-java@v3
         with:
           distribution: adopt
@@ -446,35 +461,38 @@ jobs:
       # Maven from downloading dependencies during the test phase which could
       # cause tests to timeout.
       - name: Download Maven Dependencies
-        if: ${{ steps.setup-java.outputs.cache-hit != 'true' }}
+        if: ${{ env.SKIP == 'false' && steps.setup-java.outputs.cache-hit != 'true' }}
         run: |
           mvn --file subprojects/hse-java/pom.xml dependency:go-offline
 
       - name: Setup gcc toolchain
-        if: ${{ matrix.toolchain == 'gcc' }}
+        if: ${{ env.SKIP == 'false' && matrix.toolchain == 'gcc' }}
         run: |
           echo "CC=gcc" >> "$GITHUB_ENV"
           echo "CXX=g++" >> "$GITHUB_ENV"
           dnf install -y gcc gcc-c++
 
       - name: Setup clang toolchain
-        if: ${{ matrix.toolchain == 'clang' }}
+        if: ${{ env.SKIP == 'false' && matrix.toolchain == 'clang' }}
         run: |
           echo "CC=clang" >> "$GITHUB_ENV"
           echo "CXX=clang++" >> "$GITHUB_ENV"
           dnf install -y clang
 
       - name: Setup
+        if: ${{ env.SKIP == 'false' }}
         run: |
           meson builddir --fatal-meson-warnings --werror \
             --buildtype=${{ matrix.buildtype }} -Dtools=enabled \
             -Ddocs=disabled -Dbindings=all
 
       - name: Build
+        if: ${{ env.SKIP == 'false' }}
         run: |
           ninja -C builddir
 
       - name: Test
+        if: ${{ env.SKIP == 'false' }}
         run: |
           ulimit -c unlimited
           meson test -C builddir --setup=ci --print-errorlogs --no-stdsplit

--- a/lib/cn/cn_metrics.h
+++ b/lib/cn/cn_metrics.h
@@ -26,6 +26,7 @@
  */
 struct kvset_stats {
     uint64_t kst_keys;
+    uint64_t kst_tombs;
     uint64_t kst_halen;
     uint64_t kst_hwlen;
     uint64_t kst_kalen;
@@ -122,6 +123,18 @@ static inline u64
 cn_ns_keys(const struct cn_node_stats *ns)
 {
     return ns->ns_kst.kst_keys;
+}
+
+static inline uint64_t
+cn_ns_keys_uniq(const struct cn_node_stats *ns)
+{
+    return ns->ns_keys_uniq;
+}
+
+static inline uint64_t
+cn_ns_tombs(const struct cn_node_stats *ns)
+{
+    return ns->ns_kst.kst_tombs;
 }
 
 static inline uint32_t

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -124,15 +124,24 @@ sp3_work_estimate(struct cn_compaction_work *w)
     }
 }
 
+/* Handle root spill
+ */
 static uint
-sp3_work_rspill_find_kvsets(struct sp3_node *spn, uint n_max, struct kvset_list_entry **mark)
+sp3_work_rspill(
+    struct sp3_node *         spn,
+    struct sp3_thresholds    *thresh,
+    struct kvset_list_entry **mark,
+    enum cn_action *          action,
+    enum cn_comp_rule *       rule)
 {
-    uint                     n_kvsets;
+    struct cn_tree_node *tn = spn2tn(spn);
+    uint runlen_min, runlen_max, runlen;
     struct kvset_list_entry *le;
-    struct cn_tree_node *    tn;
+    size_t sizemb_max, wlen;
 
+    *action = CN_ACTION_SPILL;
+    *rule = CN_CR_RSPILL;
     *mark = NULL;
-    tn = spn2tn(spn);
 
     /* walk from tail (oldest), skip kvsets that are busy */
     list_for_each_entry_reverse(le, &tn->tn_kvset_list, le_link) {
@@ -145,49 +154,42 @@ sp3_work_rspill_find_kvsets(struct sp3_node *spn, uint n_max, struct kvset_list_
     if (!*mark)
         return 0;
 
-    n_kvsets = 1;
+    runlen_min = thresh->rspill_runlen_min;
+    runlen_max = thresh->rspill_runlen_max;
+    sizemb_max = thresh->rspill_sizemb_max;
+    runlen = 1;
+    wlen = 0;
 
     /* look for sequence of non-busy kvsets */
     while ((le = list_prev_entry_or_null(le, le_link, &tn->tn_kvset_list))) {
-        if (n_kvsets == n_max)
-            break;
-
         if (kvset_get_workid(le->le_kvset) != 0)
             break;
 
-        n_kvsets++;
+        wlen += kvset_get_kwlen(le->le_kvset) + kvset_get_vwlen(le->le_kvset);
+
+        /* Limit spill size once we have a sufficiently long run length.
+         */
+        if (runlen >= runlen_min && wlen >= (sizemb_max << 20))
+            break;
+
+        ++runlen;
     }
 
-    return n_kvsets;
-}
-
-/* Handle root spill
- */
-static uint
-sp3_work_rspill(
-    struct sp3_node *         spn,
-    struct sp3_thresholds    *thresh,
-    struct kvset_list_entry **mark,
-    enum cn_action *          action,
-    enum cn_comp_rule *       rule)
-{
-    struct cn_tree_node *tn = spn2tn(spn);
-    uint cnt_min, cnt_max, cnt;
-
-    cnt_min = thresh->rspill_kvsets_min;
-    cnt_max = thresh->rspill_kvsets_max;
-
-    cnt = sp3_work_rspill_find_kvsets(spn, cnt_max, mark);
-    if (cnt < cnt_min)
+    if (runlen < runlen_min)
         return 0;
 
-    *action = CN_ACTION_SPILL;
-    *rule = CN_CR_RSPILL;
-
-    if (cn_ns_clen(&tn->tn_ns) < VBLOCK_MAX_SIZE)
+    if (wlen < VBLOCK_MAX_SIZE) {
         *rule = CN_CR_RTINY;
+        return runlen;
+    }
 
-    return cnt;
+    /* Avoid leaving behind a run too short to spill.  This helps
+     * clear the root node after a load or large ingest of tombs.
+     */
+    if (runlen > runlen_max)
+        runlen -= runlen_min;
+
+    return min_t(uint, runlen, runlen_max);
 }
 
 static uint
@@ -206,21 +208,33 @@ sp3_work_node_idle(
     head = &tn->tn_kvset_list;
     *mark = list_last_entry_or_null(head, typeof(*le), le_link);
     *action = CN_ACTION_COMPACT_KV;
-    *rule = CN_CR_LIDLE;
+    *rule = CN_CR_NONE;
 
     kvsets = cn_ns_kvsets(&tn->tn_ns);
+    ev_debug(1);
 
     /* Keep idle index nodes fully compacted to improve scanning
      * (e.g., mongod index nodes that rarely change after load).
      */
-    if (cn_ns_vblks(&tn->tn_ns) < kvsets)
+    if (cn_ns_vblks(&tn->tn_ns) < kvsets) {
+        *rule = CN_CR_LIDLE_IDX;
         return kvsets;
+    }
 
     /* Otherwise, compact the node if the resulting size is smaller
      * than a single vblock (rare, but happens).
      */
-    if (cn_ns_clen(&tn->tn_ns) < VBLOCK_MAX_SIZE)
+    if (cn_ns_clen(&tn->tn_ns) < VBLOCK_MAX_SIZE) {
+        *rule = CN_CR_LIDLE_SIZE;
         return kvsets;
+    }
+
+    /* Compact if the preponderance of keys appears to be tombs.
+     */
+    if (cn_ns_tombs(&tn->tn_ns) * 100 > cn_ns_keys_uniq(&tn->tn_ns) * 90) {
+        *rule = CN_CR_LIDLE_TOMB;
+        return kvsets;
+    }
 
     return 0;
 }
@@ -272,7 +286,7 @@ sp3_work_leaf_size(
         return 1;
     }
 
-    return min_t(uint, cn_ns_kvsets(&tn->tn_ns), thresh->lcomp_kvsets_max);
+    return min_t(uint, cn_ns_kvsets(&tn->tn_ns), thresh->lcomp_runlen_max);
 }
 
 static uint
@@ -297,7 +311,7 @@ sp3_work_leaf_garbage(
     *action = CN_ACTION_COMPACT_KV;
     *rule = CN_CR_LGARB;
 
-    return min_t(uint, kvsets, thresh->lcomp_kvsets_max);
+    return min_t(uint, kvsets, thresh->lcomp_runlen_max);
 }
 
 static uint

--- a/lib/cn/csched_sp3_work.h
+++ b/lib/cn/csched_sp3_work.h
@@ -29,24 +29,29 @@ enum sp3_work_type {
 };
 
 struct sp3_thresholds {
-    u8 rspill_kvsets_min;
-    u8 rspill_kvsets_max;
-    u8 lcomp_kvsets_max;
-    u8 lcomp_pop_pct;       /* leaf node spill-by-clen percentage threshold */
-    u8 lcomp_pop_keys;      /* leaf node spill-by-keys threshold (units of 4 million) */
-    u8 lscat_hwm;
-    u8 lscat_runlen_max;
-    u8 llen_runlen_min;
-    u8 llen_runlen_max;
-    u8 llen_idlec;
-    u8 llen_idlem;
+    uint8_t  rspill_runlen_min;
+    uint8_t  rspill_runlen_max;
+    uint16_t rspill_sizemb_max;
+    uint8_t  lcomp_runlen_max;
+    uint8_t  lcomp_pop_pct;       /* leaf node spill-by-clen percentage threshold */
+    uint8_t  lcomp_pop_keys;      /* leaf node spill-by-keys threshold (units of 4 million) */
+    uint8_t  lscat_hwm;
+    uint8_t  lscat_runlen_max;
+    uint8_t  llen_runlen_min;
+    uint8_t  llen_runlen_max;
+    uint8_t  llen_idlec;
+    uint8_t  llen_idlem;
 };
 
 /* root spill requires at least 1 kvset,
  * node length reduction requires at least 2 kvsets.
  */
-#define SP3_RSPILL_KVSETS_MIN   ((u8)1)
-#define SP3_LLEN_RUNLEN_MIN     ((u8)2)
+#define SP3_RSPILL_RUNLEN_MIN   (1u)
+#define SP3_RSPILL_RUNLEN_MAX   (16u)
+#define SP3_RSPILL_SIZEMB_MIN   (4u * 1024)
+#define SP3_RSPILL_SIZEMB_MAX   (32u * 1024)
+#define SP3_LLEN_RUNLEN_MIN     (2u)
+#define SP3_LLEN_RUNLEN_MAX     (16u)
 
 /* clang-format on */
 

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -638,6 +638,7 @@ kvset_open2(
         ks->ks_st.kst_kalen += props.mpr_alloc_cap;
         ks->ks_st.kst_kwlen += props.mpr_write_len;
         ks->ks_st.kst_keys += kblk->kb_metrics.num_keys;
+        ks->ks_st.kst_tombs += kblk->kb_metrics.num_tombstones;
     }
 
     /* Cache the large min/max keys from all the kblocks into a packed
@@ -1847,8 +1848,10 @@ kvset_stats(const struct kvset *ks, struct kvset_stats *stats)
 void
 kvset_stats_add(const struct kvset_stats *add, struct kvset_stats *result)
 {
-    result->kst_kvsets += add->kst_kvsets;
     result->kst_keys += add->kst_keys;
+    result->kst_tombs += add->kst_tombs;
+    result->kst_kvsets += add->kst_kvsets;
+
     result->kst_hblks += add->kst_hblks;
     result->kst_kblks += add->kst_kblks;
     result->kst_vblks += add->kst_vblks;

--- a/lib/include/hse_ikvdb/csched.h
+++ b/lib/include/hse_ikvdb/csched.h
@@ -45,7 +45,9 @@ enum cn_comp_rule {
     CN_CR_LLONG,          /* long leaf */
     CN_CR_LIDXF,          /* short leaf, full index node compaction */
     CN_CR_LIDXP,          /* short leaf, partial index node compaction */
-    CN_CR_LIDLE,          /* idle leaf */
+    CN_CR_LIDLE_IDX,      /* idle leaf, index node */
+    CN_CR_LIDLE_SIZE,     /* idle leaf, tiny node */
+    CN_CR_LIDLE_TOMB,     /* idle leaf, mostly tombs */
     CN_CR_LSCATF,         /* vgroup scatter remediation (full node) */
     CN_CR_LSCATP,         /* vgroup scatter remediation (partial node) */
 };
@@ -74,8 +76,12 @@ cn_comp_rule2str(enum cn_comp_rule rule)
         return "lidxf";
     case CN_CR_LIDXP:
         return "lidxp";
-    case CN_CR_LIDLE:
-        return "lidle";
+    case CN_CR_LIDLE_IDX:
+        return "idlidx";
+    case CN_CR_LIDLE_SIZE:
+        return "idlsiz";
+    case CN_CR_LIDLE_TOMB:
+        return "idltmb";
     case CN_CR_LSCATF:
         return "lscatf";
     case CN_CR_LSCATP:


### PR DESCRIPTION
- Add rparam rspill_sizemb_max to limit max rspill size.
- Add comments to guide future zero-writeamp root spill operations.
