### PR TITLE
Rough-in node split with csched

### DIFF
--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -212,7 +212,6 @@ cn_get_perfc(struct cn *cn, enum cn_action action)
 {
     switch (action) {
     case CN_ACTION_NONE:
-    case CN_ACTION_END:
     case CN_ACTION_SPLIT:
         break;
 

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -537,7 +537,7 @@ cn_ingest_prep(
 
     km.km_vused = mblocks->bl_vused;
     km.km_compc = 0;
-    km.km_comp_rule = CN_CR_INGEST;
+    km.km_rule = CN_RULE_INGEST;
     km.km_capped = cn_is_capped(cn);
     km.km_restored = false;
 

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -211,23 +211,22 @@ struct perfc_set *
 cn_get_perfc(struct cn *cn, enum cn_action action)
 {
     switch (action) {
+    case CN_ACTION_NONE:
+    case CN_ACTION_END:
+    case CN_ACTION_SPLIT:
+        break;
 
-        case CN_ACTION_COMPACT_K:
-            return &cn->cn_pc_kcompact;
+    case CN_ACTION_COMPACT_K:
+        return &cn->cn_pc_kcompact;
 
-        case CN_ACTION_COMPACT_KV:
-            return &cn->cn_pc_kvcompact;
+    case CN_ACTION_COMPACT_KV:
+        return &cn->cn_pc_kvcompact;
 
-        case CN_ACTION_SPILL:
-            return &cn->cn_pc_spill;
-
-        case CN_ACTION_SPLIT:
-        case CN_ACTION_NONE:
-        case CN_ACTION_END:
-            break;
+    case CN_ACTION_SPILL:
+        return &cn->cn_pc_spill;
     }
 
-    return 0;
+    return NULL;
 }
 
 struct perfc_set *
@@ -1046,7 +1045,7 @@ cn_open(
     }
 
     log_info(
-        "%s/%s cnid %lu fanout %u pfx_len %u vcomp %u,%lu"
+        "%s/%s cnid %lu fanout %u pfx_len %u vcomp %u,%u"
         " hb %lu%c/%lu kb %lu%c/%lu vb %lu%c/%lu %s%s%s%s%s%s",
         cn->cn_kvdb_alias, cn->cn_kvsname, (ulong)cnid,
         cn->cp->fanout, cn->cp->pfx_len,

--- a/lib/cn/cn_internal.h
+++ b/lib/cn/cn_internal.h
@@ -7,7 +7,6 @@
 #define HSE_KVS_CN_INTERNAL_H
 
 struct cn_tree;
-struct mpool;
 struct kvs_rparams;
 struct cndb;
 struct ikvdb;
@@ -17,7 +16,6 @@ struct csched;
 #include <hse_util/atomic.h>
 #include <hse_util/workqueue.h>
 #include <hse_util/inttypes.h>
-#include <hse_util/mutex.h>
 #include <hse_util/token_bucket.h>
 #include <hse_util/perfc.h>
 
@@ -28,7 +26,6 @@ struct cn {
     struct cn_tree *  cn_tree;
     struct perfc_set  cn_pc_get;
     struct cn_kvdb *  cn_kvdb;
-    struct cn_tstate *cn_tstate;
     struct mpool *    cn_dataset;
     struct cndb *     cn_cndb;
     struct tbkt *     cn_tbkt_maint;

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1821,7 +1821,6 @@ cn_comp_commit(struct cn_compaction_work *w)
 
     switch (w->cw_action) {
     case CN_ACTION_NONE:
-    case CN_ACTION_END:
         break;
 
     case CN_ACTION_COMPACT_K:
@@ -2024,7 +2023,7 @@ cn_comp_compact(struct cn_compaction_work *w)
 
     switch (w->cw_action) {
     case CN_ACTION_NONE:
-    case CN_ACTION_END:
+        err = merr(EINVAL);
         break;
 
     case CN_ACTION_COMPACT_K:

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1718,7 +1718,7 @@ cn_comp_commit(struct cn_compaction_work *w)
         km.km_kblk_list = w->cw_outv[i].kblks;
         km.km_vblk_list = w->cw_outv[i].vblks;
 
-        km.km_comp_rule = w->cw_comp_rule;
+        km.km_rule = w->cw_rule;
         km.km_capped = cn_is_capped(w->cw_tree->cn);
         km.km_restored = false;
 
@@ -1882,7 +1882,7 @@ cn_comp_cleanup(struct cn_compaction_work *w)
                      w->cw_err,
                      sts_job_id_get(&w->cw_job),
                      cn_action2str(w->cw_action),
-                     cn_comp_rule2str(w->cw_comp_rule),
+                     cn_rule2str(w->cw_rule),
                      cn_tree_get_cnid(w->cw_tree),
                      w->cw_node->tn_nodeid,
                      w->cw_dgen_lo,

--- a/lib/cn/cn_tree.h
+++ b/lib/cn/cn_tree.h
@@ -16,32 +16,11 @@
 
 struct cn_tree;
 struct cn_tree_node;
-struct cn_cache;
-enum cn_action;
 enum key_lookup_res;
 struct kvs_buf;
 struct kvs_ktuple;
 struct perfc_set;
 struct query_ctx;
-
-struct cn_tstate_omf;
-typedef merr_t
-cn_tstate_prepare_t(struct cn_tstate_omf *omf, void *arg);
-typedef void
-cn_tstate_commit_t(const struct cn_tstate_omf *omf, void *arg);
-typedef void
-cn_tstate_abort_t(struct cn_tstate_omf *omf, void *arg);
-
-struct cn_tstate {
-    merr_t (*ts_update)(
-        struct cn_tstate *   tstate,
-        cn_tstate_prepare_t *ts_prepare,
-        cn_tstate_commit_t * ts_commit,
-        cn_tstate_abort_t *  ts_abort,
-        void *               arg);
-
-    void (*ts_get)(struct cn_tstate *tstate, u32 *genp, u16 *mapv);
-};
 
 struct cn_tree_node *
 cn_tree_node_lookup(struct cn_tree *tree, const void *key, uint keylen);

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -141,7 +141,7 @@ struct cn_compaction_work {
     uint32_t                 cw_input_vgroups;
     uint                     cw_pfx_len;
     enum cn_action           cw_action;
-    enum cn_comp_rule        cw_comp_rule;
+    enum cn_rule             cw_rule;
     bool                     cw_have_token;
     bool                     cw_rspill_conc;
     struct list_head         cw_rspill_link;

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -1,3 +1,4 @@
+
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
@@ -33,7 +34,6 @@ enum cn_action {
     CN_ACTION_COMPACT_KV,
     CN_ACTION_SPILL,
     CN_ACTION_SPLIT,
-    CN_ACTION_END,
 };
 
 static inline const char *
@@ -41,9 +41,7 @@ cn_action2str(enum cn_action action)
 {
     switch (action) {
     case CN_ACTION_NONE:
-    case CN_ACTION_END:
-        break;
-
+        return "none";
     case CN_ACTION_COMPACT_K:
         return "kcomp";
     case CN_ACTION_COMPACT_KV:

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -40,22 +40,21 @@ static inline const char *
 cn_action2str(enum cn_action action)
 {
     switch (action) {
+    case CN_ACTION_NONE:
+    case CN_ACTION_END:
+        break;
 
-        case CN_ACTION_NONE:
-        case CN_ACTION_END:
-            break;
-
-        case CN_ACTION_COMPACT_K:
-            return "kcomp";
-        case CN_ACTION_COMPACT_KV:
-            return "kvcomp";
-        case CN_ACTION_SPILL:
-            return "spill";
-        case CN_ACTION_SPLIT:
-            return "split";
+    case CN_ACTION_COMPACT_K:
+        return "kcomp";
+    case CN_ACTION_COMPACT_KV:
+        return "kvcomp";
+    case CN_ACTION_SPILL:
+        return "spill";
+    case CN_ACTION_SPLIT:
+        return "split";
     }
 
-    return "unknown_action";
+    return "invalid";
 }
 
 /* compaction work debug flags */
@@ -118,8 +117,6 @@ struct cn_work_est {
  * @cw_t5_update:    debug stats
  */
 struct cn_compaction_work {
-
-    /* initialized in cn_compaction() */
     struct work_struct       cw_work;
     u64                      cw_horizon;
     uint                     cw_iter_flags;
@@ -134,7 +131,6 @@ struct cn_compaction_work {
     struct kvs_rparams *     cw_rp;
     struct kvs_cparams *     cw_cp;
 
-    /* initialized in constructor (cn_tree_find_compaction_candidate) */
     struct cn_tree *         cw_tree;
     struct cn_tree_node *    cw_node;
     struct kvset_list_entry *cw_mark;
@@ -171,7 +167,6 @@ struct cn_compaction_work {
     /* Progress tracking */
     u64 cw_prog_interval;
 
-    /* initialized in cn_tree_prepare_compaction () */
     uint                     cw_outc;
     bool                     cw_drop_tombs;
     uint64_t                *cw_kvsetidv;
@@ -181,7 +176,6 @@ struct cn_compaction_work {
     struct vgmap           **cw_vgmap; /* used during k-compact and split */
     struct kvset_vblk_map    cw_vbmap; /* used only during k-compact */
 
-    /* initialized in cn_compaction_worker() */
     struct cndb_txn      *cw_cndb_txn;
     bool                  cw_keep_vblks;
     void                **cw_cookie;

--- a/lib/cn/cn_tree_create.h
+++ b/lib/cn/cn_tree_create.h
@@ -19,6 +19,7 @@ struct kvs_rparams;
 struct kvset;
 struct mpool;
 struct kvs_cparams;
+struct cn_tree_node;
 
 /**
  * cn_tree_create() - Create a CN_TREE and associate it with

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -471,7 +471,7 @@ sp3_log_progress(struct cn_compaction_work *w, struct cn_merge_stats *ms, bool f
 
         SLOG_FIELD("queue_us", "%lu", qt),
         SLOG_FIELD("prep_us", "%lu", pt),
-        SLOG_FIELD("merge_us", "%lu", bt),
+        SLOG_FIELD("build_us", "%lu", bt),
         SLOG_FIELD("commit_us", "%lu", ct),
         SLOG_END);
 }

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -423,7 +423,7 @@ sp3_log_progress(struct cn_compaction_work *w, struct cn_merge_stats *ms, bool f
         SLOG_FIELD("type", "%s", msg_type),
         SLOG_FIELD("job", "%u", w->cw_job.sj_id),
         SLOG_FIELD("comp", "%s", cn_action2str(w->cw_action)),
-        SLOG_FIELD("rule", "%s", cn_comp_rule2str(w->cw_comp_rule)),
+        SLOG_FIELD("rule", "%s", cn_rule2str(w->cw_rule)),
         SLOG_FIELD("cnid", "%lu", w->cw_tree->cnid),
         SLOG_FIELD("nodeid", "%lu", w->cw_node->tn_nodeid),
         SLOG_FIELD("leaf", "%u", (uint)cn_node_isleaf(w->cw_node)),
@@ -1311,7 +1311,7 @@ sp3_comp_thread_name(
     char *              buf,
     size_t              bufsz,
     enum cn_action      action,
-    enum cn_comp_rule   rule,
+    enum cn_rule        rule,
     uint64_t            nodeid)
 {
     const char *a = "XX";
@@ -1340,52 +1340,52 @@ sp3_comp_thread_name(
     }
 
     switch (rule) {
-    case CN_CR_NONE:
+    case CN_RULE_NONE:
         r = "xx";
         break;
-    case CN_CR_INGEST:
+    case CN_RULE_INGEST:
         r = "s0";
         break;
-    case CN_CR_RSPILL:
+    case CN_RULE_RSPILL:
         r = "sr";
         break;
-    case CN_CR_TSPILL:
+    case CN_RULE_TSPILL:
         r = "st";
         break;
-    case CN_CR_ZSPILL:
+    case CN_RULE_ZSPILL:
         r = "sz";
         break;
-    case CN_CR_SPLIT:
+    case CN_RULE_SPLIT:
         r = "s2";
         break;
-    case CN_CR_GARBAGE:
+    case CN_RULE_GARBAGE:
         r = "gb";
         break;
-    case CN_CR_LENGTHK:
+    case CN_RULE_LENGTHK:
         r = "lk";
         break;
-    case CN_CR_LENGTHV:
+    case CN_RULE_LENGTHV:
         r = "lv";
         break;
-    case CN_CR_INDEXF:
+    case CN_RULE_INDEXF:
         r = "fi";
         break;
-    case CN_CR_INDEXP:
+    case CN_RULE_INDEXP:
         r = "pi";
         break;
-    case CN_CR_IDLE_INDEX:
+    case CN_RULE_IDLE_INDEX:
         r = "ii";
         break;
-    case CN_CR_IDLE_SIZE:
+    case CN_RULE_IDLE_SIZE:
         r = "is";
         break;
-    case CN_CR_IDLE_TOMB:
+    case CN_RULE_IDLE_TOMB:
         r = "it";
         break;
-    case CN_CR_SCATTERF:
+    case CN_RULE_SCATTERF:
         r = "fs";
         break;
-    case CN_CR_SCATTERP:
+    case CN_RULE_SCATTERP:
         r = "ps";
         break;
     }
@@ -1450,7 +1450,7 @@ sp3_job_print(struct sts_job *job, void *priv, char *buf, size_t bufsz)
                  w->cw_tree->cnid,
                  w->cw_node->tn_nodeid,
                  jps->jobwidth, sts_job_id_get(&w->cw_job),
-                 cn_action2str(w->cw_action), cn_comp_rule2str(w->cw_comp_rule),
+                 cn_action2str(w->cw_action), cn_rule2str(w->cw_rule),
                  w->cw_qnum,
                  atomic_read(&w->cw_node->tn_busycnt) >> 16,
                  w->cw_kvset_cnt, (uint)cn_ns_kvsets(&w->cw_ns),
@@ -1482,7 +1482,7 @@ sp3_submit(struct sp3 *sp, struct cn_compaction_work *w, uint qnum)
         w->cw_threadname,
         sizeof(w->cw_threadname),
         w->cw_action,
-        w->cw_comp_rule,
+        w->cw_rule,
         tn->tn_nodeid);
 
     w->cw_iter_flags = kvset_iter_flag_fullscan;
@@ -1553,7 +1553,7 @@ sp3_submit(struct sp3 *sp, struct cn_compaction_work *w, uint qnum)
             SLOG_FIELD("reduce", "%d", sp->samp_reduce),
             SLOG_FIELD("cnid", "%lu", w->cw_tree->cnid),
             SLOG_FIELD("comp", "%s", cn_action2str(w->cw_action)),
-            SLOG_FIELD("rule", "%s", cn_comp_rule2str(w->cw_comp_rule)),
+            SLOG_FIELD("rule", "%s", cn_rule2str(w->cw_rule)),
             SLOG_FIELD("nodeid", "%lu", w->cw_node->tn_nodeid),
             SLOG_FIELD("c_nk", "%u", w->cw_nk),
             SLOG_FIELD("c_nv", "%u", w->cw_nv),

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -144,15 +144,6 @@ struct mpool;
  *      required to manage space amp.
  */
 
-/* Leaf Node Red-Black Trees */
-#define RBT_L_PCAP  0   /* leaf nodes sorted by pct capacity */
-#define RBT_L_GARB  1   /* leaf nodes sorted by garbage */
-#define RBT_L_LEN   2   /* leaf nodes sorted by #kvsets */
-#define RBT_L_IDLE  3   /* leaf nodes sorted by ttl */
-#define RBT_L_SCAT  4   /* leaf nodes sorted by vgroup scatter */
-
-static_assert(RBT_L_SCAT + 1 == RBT_MAX, "RBT_MAX is too small or too large");
-
 #define CSCHED_SAMP_MAX_MIN  100
 #define CSCHED_SAMP_MAX_MAX  999
 #define CSCHED_LO_TH_PCT_MIN 5
@@ -197,7 +188,7 @@ struct sp3 {
     atomic_int               running;
     struct sp3_qinfo         qinfo[SP3_QNUM_MAX];
 
-    struct rb_root rbt[RBT_MAX] HSE_L1D_ALIGNED;
+    struct rb_root rbt[wtype_MAX - 1] HSE_L1D_ALIGNED;
 
     struct list_head mon_tlist HSE_L1D_ALIGNED;
     struct list_head spn_rlist;
@@ -209,7 +200,7 @@ struct sp3 {
     uint             jobs_started;
     uint             jobs_finished;
     uint             jobs_max;
-    uint             rr_job_type;
+    uint             rr_wtype;
     u64              job_id;
 
     struct cn_compaction_work *wp;
@@ -249,7 +240,6 @@ struct sp3 {
     bool tree_shape_bad;
     uint lvl_max;
 
-    u64                  leaf_pop_size;
     struct cn_samp_stats samp;
     struct cn_samp_stats samp_wip;
     struct perfc_set     sched_pc;
@@ -356,25 +346,18 @@ samp_pct_garbage(struct cn_samp_stats *s, uint scale)
 static void
 sp3_node_init(struct sp3 *sp, struct sp3_node *spn)
 {
-    struct cn_tree_node *tn;
-    uint ttl, tx;
-
     spn->spn_initialized = true;
     spn->spn_cgen = UINT_MAX;
 
-    for (tx = 0; tx < RBT_MAX; tx++)
+    for (uint tx = 0; tx < NELEM(spn->spn_rbe); tx++)
         RB_CLEAR_NODE(&spn->spn_rbe[tx].rbe_node);
 
-    tn = spn2tn(spn);
     INIT_LIST_HEAD(&spn->spn_rlink);
     INIT_LIST_HEAD(&spn->spn_alink);
 
     /* Append to list of all nodes from all managed trees.
      */
     list_add_tail(&spn->spn_alink, &sp->spn_alist);
-
-    ttl = sp->rp ? sp->rp->csched_node_min_ttl : 13;
-    spn->spn_ttl = (ttl << (tn->tn_nodeid > 0));
 }
 
 static void
@@ -625,9 +608,9 @@ sp3_refresh_thresholds(struct sp3 *sp)
         thresh.rspill_runlen_min = (v >> 8) & 0xff;
         thresh.rspill_sizemb_max = (v >> 16) & 0xffff;
     } else {
-        thresh.rspill_runlen_max = 9;
-        thresh.rspill_runlen_min = 5;
-        thresh.rspill_sizemb_max = 8192;
+        thresh.rspill_runlen_max = SP3_RSPILL_RUNLEN_MAX_DEFAULT;
+        thresh.rspill_runlen_min = SP3_RSPILL_RUNLEN_MIN_DEFAULT;
+        thresh.rspill_sizemb_max = SP3_RSPILL_SIZEMB_MAX_DEFAULT;
     }
 
     thresh.rspill_runlen_max = clamp_t(uint8_t, thresh.rspill_runlen_max,
@@ -643,12 +626,12 @@ sp3_refresh_thresholds(struct sp3 *sp)
     v = sp->rp->csched_leaf_comp_params;
     if (v) {
         thresh.lcomp_runlen_max = (v >> 0) & 0xff;
-        thresh.lcomp_pop_pct = (v >> 16) & 0xff;
-        thresh.lcomp_pop_keys = (v >> 24) & 0xff;
+        thresh.lcomp_split_pct = (v >> 16) & 0xff;
+        thresh.lcomp_split_keys = (v >> 24) & 0xff;
     } else {
-        thresh.lcomp_runlen_max = 12;
-        thresh.lcomp_pop_pct = 100;
-        thresh.lcomp_pop_keys = 128; /* units of 4 billion */
+        thresh.lcomp_runlen_max = SP3_LCOMP_RUNLEN_MAX;
+        thresh.lcomp_split_pct = SP3_LCOMP_SPLIT_PCT;
+        thresh.lcomp_split_keys = SP3_LCOMP_SPLIT_KEYS; /* units of 4 million */
     }
 
     /* leaf node length settings */
@@ -659,10 +642,10 @@ sp3_refresh_thresholds(struct sp3 *sp)
         thresh.llen_idlec = (v >> 24) & 0xff;
         thresh.llen_idlem = (v >> 32) & 0xff;
     } else {
-        thresh.llen_runlen_max = 8;
-        thresh.llen_runlen_min = 4;
-        thresh.llen_idlec = 2;
-        thresh.llen_idlem = 10;
+        thresh.llen_runlen_max = SP3_LLEN_RUNLEN_MAX_DEFAULT;
+        thresh.llen_runlen_min = SP3_LLEN_RUNLEN_MIN_DEFAULT;
+        thresh.llen_idlec = SP3_LLEN_IDLEC_DEFAULT;
+        thresh.llen_idlem = SP3_LLEN_IDLEM_DEFAULT;
     }
 
     thresh.llen_runlen_max = clamp_t(uint8_t, thresh.llen_runlen_max,
@@ -691,8 +674,8 @@ sp3_refresh_thresholds(struct sp3 *sp)
     log_info("sp3 thresholds: rspill: min/max/sizemb %u/%u/%u, lcomp: max/pct/keys %u/%u%%/%u,"
              " llen: min/max %u/%u, idlec: %u, idlem: %u, lscat: hwm/max %u/%u",
              thresh.rspill_runlen_min, thresh.rspill_runlen_max, thresh.rspill_sizemb_max,
-             thresh.lcomp_runlen_max, thresh.lcomp_pop_pct,
-             thresh.lcomp_pop_keys, thresh.llen_runlen_min, thresh.llen_runlen_max,
+             thresh.lcomp_runlen_max, thresh.lcomp_split_pct,
+             thresh.lcomp_split_keys, thresh.llen_runlen_min, thresh.llen_runlen_max,
              thresh.llen_idlec, thresh.llen_idlem,
              thresh.lscat_hwm, thresh.lscat_runlen_max);
 }
@@ -854,7 +837,7 @@ sp3_node_insert(struct sp3 *sp, struct sp3_node *spn, uint tx, u64 weight)
     struct rb_root *root = sp->rbt + tx;
     struct sp3_rbe *rbe = spn->spn_rbe + tx;
 
-    assert(tx < RBT_MAX);
+    assert(tx < NELEM(spn->spn_rbe));
 
     if (!RB_EMPTY_NODE(&rbe->rbe_node)) {
         if (rbe->rbe_weight == weight)
@@ -881,7 +864,7 @@ sp3_node_unlink(struct sp3 *sp, struct sp3_node *spn)
 {
     uint tx;
 
-    for (tx = 0; tx < RBT_MAX; tx++)
+    for (tx = 0; tx < NELEM(spn->spn_rbe); tx++)
         sp3_rb_erase(sp->rbt + tx, spn->spn_rbe + tx);
 }
 
@@ -900,9 +883,6 @@ sp3_unlink_all_nodes(struct sp3 *sp, struct cn_tree *tree)
         list_del_init(&spn->spn_alink);
     }
 }
-
-static_assert(NELEM(((struct sp3_node *)0)->spn_rbe) == RBT_MAX,
-              "number of elements of spn_rbe[] is not RBT_MAX");
 
 static void
 sp3_dirty_node_locked(struct sp3 *sp, struct cn_tree_node *tn)
@@ -938,81 +918,69 @@ sp3_dirty_node_locked(struct sp3 *sp, struct cn_tree_node *tn)
 
         scatter = cn_tree_node_scatter(tn);
 
-        /* RBT_L_LEN: internal and leaf nodes sorted by number of kvsets.
+        /* Leaf nodes sorted by number of kvsets.
          * We use inverse scatter as a secondary discriminant so as to
          * prefer scatter jobs over kcompactions when scatter is high.
          */
         if (nkvsets >= sp->thresh.llen_runlen_min && jobs < 1) {
             const uint64_t weight = (nkvsets << 32) | (UINT32_MAX - scatter);
 
-            sp3_node_insert(sp, spn, RBT_L_LEN, weight);
+            sp3_node_insert(sp, spn, wtype_length, weight);
         } else {
-            sp3_node_remove(sp, spn, RBT_L_LEN);
-        }
-
-        /* RBT_L_IDLE: Nodes sorted by idle check expiration time.
-         * Time is a negative offset in 4-second intervals from
-         * UINT32_MAX in order to work correctly with the rb-tree
-         * weight comparator logic.
-         */
-        if (nkvsets >= sp->thresh.llen_idlec && jobs < 1) {
-            if (sp->thresh.llen_idlem > 0) {
-                const uint64_t ttl = (sp->thresh.llen_idlem * 60) / 4;
-                uint64_t weight = UINT32_MAX - (jclock_ns >> 32) - ttl;
-
-                weight = (weight << 32) | nkvsets;
-
-                sp3_node_insert(sp, spn, RBT_L_IDLE, weight);
-            }
-        } else {
-            sp3_node_remove(sp, spn, RBT_L_IDLE);
+            sp3_node_remove(sp, spn, wtype_length);
         }
 
         garbage = samp_pct_garbage(&tn->tn_samp, 100);
 
-        /* RBT_L_GARB: leaf nodes sorted by pct garbage.
+        /* Leaf nodes sorted by pct garbage.
          * Range: 0 <= rbe_weight <= 100.  If rbe_weight == 3, then
          * node has 3% garbage.
          * We use alen as the secondary discriminant to prefer nodes
          * with higher total bytes of garbage.
+         *
+         * TODO: The garbage caculation needs help:  It sometimes returns
+         * a non-zero result for nodes consisting entirely of unique keys.
          */
         if (garbage > 0 && nkvsets > 1 && jobs < 1) {
             const uint64_t weight = ((uint64_t)garbage << 32) | (cn_ns_alen(&tn->tn_ns) >> 20);
 
-            sp3_node_insert(sp, spn, RBT_L_GARB, weight);
+            sp3_node_insert(sp, spn, wtype_garbage, weight);
         } else {
-            sp3_node_remove(sp, spn, RBT_L_GARB);
+            sp3_node_remove(sp, spn, wtype_garbage);
         }
 
-        /* RBT_L_SCAT: leaf nodes sorted by vgroup scatter and garbage.
+        /* Leaf nodes sorted by vgroup scatter and garbage.
          */
         if (scatter > 0 && jobs < 1) {
             const uint64_t weight = ((uint64_t)scatter << 32) | garbage;
 
-            sp3_node_insert(sp, spn, RBT_L_SCAT, weight);
+            sp3_node_insert(sp, spn, wtype_scatter, weight);
         } else {
-            sp3_node_remove(sp, spn, RBT_L_SCAT);
+            sp3_node_remove(sp, spn, wtype_scatter);
         }
 
-        /* RBT_L_PCAP: Leaf nodes sorted by pct capacity and secondarily by
-         * number of keys.  If the node's size doesn't exceed the "pop_pct"
+        /* Leaf nodes sorted by pct capacity and secondarily by
+         * number of keys.  If the node's size doesn't exceed the "split_pct"
          * threshold then we check to see if the number of keys exceeds the
-         * "pop_keys" threshold.  If so, we insert this node into the tree
-         * with "pop_pct" capacity to ensure it gets spilled.
+         * "split_keys" threshold.  If so, we insert this node into the tree
+         * with "split_pct" capacity to ensure it gets split or compacted.
          */
-        if (tn->tn_ns.ns_pcap >= sp->thresh.lcomp_pop_pct && jobs < 1) {
+        if (tn->tn_ns.ns_pcap >= sp->thresh.lcomp_split_pct && jobs < 1) {
             const uint64_t weight = ((uint64_t)tn->tn_ns.ns_pcap << 32) | nkeys;
 
-            sp3_node_insert(sp, spn, RBT_L_PCAP, weight);
+            sp3_node_insert(sp, spn, wtype_split, weight);
+            ev_debug(1);
         } else {
-            uint64_t pop_keys = (uint64_t)sp->thresh.lcomp_pop_keys << 32;
+            uint64_t split_keys = (uint64_t)sp->thresh.lcomp_split_keys << 22;
+            uint64_t keys_uniq = cn_ns_keys_uniq(&tn->tn_ns);
 
-            if (nkeys > pop_keys && jobs < 1) {
-                const uint64_t weight = ((uint64_t)sp->thresh.lcomp_pop_pct << 32) | nkeys;
+            if (keys_uniq > split_keys && jobs < 1) {
+                const uint64_t weight = ((uint64_t)sp->thresh.lcomp_split_pct << 32) | keys_uniq;
 
-                sp3_node_insert(sp, spn, RBT_L_PCAP, weight);
+                sp3_node_insert(sp, spn, wtype_split, weight);
+                ev_debug(1);
             } else {
-                sp3_node_remove(sp, spn, RBT_L_PCAP);
+                sp3_node_remove(sp, spn, wtype_split);
             }
         }
     } else {
@@ -1029,12 +997,28 @@ sp3_dirty_node_locked(struct sp3 *sp, struct cn_tree_node *tn)
         }
     }
 
+    /* Nodes sorted by idle check expiration time.
+     * Time is a negative offset in 4-second intervals from
+     * UINT32_MAX in order to work correctly with the rb-tree
+     * weight comparator logic.
+     */
+    if (nkvsets >= sp->thresh.llen_idlec && sp->thresh.llen_idlem > 0 && jobs < 1) {
+        const uint64_t ttl = (sp->thresh.llen_idlem * 60) / 4;
+        uint64_t weight = UINT32_MAX - (jclock_ns >> 32) - ttl;
+
+        weight = (weight << 32) | nkvsets;
+
+        sp3_node_insert(sp, spn, wtype_idle, weight);
+    } else {
+        sp3_node_remove(sp, spn, wtype_idle);
+    }
+
     if (debug_dirty_node(sp)) {
         slog_info(
             SLOG_START("cn_dirty_node"),
             SLOG_FIELD("cnid", "%lu", (ulong)tn->tn_tree->cnid),
-            SLOG_FIELD("nodeid", "%lu", (ulong)tn->tn_nodeid),
-            SLOG_FIELD("kvsets", "%lu", (ulong)nkvsets_total),
+            SLOG_FIELD("nodeid", "%-2lu", (ulong)tn->tn_nodeid),
+            SLOG_FIELD("kvsets", "%-2lu", (ulong)nkvsets_total),
             SLOG_FIELD("keys", "%lu", (ulong)cn_ns_keys(&tn->tn_ns)),
             SLOG_FIELD("uniq", "%lu", (ulong)cn_ns_keys_uniq(&tn->tn_ns)),
             SLOG_FIELD("tombs", "%lu", (ulong)cn_ns_tombs(&tn->tn_ns)),
@@ -1322,14 +1306,13 @@ sp3_work_progress(struct cn_compaction_work *w)
     sp3_log_progress(w, &ms, false);
 }
 
-static inline void
+static void
 sp3_comp_thread_name(
     char *              buf,
     size_t              bufsz,
     enum cn_action      action,
     enum cn_comp_rule   rule,
-    uint64_t            nodeid,
-    bool                leaf)
+    uint64_t            nodeid)
 {
     const char *a = "XX";
     const char *r = "XX";
@@ -1337,7 +1320,6 @@ sp3_comp_thread_name(
     switch (action) {
     case CN_ACTION_NONE:
     case CN_ACTION_END:
-    case CN_ACTION_SPLIT:
         break;
 
     case CN_ACTION_COMPACT_K:
@@ -1351,6 +1333,10 @@ sp3_comp_thread_name(
     case CN_ACTION_SPILL:
         a = "sp";
         break;
+
+    case CN_ACTION_SPLIT:
+        a = "s2";
+        break;
     }
 
     switch (rule) {
@@ -1363,40 +1349,43 @@ sp3_comp_thread_name(
     case CN_CR_RSPILL:
         r = "sr";
         break;
-    case CN_CR_RTINY:
-        r = "tr";
+    case CN_CR_TSPILL:
+        r = "st";
         break;
-    case CN_CR_LBIG:
-        r = "bn";
+    case CN_CR_ZSPILL:
+        r = "sz";
         break;
-    case CN_CR_LBIG_ONE:
-        r = "b1";
+    case CN_CR_SPLIT:
+        r = "s2";
         break;
-    case CN_CR_LGARB:
+    case CN_CR_GARBAGE:
         r = "gb";
         break;
-    case CN_CR_LLONG:
-        r = "lg";
+    case CN_CR_LENGTHK:
+        r = "lk";
         break;
-    case CN_CR_LIDXF:
-        r = "fx";
+    case CN_CR_LENGTHV:
+        r = "lv";
         break;
-    case CN_CR_LIDXP:
-        r = "px";
+    case CN_CR_INDEXF:
+        r = "fi";
         break;
-    case CN_CR_LIDLE_IDX:
+    case CN_CR_INDEXP:
+        r = "pi";
+        break;
+    case CN_CR_IDLE_INDEX:
         r = "ii";
         break;
-    case CN_CR_LIDLE_SIZE:
+    case CN_CR_IDLE_SIZE:
         r = "is";
         break;
-    case CN_CR_LIDLE_TOMB:
+    case CN_CR_IDLE_TOMB:
         r = "it";
         break;
-    case CN_CR_LSCATF:
+    case CN_CR_SCATTERF:
         r = "fs";
         break;
-    case CN_CR_LSCATP:
+    case CN_CR_SCATTERP:
         r = "ps";
         break;
     }
@@ -1494,8 +1483,7 @@ sp3_submit(struct sp3 *sp, struct cn_compaction_work *w, uint qnum)
         sizeof(w->cw_threadname),
         w->cw_action,
         w->cw_comp_rule,
-        tn->tn_nodeid,
-        cn_node_isleaf(w->cw_node));
+        tn->tn_nodeid);
 
     w->cw_iter_flags = kvset_iter_flag_fullscan;
     w->cw_io_workq = NULL;
@@ -1593,7 +1581,7 @@ sp3_check_roots(struct sp3 *sp, uint qnum)
     list_for_each_entry_safe(spn, next, &sp->spn_rlist, spn_rlink) {
         bool have_work;
 
-        if (sp3_work(spn, &sp->thresh, wtype_rspill, debug, &sp->wp))
+        if (sp3_work(spn, wtype_root, &sp->thresh, debug, &sp->wp))
             return false;
 
         have_work = sp->wp && sp->wp->cw_action != CN_ACTION_NONE;
@@ -1632,7 +1620,7 @@ sp3_rb_dump(struct sp3 *sp, uint tx, uint count_max)
     struct cn_tree_node *tn;
     uint                 count;
 
-    if (tx >= RBT_MAX)
+    if (tx >= NELEM(sp->rbt))
         return;
 
     /* spn_rbe must be first element in sp3_node struct in order for
@@ -1804,17 +1792,17 @@ static_assert(offsetof(struct sp3_node, spn_rbe) == 0,
               "spn_rbe must be first field in struct sp3_node");
 
 static bool
-sp3_check_rb_tree(struct sp3 *sp, uint tx, u64 threshold, enum sp3_work_type wtype, uint qnum)
+sp3_check_rb_tree(struct sp3 *sp, enum sp3_work_type wtype, uint64_t threshold, uint qnum)
 {
     struct rb_root *root;
     struct rb_node *rbn;
     uint            debug;
 
-    assert(tx < RBT_MAX);
+    assert(wtype < NELEM(sp->rbt));
 
     debug = csched_rp_dbg_comp(sp->rp);
 
-    root = sp->rbt + tx;
+    root = sp->rbt + wtype;
     rbn = rb_first(root);
 
     while (rbn) {
@@ -1823,19 +1811,19 @@ sp3_check_rb_tree(struct sp3 *sp, uint tx, u64 threshold, enum sp3_work_type wty
         bool             have_work;
 
         rbe = rb_entry(rbn, struct sp3_rbe, rbe_node);
-        spn = (void *)(rbe - tx);
+        spn = (void *)(rbe - wtype);
 
         if (rbe->rbe_weight < threshold)
             return false;
 
-        if (sp3_work(spn, &sp->thresh, wtype, debug, &sp->wp))
+        if (sp3_work(spn, wtype, &sp->thresh, debug, &sp->wp))
             return false;
 
         /* Remove node from future consideration of this job type
          * until put back on the RBT by sp3_dirty_node().
          */
         rbn = rb_next(rbn);
-        sp3_node_remove(sp, spn, tx);
+        sp3_node_remove(sp, spn, wtype);
 
         have_work = sp->wp && sp->wp->cw_action != CN_ACTION_NONE;
         if (have_work) {
@@ -1931,19 +1919,7 @@ sp3_qos_check(struct sp3 *sp)
 static void
 sp3_schedule(struct sp3 *sp)
 {
-    enum job_type {
-        jtype_root,
-        jtype_leaf_len,
-        jtype_leaf_idle,
-        jtype_leaf_garbage,
-        jtype_leaf_scatter,
-        jtype_leaf_size,
-        jtype_MAX,
-    };
-
     bool job = false;
-    uint rp_leaf_pct;
-    uint rr;
 
     /* This log message should never be emitted (unless someone has reduced
      * csched_qthreads at run time).  Scheduling of new jobs will resume
@@ -1956,91 +1932,74 @@ sp3_schedule(struct sp3 *sp)
         return;
     }
 
-    /* convert rparam to internal scale */
-    rp_leaf_pct = sp->inputs.csched_leaf_pct * SCALE / EXT_SCALE;
-
-    for (rr = 0; !job && rr < jtype_MAX; rr++) {
+    for (uint rr = 0; rr < wtype_MAX && !job; rr++) {
+        uint rp_leaf_pct, qnum;
         uint64_t thresh;
-        uint qnum;
 
         /* round robin between job types */
-        sp->rr_job_type++;
-        if (sp->rr_job_type >= jtype_MAX)
-            sp->rr_job_type = 0;
+        sp->rr_wtype = (sp->rr_wtype + 1) % wtype_MAX;
 
-        switch (sp->rr_job_type) {
-        case jtype_root:
+        switch (sp->rr_wtype) {
+        case wtype_root:
             qnum = SP3_QNUM_ROOT;
             if (qfull(sp, qnum))
                 break;
 
-            /* Implements root node query-shape rule.
-             * Uses "root" queue.
-             */
             job = sp3_check_roots(sp, qnum);
             break;
 
-        case jtype_leaf_len:
-            qnum = SP3_QNUM_LLEN;
+        case wtype_length:
+            qnum = SP3_QNUM_LENGTH;
             if (qfull(sp, qnum))
                 break;
 
-            /* Service RBT_L_LEN red-black tree.
-             * Implements:
-             *   - Internal node query-shape rule
-             *   - Leaf node query-shape rule
-             */
-            job = sp3_check_rb_tree(sp, RBT_L_LEN, 0, wtype_node_len, qnum);
+            job = sp3_check_rb_tree(sp, sp->rr_wtype, 0, qnum);
             break;
 
-        case jtype_leaf_idle:
+        case wtype_idle:
             qnum = SP3_QNUM_SHARED;
             if (qfull(sp, qnum))
                 break;
 
-            /* Service RBT_L_IDLE red-black tree.
-             * Implements:
-             *   - Idle node query-shape rule
-             */
-            if (sp->thresh.llen_idlec > 0) {
-                thresh = (UINT32_MAX - (jclock_ns >> 32)) << 32;
+            thresh = (UINT32_MAX - (jclock_ns >> 32)) << 32;
 
-                job = sp3_check_rb_tree(sp, RBT_L_IDLE, thresh, wtype_node_idle, qnum);
-            }
+            job = sp3_check_rb_tree(sp, sp->rr_wtype, thresh, qnum);
             break;
 
-        case jtype_leaf_garbage:
-            qnum = SP3_QNUM_LGARB;
+        case wtype_garbage:
+            qnum = SP3_QNUM_GARBAGE;
             if (qfull(sp, qnum)) {
                 qnum = SP3_QNUM_SHARED;
                 if (qfull(sp, qnum))
                     break;
             }
 
-            /* Service RBT_L_GARB red-black tree.
-             * Implements:
+            /* convert rparam to internal scale */
+            rp_leaf_pct = (uint)sp->inputs.csched_leaf_pct * SCALE / EXT_SCALE;
+
+            /* Implements:
              *   - Leaf node space amp rule
              * Notes:
-             *   - Don't check for garbage unless ucomp is active
-             *     or if in samp_reduce mode and leaf percent is
-             *     somewhat caught up (ie, current leaf pct
-             *     (lpct_targ) is within 90% of rparam setting
-             *     (rp_leaf_pct)).
-             *   - When checking for garbage, if leaf percent is
-             *     behind, then bump up threshold so we don't waste
-             *     write amp by compacting nodes with a small
-             *     amount of garbage (we'd rather wait for
-             *     leaf_pct to catch up).
+             *   - Check for garbage if ucomp is active OR samp_reduce mode is enabled
+             *     and leaf percent is somewhat caught up (ie, current leaf pct (lpct_targ)
+             *     is within 90% of rparam setting (rp_leaf_pct)).
+             *   - When checking for garbage, if leaf percent is behind, then bump up
+             *     the threshold so we don't waste write amp compacting nodes with
+             *     low garbage (we'd rather wait for leaf_pct to catch up).
+             *   - If neither ucomp nor samp_reduce is active then check for nodes
+             *     with excessively high garbage (e.g., 90% is roughly 10x garbage,
+             *     93% is roughly 15x garbage, 95% is roughly 20x garbage, ...)
              */
             if (sp->samp_reduce && (100 * sp->lpct_targ > 90 * rp_leaf_pct)) {
                 thresh = (sp->lpct_targ < rp_leaf_pct ? 10ul : 0ul) << 32;
-
-                job = sp3_check_rb_tree(sp, RBT_L_GARB, thresh, wtype_leaf_garbage, qnum);
+            } else {
+                thresh = 93ul << 32;
             }
+            job = sp3_check_rb_tree(sp, sp->rr_wtype, thresh, qnum);
             break;
 
-        case jtype_leaf_scatter:
-            qnum = SP3_QNUM_LSCAT;
+        case wtype_scatter:
+            qnum = SP3_QNUM_SCATTER;
             if (qfull(sp, qnum)) {
                 qnum = SP3_QNUM_SHARED;
                 if (qfull(sp, qnum))
@@ -2049,23 +2008,15 @@ sp3_schedule(struct sp3 *sp)
 
             thresh = (uint64_t)sp->thresh.lscat_hwm << 32;
 
-            job = sp3_check_rb_tree(sp, RBT_L_SCAT, thresh, wtype_leaf_scatter, qnum);
+            job = sp3_check_rb_tree(sp, sp->rr_wtype, thresh, qnum);
             break;
 
-        case jtype_leaf_size:
-            qnum = SP3_QNUM_LSIZE;
-            if (qfull(sp, qnum)) {
-                qnum = SP3_QNUM_SHARED;
-                if (qfull(sp, qnum))
-                    break;
-            }
+        case wtype_split:
+            qnum = SP3_QNUM_SPLIT;
+            if (qfull(sp, qnum))
+                break;
 
-            /* Service RBT_L_PCAP red-black tree.
-             * - Handles big leaf nodes with or with out garbage.
-             * Implements:
-             *   - Leaf node size rule
-             */
-            job = sp3_check_rb_tree(sp, RBT_L_PCAP, 0, wtype_leaf_size, qnum);
+            job = sp3_check_rb_tree(sp, sp->rr_wtype, 0, qnum);
             break;
         }
     }
@@ -2197,7 +2148,7 @@ sp3_monitor(struct work_struct *work)
         if (now > chk_shape.next) {
             sp3_tree_shape_check(sp);
             if (debug_rbtree(sp)) {
-                for (uint tx = 0; tx < RBT_MAX; tx++)
+                for (uint tx = 0; tx < NELEM(sp->rbt); tx++)
                     sp3_rb_dump(sp, tx, 25);
             }
             chk_shape.next = now + chk_shape.interval;
@@ -2355,7 +2306,7 @@ sp3_destroy(struct csched *handle)
     assert(list_empty(&sp->mon_tlist));
     assert(list_empty(&sp->work_list));
 
-    for (tx = 0; tx < RBT_MAX; tx++)
+    for (tx = 0; tx < NELEM(sp->rbt); tx++)
         assert(!rb_first(sp->rbt + tx));
 
     atomic_set(&sp->running, 0);
@@ -2424,7 +2375,7 @@ sp3_create(
     INIT_LIST_HEAD(&sp->spn_alist);
     INIT_LIST_HEAD(&sp->spn_rlist);
 
-    for (tx = 0; tx < RBT_MAX; tx++)
+    for (tx = 0; tx < NELEM(sp->rbt); tx++)
         sp->rbt[tx] = RB_ROOT;
 
     atomic_set(&sp->running, 1);

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -1319,7 +1319,7 @@ sp3_comp_thread_name(
 
     switch (action) {
     case CN_ACTION_NONE:
-    case CN_ACTION_END:
+        a = "no";
         break;
 
     case CN_ACTION_COMPACT_K:

--- a/lib/cn/csched_sp3.h
+++ b/lib/cn/csched_sp3.h
@@ -12,9 +12,10 @@
 #include <error/merr.h>
 #include <hse_util/list.h>
 
+#include "csched_sp3_work.h"
+
 /* MTF_MOCK_DECL(csched_sp3) */
 
-#define RBT_MAX 5
 #define CN_THROTTLE_MAX (THROTTLE_SENSOR_SCALE_MED + 50)
 
 struct kvdb_rparams;
@@ -31,10 +32,9 @@ struct sp3_rbe {
 };
 
 struct sp3_node {
-    struct sp3_rbe   spn_rbe[RBT_MAX];
+    struct sp3_rbe   spn_rbe[wtype_MAX - 1];
     struct list_head spn_rlink;
     struct list_head spn_alink;
-    u16              spn_ttl;
     bool             spn_initialized;
     uint             spn_cgen;
 };

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -566,13 +566,11 @@ sp3_work(
 
     switch (action) {
     case CN_ACTION_SPILL:
-        uint jobs = atomic_read(&tn->tn_busycnt) >> 16;
+        if ((atomic_read(&tn->tn_busycnt) >> 16) > 2)
+            goto locked_nowork;
 
         if (!cn_node_isroot(tn))
             abort();
-
-        if (jobs > 2)
-            goto locked_nowork;
 
         cn_node_comp_token_put(tn);
         have_token = false;

--- a/lib/cn/csched_sp3_work.h
+++ b/lib/cn/csched_sp3_work.h
@@ -9,23 +9,46 @@
 #include <error/merr.h>
 #include <hse_util/inttypes.h>
 
-#include "csched_sp3.h"
-
 /* MTF_MOCK_DECL(csched_sp3_work) */
 
 /* clang-format off */
 
-struct kvset;
-struct cn_tree_node;
+#define SP3_RSPILL_RUNLEN_MIN           (1u) /* root spill requires at least 1 kvset */
+#define SP3_RSPILL_RUNLEN_MAX           (16u)
+#define SP3_RSPILL_RUNLEN_MIN_DEFAULT   (5u)
+#define SP3_RSPILL_RUNLEN_MAX_DEFAULT   (9u)
+
+#define SP3_RSPILL_SIZEMB_MIN           (4u * 1024)
+#define SP3_RSPILL_SIZEMB_MAX           (32u * 1024)
+#define SP3_RSPILL_SIZEMB_MAX_DEFAULT   (8u * 1024)
+
+#define SP3_LLEN_RUNLEN_MIN             (2u) /* length reduction requires at least 2 kvsets */
+#define SP3_LLEN_RUNLEN_MAX             (16u)
+#define SP3_LLEN_RUNLEN_MIN_DEFAULT     (4u)
+#define SP3_LLEN_RUNLEN_MAX_DEFAULT     (8u)
+#define SP3_LLEN_IDLEC_DEFAULT          (2u)  /* minimum number of kvsets */
+#define SP3_LLEN_IDLEM_DEFAULT          (10u) /* minimum number of minutes */
+
+#define SP3_LCOMP_RUNLEN_MAX            (12u)
+#define SP3_LCOMP_SPLIT_PCT             (100u)
+#define SP3_LCOMP_SPLIT_KEYS            (128u) /* units of 4 million */
+
+/* clang-format on */
+
+struct sp3_node;
 struct cn_compaction_work;
 
+/* The first work types up to but not including wtype_root are used to index
+ * the work tree arrays, so be sure to add new work types before wtype_root.
+ */
 enum sp3_work_type {
-    wtype_rspill,       /* root node: spill */
-    wtype_node_len,     /* all nodes: number of kvsets */
-    wtype_node_idle,    /* internal+leaf nodes: kcompact/kvcompact */
-    wtype_leaf_garbage, /* leaf nodes: garbage */
-    wtype_leaf_scatter, /* leaf nodes: vgroup scatter */
-    wtype_leaf_size,    /* leaf nodes: size */
+    wtype_length = 0u,  /* leaf nodes: k-compact to reduce node length */
+    wtype_garbage,      /* leaf nodes: kv-compact to reduce garbage */
+    wtype_scatter,      /* leaf nodes: kv-compact to reduce vgroup scatter */
+    wtype_split,        /* leaf nodes: split to eliminate large nodes */
+    wtype_idle,         /* root+leaf nodes: kv-compact idle nodes */
+    wtype_root,         /* root node: spill to leaves */
+    wtype_MAX
 };
 
 struct sp3_thresholds {
@@ -33,8 +56,8 @@ struct sp3_thresholds {
     uint8_t  rspill_runlen_max;
     uint16_t rspill_sizemb_max;
     uint8_t  lcomp_runlen_max;
-    uint8_t  lcomp_pop_pct;       /* leaf node spill-by-clen percentage threshold */
-    uint8_t  lcomp_pop_keys;      /* leaf node spill-by-keys threshold (units of 4 million) */
+    uint8_t  lcomp_split_pct;     /* leaf node split-by-clen percentage threshold */
+    uint8_t  lcomp_split_keys;    /* leaf node split-by-keys threshold (units of 4 million) */
     uint8_t  lscat_hwm;
     uint8_t  lscat_runlen_max;
     uint8_t  llen_runlen_min;
@@ -43,24 +66,12 @@ struct sp3_thresholds {
     uint8_t  llen_idlem;
 };
 
-/* root spill requires at least 1 kvset,
- * node length reduction requires at least 2 kvsets.
- */
-#define SP3_RSPILL_RUNLEN_MIN   (1u)
-#define SP3_RSPILL_RUNLEN_MAX   (16u)
-#define SP3_RSPILL_SIZEMB_MIN   (4u * 1024)
-#define SP3_RSPILL_SIZEMB_MAX   (32u * 1024)
-#define SP3_LLEN_RUNLEN_MIN     (2u)
-#define SP3_LLEN_RUNLEN_MAX     (16u)
-
-/* clang-format on */
-
 /* MTF_MOCK */
 merr_t
 sp3_work(
-    struct sp3_node *           spn,
-    struct sp3_thresholds *     thresholds,
+    struct sp3_node            *spn,
     enum sp3_work_type          wtype,
+    struct sp3_thresholds      *thresholds,
     uint                        debug,
     struct cn_compaction_work **wp);
 

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -549,7 +549,7 @@ kvset_open2(
     ks->ks_rp = rp;
     ks->ks_dgen = km->km_dgen;
     ks->ks_compc = km->km_compc;
-    ks->ks_comp_rule = km->km_comp_rule;
+    ks->ks_rule = km->km_rule;
     ks->ks_kvsetid = kvsetid;
     ks->ks_cnid = cn_tree_get_cnid(tree);
     ks->ks_cndb = cn_tree_get_cndb(tree);
@@ -2017,7 +2017,7 @@ kvset_get_metrics(struct kvset *ks, struct kvset_metrics *m)
     m->num_vblocks = ks->ks_st.kst_vblks;
     m->header_bytes = ks->ks_st.kst_hwlen;
     m->compc = ks->ks_compc;
-    m->comp_rule = ks->ks_comp_rule;
+    m->rule = ks->ks_rule;
     m->vgroups = kvset_get_vgroups(ks);
     m->nptombs = ks->ks_hblk.kh_metrics.hm_nptombs;
 

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -557,7 +557,7 @@ kvset_open2(
     ks->ks_sfx_len = cp->sfx_len;
     ks->ks_node_level = km->km_node_level;
     ks->ks_nodeid = km->km_nodeid;
-    ks->ks_vminlvl = min_t(u16, rp->cn_mcache_vminlvl, U16_MAX);
+    ks->ks_vminlvl = min_t(uint8_t, rp->cn_mcache_vminlvl, UINT8_MAX);
     ks->ks_vmin = rp->cn_mcache_vmin;
     ks->ks_vmax = rp->cn_mcache_vmax;
     ks->ks_cn_kvdb = cn_kvdb;
@@ -861,11 +861,11 @@ kvset_open2(
          */
         if (ra_willneed(vra) & 0x01) {
             kvset_madvise_vblks(ks, MADV_WILLNEED);
-            ks->ks_vminlvl = U16_MAX;
+            ks->ks_vminlvl = UINT8_MAX;
             ks->ks_vra_len = 0;
         } else if (cn_tree_is_capped(ks->ks_tree)) {
             kvset_madvise_capped(ks, MADV_WILLNEED);
-            ks->ks_vminlvl = U16_MAX;
+            ks->ks_vminlvl = UINT8_MAX;
         }
     }
 

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -73,7 +73,7 @@ struct kvset_meta {
     uint16_t        km_node_level;
     uint16_t        km_compc;
     uint64_t        km_nodeid;
-    uint16_t        km_comp_rule;
+    uint16_t        km_rule;
     bool            km_capped;
     bool            km_restored;
 };

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -77,7 +77,7 @@ struct kvset {
     u32           ks_sfx_len; /* cn tree sfx_len */
     uint8_t       ks_node_level;
     uint8_t       ks_vminlvl;
-    uint16_t      ks_comp_rule;
+    uint16_t      ks_rule;
     u64           ks_nodeid;
     u32           ks_vmin;
     u32           ks_vmax;

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -75,8 +75,8 @@ struct kvset {
     struct mpool *ks_mp;
     u32           ks_pfx_len; /* cn tree pfx_len */
     u32           ks_sfx_len; /* cn tree sfx_len */
-    u16           ks_node_level;
-    u16           ks_vminlvl;
+    uint8_t       ks_node_level;
+    uint8_t       ks_vminlvl;
     uint16_t      ks_comp_rule;
     u64           ks_nodeid;
     u32           ks_vmin;

--- a/lib/cndb/cndb.c
+++ b/lib/cndb/cndb.c
@@ -531,7 +531,7 @@ cndb_record_kvset_add(
 
     if (!cndb->replaying)
         err = cndb_omf_kvset_add_write(cndb->mdc, cndb_txn_txid_get(tx), cnid, kvsetid, nodeid,
-                                       km->km_dgen, km->km_vused, km->km_compc, km->km_comp_rule,
+                                       km->km_dgen, km->km_vused, km->km_compc, km->km_rule,
                                        hblkid, kblkc, kblkv, vblkc, vblkv);
 out:
     mutex_unlock(&cndb->mutex);
@@ -734,7 +734,7 @@ compact_incomplete_intents(
 
     err = cndb_omf_kvset_add_write(cndb->mdc, txid, kvset->ck_cnid, kvset->ck_kvsetid,
                                    kvset->ck_nodeid, kvset->ck_dgen, kvset->ck_vused,
-                                   kvset->ck_compc, kvset->ck_comp_rule, kvset->ck_hblkid,
+                                   kvset->ck_compc, kvset->ck_rule, kvset->ck_hblkid,
                                    kvset->ck_kblkc, kvset->ck_kblkv,
                                    kvset->ck_vblkc, kvset->ck_vblkv);
     return err;
@@ -779,7 +779,7 @@ log_full_rec(
 
     err = cndb_omf_kvset_add_write(cndb->mdc, txid, kvset->ck_cnid, kvset->ck_kvsetid,
                                    kvset->ck_nodeid, kvset->ck_dgen, kvset->ck_vused,
-                                   kvset->ck_compc, kvset->ck_comp_rule, kvset->ck_hblkid,
+                                   kvset->ck_compc, kvset->ck_rule, kvset->ck_hblkid,
                                    kvset->ck_kblkc, kvset->ck_kblkv,
                                    kvset->ck_vblkc, kvset->ck_vblkv);
     if (ev(err))
@@ -1328,7 +1328,7 @@ cndb_cn_instantiate(struct cndb *cndb, uint64_t cnid, void *ctx, cn_init_callbac
         struct kvset_meta km = {
             .km_dgen = kvset->ck_dgen,
             .km_compc = kvset->ck_compc,
-            .km_comp_rule = kvset->ck_comp_rule,
+            .km_rule = kvset->ck_rule,
             .km_vused = kvset->ck_vused,
             .km_capped = cn->cp.kvs_ext01,
             .km_nodeid = kvset->ck_nodeid,

--- a/lib/cndb/common.h
+++ b/lib/cndb/common.h
@@ -13,7 +13,7 @@ struct cndb_kvset {
     uint64_t       ck_dgen;
     uint64_t       ck_vused;
     uint32_t       ck_compc;
-    uint16_t       ck_comp_rule;
+    uint16_t       ck_rule;
     uint64_t       ck_hblkid;
     unsigned int   ck_kblkc;
     unsigned int   ck_vblkc;

--- a/lib/cndb/omf.c
+++ b/lib/cndb/omf.c
@@ -120,7 +120,7 @@ cndb_omf_kvset_add_write(
     uint64_t          dgen,
     uint64_t          vused,
     uint32_t          compc,
-    uint16_t          comp_rule,
+    uint16_t          rule,
     uint64_t          hblkid,
     uint32_t          kblkc,
     uint64_t         *kblkv,
@@ -152,7 +152,7 @@ cndb_omf_kvset_add_write(
     omf_set_kvset_add_dgen(omf, dgen);
     omf_set_kvset_add_vused(omf, vused);
     omf_set_kvset_add_compc(omf, compc);
-    omf_set_kvset_add_comp_rule(omf, comp_rule);
+    omf_set_kvset_add_rule(omf, rule);
     omf_set_kvset_add_kblk_cnt(omf, kblkc);
     omf_set_kvset_add_vblk_cnt(omf, vblkc);
     omf_set_kvset_add_hblkid(omf, hblkid);
@@ -319,7 +319,7 @@ cndb_omf_kvset_add_read(
     km->km_dgen = omf_kvset_add_dgen(omf);
     km->km_vused = omf_kvset_add_vused(omf);
     km->km_compc = omf_kvset_add_compc(omf);
-    km->km_comp_rule = omf_kvset_add_comp_rule(omf);
+    km->km_rule = omf_kvset_add_rule(omf);
 
     *kblkc = omf_kvset_add_kblk_cnt(omf);
     *vblkc = omf_kvset_add_vblk_cnt(omf);

--- a/lib/cndb/omf.h
+++ b/lib/cndb/omf.h
@@ -164,7 +164,7 @@ struct cndb_kvset_add_omf {
     uint64_t            kvset_add_dgen;
     uint64_t            kvset_add_vused;
     uint32_t            kvset_add_compc;
-    uint16_t            kvset_add_comp_rule;
+    uint16_t            kvset_add_rule;
     uint16_t            kvset_add_pad;
     uint64_t            kvset_add_hblkid;
     uint32_t            kvset_add_kblk_cnt;
@@ -178,7 +178,7 @@ OMF_SETGET(struct cndb_kvset_add_omf, kvset_add_nodeid, 64);
 OMF_SETGET(struct cndb_kvset_add_omf, kvset_add_dgen, 64);
 OMF_SETGET(struct cndb_kvset_add_omf, kvset_add_vused, 64);
 OMF_SETGET(struct cndb_kvset_add_omf, kvset_add_compc, 32);
-OMF_SETGET(struct cndb_kvset_add_omf, kvset_add_comp_rule, 16);
+OMF_SETGET(struct cndb_kvset_add_omf, kvset_add_rule, 16);
 OMF_SETGET(struct cndb_kvset_add_omf, kvset_add_hblkid, 64);
 OMF_SETGET(struct cndb_kvset_add_omf, kvset_add_kblk_cnt, 32);
 OMF_SETGET(struct cndb_kvset_add_omf, kvset_add_vblk_cnt, 32);
@@ -300,7 +300,7 @@ cndb_omf_kvset_add_write(
     uint64_t          dgen,
     uint64_t          vused,
     uint32_t          compc,
-    uint16_t          comp_rule,
+    uint16_t          rule,
     uint64_t          hblkid,
     uint32_t          kblkc,
     uint64_t         *kblkv,

--- a/lib/cndb/txn.c
+++ b/lib/cndb/txn.c
@@ -133,7 +133,7 @@ cndb_txn_kvset_add(
     kvset->ck_dgen = km->km_dgen;
     kvset->ck_vused = km->km_vused;
     kvset->ck_compc = km->km_compc;
-    kvset->ck_comp_rule = km->km_comp_rule;
+    kvset->ck_rule = km->km_rule;
 
     kvset->ck_kblkc = kblkc;
     for (i = 0; i < kblkc; i++)

--- a/lib/include/hse_ikvdb/csched.h
+++ b/lib/include/hse_ikvdb/csched.h
@@ -38,60 +38,60 @@ enum sp3_qnum {
 /* Add new rules to the end of the list because rules are persisted
  * in the omf.
  */
-enum cn_comp_rule {
-    CN_CR_NONE = 0u,
-    CN_CR_INGEST,       /* normal c0 spill */
-    CN_CR_RSPILL,       /* normal root spill */
-    CN_CR_TSPILL,       /* tiny root spill */
-    CN_CR_ZSPILL,       /* zero writeamp root spill */
-    CN_CR_LENGTHK,      /* long leaf, k-compact */
-    CN_CR_LENGTHV,      /* long tiny leaf, kv-compact */
-    CN_CR_INDEXF,       /* short leaf, full index node compaction */
-    CN_CR_INDEXP,       /* short leaf, partial index node compaction */
-    CN_CR_IDLE_INDEX,   /* idle leaf, index node */
-    CN_CR_IDLE_SIZE,    /* idle leaf, tiny node */
-    CN_CR_IDLE_TOMB,    /* idle leaf, mostly tombs */
-    CN_CR_SCATTERF,     /* vgroup scatter remediation (full node) */
-    CN_CR_SCATTERP,     /* vgroup scatter remediation (partial node) */
-    CN_CR_GARBAGE,      /* leaf garbage (reducing space amp) */
-    CN_CR_SPLIT,        /* big leaf (near split threshold) */
+enum cn_rule {
+    CN_RULE_NONE = 0u,
+    CN_RULE_INGEST,     /* normal c0 spill */
+    CN_RULE_RSPILL,     /* normal root spill */
+    CN_RULE_TSPILL,     /* tiny root spill */
+    CN_RULE_ZSPILL,     /* zero writeamp root spill */
+    CN_RULE_LENGTHK,    /* long leaf, k-compact */
+    CN_RULE_LENGTHV,    /* long tiny leaf, kv-compact */
+    CN_RULE_INDEXF,     /* short leaf, full index node compaction */
+    CN_RULE_INDEXP,     /* short leaf, partial index node compaction */
+    CN_RULE_IDLE_INDEX, /* idle leaf, index node */
+    CN_RULE_IDLE_SIZE,  /* idle leaf, tiny node */
+    CN_RULE_IDLE_TOMB,  /* idle leaf, mostly tombs */
+    CN_RULE_SCATTERF,   /* vgroup scatter remediation (full node) */
+    CN_RULE_SCATTERP,   /* vgroup scatter remediation (partial node) */
+    CN_RULE_GARBAGE,    /* leaf garbage (reducing space amp) */
+    CN_RULE_SPLIT,      /* big leaf (near split threshold) */
 };
 
 static inline const char *
-cn_comp_rule2str(enum cn_comp_rule rule)
+cn_rule2str(enum cn_rule rule)
 {
     switch (rule) {
-    case CN_CR_NONE:
+    case CN_RULE_NONE:
         return "none";
-    case CN_CR_INGEST:
+    case CN_RULE_INGEST:
         return "ingest";
-    case CN_CR_RSPILL:
+    case CN_RULE_RSPILL:
         return "rspill";
-    case CN_CR_TSPILL:
+    case CN_RULE_TSPILL:
         return "tspill";
-    case CN_CR_ZSPILL:
+    case CN_RULE_ZSPILL:
         return "zspill";
-    case CN_CR_LENGTHK:
+    case CN_RULE_LENGTHK:
         return "lenk";
-    case CN_CR_LENGTHV:
+    case CN_RULE_LENGTHV:
         return "lenv";
-    case CN_CR_INDEXF:
+    case CN_RULE_INDEXF:
         return "idxf";
-    case CN_CR_INDEXP:
+    case CN_RULE_INDEXP:
         return "idxp";
-    case CN_CR_IDLE_INDEX:
+    case CN_RULE_IDLE_INDEX:
         return "idlidx";
-    case CN_CR_IDLE_SIZE:
+    case CN_RULE_IDLE_SIZE:
         return "idlsiz";
-    case CN_CR_IDLE_TOMB:
+    case CN_RULE_IDLE_TOMB:
         return "idltmb";
-    case CN_CR_SCATTERF:
+    case CN_RULE_SCATTERF:
         return "scatf";
-    case CN_CR_SCATTERP:
+    case CN_RULE_SCATTERP:
         return "scatp";
-    case CN_CR_GARBAGE:
+    case CN_RULE_GARBAGE:
         return "garb";
-    case CN_CR_SPLIT:
+    case CN_RULE_SPLIT:
         return "split";
     }
 

--- a/lib/include/hse_ikvdb/csched.h
+++ b/lib/include/hse_ikvdb/csched.h
@@ -27,30 +27,34 @@ struct cn_tree_node;
 /* work queues */
 enum sp3_qnum {
     SP3_QNUM_ROOT,
-    SP3_QNUM_LLEN,
-    SP3_QNUM_LGARB,
-    SP3_QNUM_LSCAT,
-    SP3_QNUM_LSIZE,
+    SP3_QNUM_LENGTH,
+    SP3_QNUM_GARBAGE,
+    SP3_QNUM_SCATTER,
+    SP3_QNUM_SPLIT,
     SP3_QNUM_SHARED,
     SP3_QNUM_MAX
 };
 
+/* Add new rules to the end of the list because rules are persisted
+ * in the omf.
+ */
 enum cn_comp_rule {
     CN_CR_NONE = 0u,
-    CN_CR_INGEST,         /* normal c0 spill */
-    CN_CR_RSPILL,         /* normal root spill */
-    CN_CR_RTINY,          /* tiny root spill */
-    CN_CR_LBIG,           /* big leaf (near pop threshold) */
-    CN_CR_LBIG_ONE,       /* big leaf, compact one kvset */
-    CN_CR_LGARB,          /* leaf garbage (reducing space amp) */
-    CN_CR_LLONG,          /* long leaf */
-    CN_CR_LIDXF,          /* short leaf, full index node compaction */
-    CN_CR_LIDXP,          /* short leaf, partial index node compaction */
-    CN_CR_LIDLE_IDX,      /* idle leaf, index node */
-    CN_CR_LIDLE_SIZE,     /* idle leaf, tiny node */
-    CN_CR_LIDLE_TOMB,     /* idle leaf, mostly tombs */
-    CN_CR_LSCATF,         /* vgroup scatter remediation (full node) */
-    CN_CR_LSCATP,         /* vgroup scatter remediation (partial node) */
+    CN_CR_INGEST,       /* normal c0 spill */
+    CN_CR_RSPILL,       /* normal root spill */
+    CN_CR_TSPILL,       /* tiny root spill */
+    CN_CR_ZSPILL,       /* zero writeamp root spill */
+    CN_CR_LENGTHK,      /* long leaf, k-compact */
+    CN_CR_LENGTHV,      /* long tiny leaf, kv-compact */
+    CN_CR_INDEXF,       /* short leaf, full index node compaction */
+    CN_CR_INDEXP,       /* short leaf, partial index node compaction */
+    CN_CR_IDLE_INDEX,   /* idle leaf, index node */
+    CN_CR_IDLE_SIZE,    /* idle leaf, tiny node */
+    CN_CR_IDLE_TOMB,    /* idle leaf, mostly tombs */
+    CN_CR_SCATTERF,     /* vgroup scatter remediation (full node) */
+    CN_CR_SCATTERP,     /* vgroup scatter remediation (partial node) */
+    CN_CR_GARBAGE,      /* leaf garbage (reducing space amp) */
+    CN_CR_SPLIT,        /* big leaf (near split threshold) */
 };
 
 static inline const char *
@@ -63,30 +67,32 @@ cn_comp_rule2str(enum cn_comp_rule rule)
         return "ingest";
     case CN_CR_RSPILL:
         return "rspill";
-    case CN_CR_RTINY:
-        return "rtiny";
-    case CN_CR_LBIG:
-        return "lbig";
-    case CN_CR_LBIG_ONE:
-        return "lbig1";
-    case CN_CR_LGARB:
-        return "lgarb";
-    case CN_CR_LLONG:
-        return "llong";
-    case CN_CR_LIDXF:
-        return "lidxf";
-    case CN_CR_LIDXP:
-        return "lidxp";
-    case CN_CR_LIDLE_IDX:
+    case CN_CR_TSPILL:
+        return "tspill";
+    case CN_CR_ZSPILL:
+        return "zspill";
+    case CN_CR_LENGTHK:
+        return "lenk";
+    case CN_CR_LENGTHV:
+        return "lenv";
+    case CN_CR_INDEXF:
+        return "idxf";
+    case CN_CR_INDEXP:
+        return "idxp";
+    case CN_CR_IDLE_INDEX:
         return "idlidx";
-    case CN_CR_LIDLE_SIZE:
+    case CN_CR_IDLE_SIZE:
         return "idlsiz";
-    case CN_CR_LIDLE_TOMB:
+    case CN_CR_IDLE_TOMB:
         return "idltmb";
-    case CN_CR_LSCATF:
-        return "lscatf";
-    case CN_CR_LSCATP:
-        return "lscatp";
+    case CN_CR_SCATTERF:
+        return "scatf";
+    case CN_CR_SCATTERP:
+        return "scatp";
+    case CN_CR_GARBAGE:
+        return "garb";
+    case CN_CR_SPLIT:
+        return "split";
     }
 
     return "invalid";
@@ -94,12 +100,12 @@ cn_comp_rule2str(enum cn_comp_rule rule)
 
 /* Default threads-per-queue for csched_qthreads kvdb rparam.
  */
-#define CSCHED_QTHREADS_DEFAULT                 \
-    ((5ul << (8 * SP3_QNUM_ROOT)) |             \
-     (5ul << (8 * SP3_QNUM_LLEN)) |             \
-     (1ul << (8 * SP3_QNUM_LGARB)) |            \
-     (1ul << (8 * SP3_QNUM_LSCAT)) |            \
-     (1ul << (8 * SP3_QNUM_LSIZE)) |            \
+#define CSCHED_QTHREADS_DEFAULT                   \
+    ((5ul << (8 * SP3_QNUM_ROOT)) |               \
+     (5ul << (8 * SP3_QNUM_LENGTH)) |             \
+     (1ul << (8 * SP3_QNUM_GARBAGE)) |            \
+     (1ul << (8 * SP3_QNUM_SCATTER)) |            \
+     (1ul << (8 * SP3_QNUM_SPLIT)) |              \
      (2ul << (8 * SP3_QNUM_SHARED)))
 
 /* clang-format on */

--- a/lib/include/hse_ikvdb/kvs_rparams.h
+++ b/lib/include/hse_ikvdb/kvs_rparams.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_KVS_RPARAMS_H
@@ -33,6 +33,7 @@
  */
 struct kvs_rparams {
     uint64_t kvs_cursor_ttl;
+
     bool     transactions_enable;
     bool     cn_maint_disable;
     bool     cn_close_wait;
@@ -40,27 +41,26 @@ struct kvs_rparams {
     bool     cn_verify;
     bool     read_only;
     uint8_t  perfc_level;
+    uint8_t  cn_compaction_debug; /* 1=compact, 2=ingest */
+
     uint32_t cn_maint_delay;
-    uint64_t cn_compaction_debug; /* 1=compact, 2=ingest */
+    uint32_t cn_split_size;
 
     uint64_t cn_compact_kblk_ra;
     uint64_t cn_compact_vblk_ra;
     uint64_t cn_compact_vra;
 
-    uint64_t cn_node_size_lo;
-    uint64_t cn_node_size_hi;
-
     uint64_t cn_capped_ttl;
     uint64_t cn_capped_vra;
 
+    uint64_t cn_cursor_seq;
     uint64_t cn_cursor_vra;
     bool     cn_cursor_kra;
-    uint64_t cn_cursor_seq;
 
-    uint64_t cn_mcache_wbt;
-    uint64_t cn_mcache_vmin;
-    uint64_t cn_mcache_vmax;
-    uint64_t cn_mcache_vminlvl;
+    uint8_t  cn_mcache_wbt;
+    uint8_t  cn_mcache_vminlvl;
+    uint32_t cn_mcache_vmin;
+    uint32_t cn_mcache_vmax;
 
     uint64_t cn_mcache_kra_params;
     uint64_t cn_mcache_vra_params;
@@ -74,10 +74,10 @@ struct kvs_rparams {
 
     uint64_t capped_evict_ttl;
 
-    char mclass_policy[HSE_MPOLICY_NAME_LEN_MAX];
-
-    uint64_t             vcompmin;
+    uint32_t             vcompmin;
     enum vcomp_algorithm value_compression;
+
+    char mclass_policy[HSE_MPOLICY_NAME_LEN_MAX];
 };
 
 const struct param_spec *

--- a/lib/include/hse_ikvdb/kvset_view.h
+++ b/lib/include/hse_ikvdb/kvset_view.h
@@ -25,7 +25,7 @@ struct kvset_metrics {
     uint32_t tot_wbt_pages;
     uint32_t tot_blm_pages;
     uint32_t compc;
-    uint16_t comp_rule;
+    uint16_t rule;
     uint16_t vgroups;
 };
 

--- a/lib/kvdb/kvdb_rest.c
+++ b/lib/kvdb/kvdb_rest.c
@@ -687,7 +687,7 @@ print_unit(
         yaml_field_fmt(yc, "vgroups", "%u", m->vgroups);
 
         if (type == TYPE_KVSET)
-            yaml_field_fmt(yc, "rule", "%s", cn_comp_rule2str(m->comp_rule));
+            yaml_field_fmt(yc, "rule", "%s", cn_rule2str(m->rule));
         else
             yaml_field_fmt(yc, "kvsets", "%d", nkvsets);
     } else {
@@ -703,7 +703,7 @@ print_unit(
                     width[5], vlenbuf,
                     nhblks, nkblks, nvblks,
                     m->vgroups,
-                    (type == TYPE_KVSET) ? cn_comp_rule2str(m->comp_rule) : "-",
+                    (type == TYPE_KVSET) ? cn_rule2str(m->rule) : "-",
                     ctx->cnid,
                     ctx->eklen,
                     trailer);

--- a/tests/functional/smoke/cursor_test1.sh
+++ b/tests/functional/smoke/cursor_test1.sh
@@ -21,7 +21,7 @@ kvs=$(kvs_create smoke-0)
 keys=$((1000 * 1000 * 4))
 nthread=20
 ncursor=10000
-cmd multicursor "$home" "$kvs" "-c$keys" "-j$nthread" "-r$ncursor" -l -v kvs-oparms cn_node_size_lo=32 cn_node_size_hi=32
+cmd multicursor "$home" "$kvs" "-c$keys" "-j$nthread" "-r$ncursor" -l -v kvs-oparms cn_split_size=32
 
 #
 # capput tests
@@ -35,7 +35,7 @@ dur=30
 
 # regular kvs
 kvs=$(kvs_create smoke-1 prefix.length=8)
-cmd capput "$home" "$kvs" "-j$wth" "-t$rth" "-c$chunksz" "-b$batchsz" "-m$pwin" "-d$dur" -v kvs-oparms cn_node_size_lo=32 cn_node_size_hi=32
+cmd capput "$home" "$kvs" "-j$wth" "-t$rth" "-c$chunksz" "-b$batchsz" "-m$pwin" "-d$dur" -v kvs-oparms cn_split_size=32
 
 # capped kvs
 kvs=$(kvs_create smoke-2 prefix.length=8 kvs_ext01=1)

--- a/tests/functional/smoke/prefix-tree-shape1.sh
+++ b/tests/functional/smoke/prefix-tree-shape1.sh
@@ -54,8 +54,7 @@ oparms=(
     csched_qthreads=0x080808
     kvs-oparms
     cn_close_wait=true
-    cn_node_size_lo=32
-    cn_node_size_hi=32)
+    cn_split_size=32)
 
 for fanout in 2 4 8 16; do
     # shellcheck disable=SC2034

--- a/tests/unit/cn/cn_api_test.c
+++ b/tests/unit/cn/cn_api_test.c
@@ -104,7 +104,6 @@ MTF_DEFINE_UTEST_PRE(cn_api, basic, pre)
     (void)cn_get_perfc(cn, CN_ACTION_COMPACT_KV);
     (void)cn_get_perfc(cn, CN_ACTION_SPILL);
     (void)cn_get_perfc(cn, CN_ACTION_NONE);
-    (void)cn_get_perfc(cn, CN_ACTION_END);
 
     err = cn_get(cn, &kt, 0, &res, &vbuf);
     ASSERT_EQ(err, 0);

--- a/tests/unit/cn/csched_sp3_test.c
+++ b/tests/unit/cn/csched_sp3_test.c
@@ -246,9 +246,9 @@ sts_job_submit_mock(struct sts *self, struct sts_job *job)
 
 merr_t
 sp3_work_mock(
-    struct sp3_node *           spn,
-    struct sp3_thresholds *     thresh,
+    struct sp3_node            *spn,
     enum sp3_work_type          wtype,
+    struct sp3_thresholds      *thresh,
     uint                        debug,
     struct cn_compaction_work **w_out)
 {

--- a/tests/unit/config/argv_test.c
+++ b/tests/unit/config/argv_test.c
@@ -47,10 +47,10 @@ MTF_DEFINE_UTEST(argv_test, deserialize_to_params_invalid_value)
 MTF_DEFINE_UTEST(argv_test, deserialize_to_params_invalid_relation_validation)
 {
     merr_t             err;
-    const char * const paramv[] = { "cn_node_size_lo=51", "cn_node_size_hi=49" };
+    const char * const paramv[] = { "cn_node_size_hi=49" };
     struct kvs_rparams params;
 
-    err = argv_deserialize_to_kvs_rparams(2, paramv, &params);
+    err = argv_deserialize_to_kvs_rparams(NELEM(paramv), paramv, &params);
     ASSERT_NE(0, err);
 }
 

--- a/tests/unit/kvdb/kvdb_rest_test.c
+++ b/tests/unit/kvdb/kvdb_rest_test.c
@@ -112,7 +112,7 @@ _kvset_get_metrics(struct kvset *kvset, struct kvset_metrics *metrics)
     metrics->tot_key_bytes = 4000000;
     metrics->tot_val_bytes = 8000000;
     metrics->compc = (v->nodeid == 0) ? 0 : 3;
-    metrics->comp_rule = (v->nodeid == 0) ? CN_CR_INGEST : CN_CR_RSPILL;
+    metrics->rule = (v->nodeid == 0) ? CN_RULE_INGEST : CN_RULE_RSPILL;
     metrics->vgroups = 1;
 }
 

--- a/tests/unit/kvs/kvs_rparams_test.c
+++ b/tests/unit/kvs/kvs_rparams_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <mtf/framework.h>
@@ -131,66 +131,37 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, perfc_level, test_pre)
     ASSERT_EQ(PERFC_LEVEL_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
-MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_node_sisze_lo, test_pre)
+MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_split_size, test_pre)
 {
     merr_t                   err;
-    const struct param_spec *ps = ps_get("cn_node_size_lo");
+    const struct param_spec *ps = ps_get("cn_split_size");
 
     ASSERT_NE(NULL, ps);
     ASSERT_NE(NULL, ps->ps_description);
     ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
-    ASSERT_EQ(offsetof(struct kvs_rparams, cn_node_size_lo), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
+    ASSERT_EQ(PARAM_TYPE_U32, ps->ps_type);
+    ASSERT_EQ(offsetof(struct kvs_rparams, cn_split_size), ps->ps_offset);
+    ASSERT_EQ(sizeof(uint32_t), ps->ps_size);
     ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
-    ASSERT_NE(NULL, ps->ps_validate_relations);
-    ASSERT_EQ(8192 * 1024, params.cn_node_size_lo);
-    ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(16, params.cn_split_size);
+    ASSERT_EQ(4, ps->ps_bounds.as_uscalar.ps_min);
+    ASSERT_EQ(1024, ps->ps_bounds.as_uscalar.ps_max);
 
     /* clang-format off */
     err = check(
-        "cn_node_size_lo=50000", true,
-        "cn_node_size_hi=40000", true,
+        "cn_split_size=3", false,
+        "cn_split_size=4", true,
+        "cn_split_size=32", true,
+        "cn_split_size=1024", true,
+        "cn_split_size=1025", false,
         NULL
     );
     /* clang-format on */
 
-    ASSERT_NE(0, merr_errno(err));
-}
-
-MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_node_size_hi, test_pre)
-{
-    merr_t                   err;
-    const struct param_spec *ps = ps_get("cn_node_size_hi");
-
-    ASSERT_NE(NULL, ps);
-    ASSERT_NE(NULL, ps->ps_description);
-    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
-    ASSERT_EQ(offsetof(struct kvs_rparams, cn_node_size_hi), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
-    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
-    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
-    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
-    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
-    ASSERT_NE(NULL, ps->ps_validate_relations);
-    ASSERT_EQ(9216 * 1024, params.cn_node_size_hi);
-    ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
-
-    /* clang-format off */
-    err = check(
-        "cn_node_size_lo=50000", true,
-        "cn_node_size_hi=40000", true,
-        NULL
-    );
-    /* clang-format on */
-
-    ASSERT_NE(0, merr_errno(err));
+    ASSERT_EQ(0, merr_errno(err));
 }
 
 MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_compact_vblk_ra, test_pre)
@@ -350,9 +321,9 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_mcache_wbt, test_pre)
     ASSERT_NE(NULL, ps);
     ASSERT_NE(NULL, ps->ps_description);
     ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
+    ASSERT_EQ(PARAM_TYPE_U8, ps->ps_type);
     ASSERT_EQ(offsetof(struct kvs_rparams, cn_mcache_wbt), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
+    ASSERT_EQ(sizeof(uint8_t), ps->ps_size);
     ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
@@ -369,16 +340,16 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_mcache_vminlvl, test_pre)
     ASSERT_NE(NULL, ps);
     ASSERT_NE(NULL, ps->ps_description);
     ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
+    ASSERT_EQ(PARAM_TYPE_U8, ps->ps_type);
     ASSERT_EQ(offsetof(struct kvs_rparams, cn_mcache_vminlvl), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
+    ASSERT_EQ(sizeof(uint8_t), ps->ps_size);
     ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
     ASSERT_EQ(UINT16_MAX, params.cn_mcache_vminlvl);
     ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(UINT8_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_mcache_vmin, test_pre)
@@ -388,16 +359,16 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_mcache_vmin, test_pre)
     ASSERT_NE(NULL, ps);
     ASSERT_NE(NULL, ps->ps_description);
     ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
+    ASSERT_EQ(PARAM_TYPE_U32, ps->ps_type);
     ASSERT_EQ(offsetof(struct kvs_rparams, cn_mcache_vmin), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
+    ASSERT_EQ(sizeof(uint32_t), ps->ps_size);
     ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
     ASSERT_EQ(256, params.cn_mcache_vmin);
     ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(UINT32_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_mcache_vmax, test_pre)
@@ -407,16 +378,16 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_mcache_vmax, test_pre)
     ASSERT_NE(NULL, ps);
     ASSERT_NE(NULL, ps->ps_description);
     ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL | PARAM_FLAG_WRITABLE, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
+    ASSERT_EQ(PARAM_TYPE_U32, ps->ps_type);
     ASSERT_EQ(offsetof(struct kvs_rparams, cn_mcache_vmax), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
+    ASSERT_EQ(sizeof(uint32_t), ps->ps_size);
     ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
     ASSERT_EQ(4096, params.cn_mcache_vmax);
     ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(UINT32_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_mcache_kra_params, test_pre)
@@ -570,16 +541,16 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_compaction_debug, test_pre)
     ASSERT_NE(NULL, ps);
     ASSERT_NE(NULL, ps->ps_description);
     ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL | PARAM_FLAG_WRITABLE, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
+    ASSERT_EQ(PARAM_TYPE_U8, ps->ps_type);
     ASSERT_EQ(offsetof(struct kvs_rparams, cn_compaction_debug), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
+    ASSERT_EQ(sizeof(uint8_t), ps->ps_size);
     ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
     ASSERT_EQ(0, params.cn_compaction_debug);
     ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(UINT8_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_maint_delay, test_pre)
@@ -715,16 +686,16 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, compression_value_min_length, test_pre)
     ASSERT_NE(NULL, ps);
     ASSERT_NE(NULL, ps->ps_description);
     ASSERT_EQ(0, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U64, ps->ps_type);
+    ASSERT_EQ(PARAM_TYPE_U32, ps->ps_type);
     ASSERT_EQ(offsetof(struct kvs_rparams, vcompmin), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint64_t), ps->ps_size);
+    ASSERT_EQ(sizeof(uint32_t), ps->ps_size);
     ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
     ASSERT_EQ(12, params.vcompmin);
     ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(UINT32_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvs_rparams_test, compression_value_algorithm, test_pre)

--- a/tools/cn_metrics/cn_metrics.c
+++ b/tools/cn_metrics/cn_metrics.c
@@ -424,7 +424,7 @@ print_row(struct ctx *ctx, char *tag, struct rollup *r, uint index, char *sep)
         bn_width(opt.bnfmt, 11), r->ks.kst_kblks,
         bn_width(opt.bnfmt, 12), r->ks.kst_vblks,
         r->km.vgroups,
-        (tag[0] == 'k') ? cn_comp_rule2str(r->km.comp_rule) : "-",
+        (tag[0] == 'k') ? cn_rule2str(r->km.rule) : "-",
         bn_width(opt.bnfmt, 15), avg_klen,
         bn_width(opt.bnfmt, 16), avg_vlen);
 


### PR DESCRIPTION
- Wire node split into csched and let it run up to commit, but fail before commit. Fix busycnt accounting for compaction error path. Remove cn_node_size_{lo,hi} rparams in favor of cn_split_size rparam, Reduce size of unnecessarily large kvs rparams . Trigger per-node gc when a node reaches 15x garbage. Remove cn_tstate remnants Move tn_rspills fields from cn_tree_node to cn_tree. Unify RBT_, jtype_, wtype_, in favor of wtype_. Add macros to specify default csched params. Add additional cn comp rules and unify naming with wtype_.
- Remove superfluous comments.
