### PR TITLE
Remove skip function in favor of status variable

### DIFF
--- a/tests/functional/cli/storage/profile/success.sh
+++ b/tests/functional/cli/storage/profile/success.sh
@@ -15,7 +15,7 @@ status=$?
 if [ "$status" -ne 0 ]; then
     if echo "$output" | grep --quiet -P "The profiling test needs \d+ MiB of free space to characterize KVDB performance."; then
         # Skip the test since we don't have enough space to run it.
-        skip
+        exit "$SKIP_STATUS"
     else
         exit "$status"
     fi

--- a/tests/functional/common.subr
+++ b/tests/functional/common.subr
@@ -8,6 +8,10 @@ set -u
 set -o pipefail
 set -e
 
+# https://mesonbuild.com/Unit-tests.html#skipped-tests-and-hard-errors
+# shellcheck disable=SC2034
+SKIP_STATUS=77
+
 err() {
     # reset OPTIND
     OPTIND=0
@@ -42,10 +46,6 @@ while getopts ":hC:" o; do
     esac
 done
 shift $((OPTIND-1))
-
-skip () {
-    exit 77
-}
 
 cmd () {
     # reset OPTIND from global getopts


### PR DESCRIPTION
Alex thought the previous name was ambiguous, which it was.

Signed-off-by: Tristan Partin <tpartin@micron.com>
