### PR TITLE
Use more lenient pattern for the CLI version test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,7 @@ endif
 
 git = find_program('git', required: false)
 in_git = git.found() and run_command(git, 'rev-parse', check: false).returncode() == 0
-if not meson.is_subproject() and in_git
+if in_git
     build_version = run_command(
         git,
         'describe',

--- a/tests/functional/cli/version.sh
+++ b/tests/functional/cli/version.sh
@@ -12,8 +12,8 @@ verbose_output=$(cmd hse -vV)
 
 cmd test "$long_output" == "$short_ouptut"
 
-echo "$short_ouptut" | cmd grep -P '^r\d+\.\d+\.\d+'
+echo "$short_ouptut" | cmd grep -P "r?[a-zA-Z0-9.]+"
 
 cmd test "$(printf "%s\n" "$verbose_output" | wc -l)" -eq 2
-echo "$verbose_output" | cmd grep -P '^version: r\d+\.\d+\.\d+'
-echo "$verbose_output" | cmd grep -P '^build-configuration: '
+echo "$verbose_output" | cmd grep -P "^version: r?[a-zA-Z0-9.]+"
+echo "$verbose_output" | cmd grep -P "^build-configuration: "


### PR DESCRIPTION
This should allow the test to pass when HSE is cloned with a depth of 1.

Signed-off-by: Tristan Partin <tpartin@micron.com>
