### PR TITLE
Workaround Debian issue during cross builds

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -524,11 +524,10 @@ jobs:
           apt-get -y install git python3 python3-pip pkg-config ninja-build \
             cmake gawk build-essential crossbuild-essential-${{ matrix.arch }} \
             libpython3-dev:${{ matrix.arch }} liburcu-dev:${{ matrix.arch }} \
-            libcurl4-openssl-dev:${{ matrix.arch }} \
             libbsd-dev:${{ matrix.arch }} libmicrohttpd-dev:${{ matrix.arch }} \
             libyaml-dev:${{ matrix.arch }} libmongoc-dev:${{ matrix.arch }} \
             libbson-dev:${{ matrix.arch }} libncurses-dev:${{ matrix.arch }} \
-            maven
+            maven autoconf automake make libtool
           python3 -m pip install meson==0.62.2 Cython
 
       - name: Checkout HSE

--- a/cross/common.ini
+++ b/cross/common.ini
@@ -8,8 +8,4 @@ gcov = arch + '-gcov'
 [cmake]
 CMAKE_C_COMPILER = arch + '-gcc'
 CMAKE_CXX_COMPILER  = arch + '-g++'
-CMAKE_FIND_ROOT_PATH = '/usr' + arch
-CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = 'NEVER'
-CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = 'ONLY'
-CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = 'ONLY'
 PKG_CONFIG_EXECUTABLE = arch + '-pkg-config'


### PR DESCRIPTION
For whatever reason, libcurl4:s390x has started conflicting with
libcurl4 on the host platform. This just forces the build to use the
subproject libcurl.

Signed-off-by: Tristan Partin <tpartin@micron.com>
