### PR TITLE
Fix memory leak in /params endpoint

### DIFF
--- a/lib/util/src/rest_api.c
+++ b/lib/util/src/rest_api.c
@@ -1017,6 +1017,7 @@ rest_param_get(
             return merr(ENOMEM);
 
         str = cJSON_PrintUnformatted(root);
+        cJSON_Delete(root);
         if (!str)
             return merr(ENOMEM);
 


### PR DESCRIPTION
Same issue as other 2 endpoints.

Signed-off-by: Tristan Partin <tpartin@micron.com>
