### PR TITLE
Use a static value for the KVDB alias

### DIFF
--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -1438,8 +1438,11 @@ ikvdb_open(
     mutex_init(&self->ikdb_lock);
     ikvdb_txn_init(self);
 
+    /* alias is just a static 0. Remove if HSE decides to allow more than one
+     * KVDB to be opened.
+     */
     n = snprintf(
-        self->ikdb_alias, sizeof(self->ikdb_alias), "%d", atomic_fetch_add(&kvdb_alias, 1));
+        self->ikdb_alias, sizeof(self->ikdb_alias), "%d", atomic_read(&kvdb_alias));
     if (n < 0) {
         err = merr(EBADMSG);
         goto out;

--- a/tests/unit/kvdb/ikvdb_test.c
+++ b/tests/unit/kvdb/ikvdb_test.c
@@ -242,6 +242,34 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, init_fail, test_pre, test_post)
     mapi_inject_unset(mapi_idx_malloc);
 }
 
+MTF_DEFINE_UTEST_PREPOST(ikvdb_test, alias, test_pre, test_post)
+{
+    const char *        mpool = __func__;
+    struct ikvdb *      store = NULL;
+    merr_t              err;
+    const char *const   paramv[] = { "c0_diag_mode=true" };
+    struct kvdb_rparams params = kvdb_rparams_defaults();
+
+    err = argv_deserialize_to_kvdb_rparams(NELEM(paramv), paramv, &params);
+    ASSERT_EQ(0, err);
+
+    err = ikvdb_open(mpool, &params, &store);
+    ASSERT_EQ(0, err);
+    ASSERT_NE(0, store);
+    ASSERT_EQ(0, strcmp(ikvdb_alias(store), "0"));
+
+    err = ikvdb_close(store);
+    ASSERT_EQ(0, err);
+
+    err = ikvdb_open(mpool, &params, &store);
+    ASSERT_EQ(0, err);
+    ASSERT_NE(0, store);
+    ASSERT_EQ(0, strcmp(ikvdb_alias(store), "0"));
+
+    err = ikvdb_close(store);
+    ASSERT_EQ(0, err);
+}
+
 MTF_DEFINE_UTEST_PREPOST(ikvdb_test, basic_txn_alloc, test_pre, test_post)
 {
     const char *         mpool = __func__;


### PR DESCRIPTION
Since we don't support more than one KVDB, just always use 0 as the
alias in order to make REST queries more well-defined.

Signed-off-by: Tristan Partin <tpartin@micron.com>
