### PR TITLE
Skip cli-storage-profile[success] when out of free space

### DIFF
--- a/cli/storage_profile.c
+++ b/cli/storage_profile.c
@@ -452,6 +452,9 @@ hse_storage_profile(const char *path, bool quiet, bool verbose)
         uint32_t space_needed_mb = 1 + (max_space_needed / (1u << 20));
 
         rc = ENOSPC;
+        /* This output message is grepped by
+         * tests/function/cli/storage/profile/success.sh
+         */
         fprintf(
             stderr,
             "The profiling test needs %u MiB of free space to characterize KVDB performance.\n",

--- a/tests/functional/cli/meson.build
+++ b/tests/functional/cli/meson.build
@@ -3,11 +3,7 @@ tests = {
     'no-args': {},
     'unknown-arg': {},
     'unknown-command': {},
-    # Ignored because GitHub Actions only clones with a depth of 1. Unclear what
-    # the best course of action is here.
-    'version': {
-        'enabled': not ci,
-    },
+    'version': {},
 
     'kvdb/help': {},
     'kvdb/no-args': {},

--- a/tests/functional/cli/storage/profile/success.sh
+++ b/tests/functional/cli/storage/profile/success.sh
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
 
 . common.subr
 
@@ -10,7 +10,16 @@ trap kvdb_drop EXIT
 
 kvdb_create
 
-output=$(cmd hse storage profile --quiet "$home")
+output=$(cmd -i hse storage profile --quiet "$home")
+status=$?
+if [ "$status" -ne 0 ]; then
+    if echo "$output" | grep --quiet -P "The profiling test needs \d+ MiB of free space to characterize KVDB performance."; then
+        # Skip the test since we don't have enough space to run it.
+        skip
+    else
+        exit "$status"
+    fi
+fi
 
 echo "$output" | cmd grep -P "(medium|heavy|light)"
 

--- a/tests/functional/common.subr
+++ b/tests/functional/common.subr
@@ -43,6 +43,10 @@ while getopts ":hC:" o; do
 done
 shift $((OPTIND-1))
 
+skip () {
+    exit 77
+}
+
 cmd () {
     # reset OPTIND from global getopts
     OPTIND=0


### PR DESCRIPTION
This should get the test suite running better on drives that are starved
for space, whether that is the CI or that is a user's drive for testing.

Signed-off-by: Tristan Partin <tpartin@micron.com>
