### PR TITLE
Remove fanout and user-directed routemap initialization

### DIFF
--- a/lib/cn/cn_tree.h
+++ b/lib/cn/cn_tree.h
@@ -81,9 +81,6 @@ struct kvs_cparams *
 cn_tree_get_cparams(const struct cn_tree *tree);
 
 uint
-cn_tree_get_fanout(const struct cn_tree *tree);
-
-uint
 cn_tree_get_pfx_len(const struct cn_tree *tree);
 
 bool

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -82,6 +82,7 @@ struct cn_work_est {
  *
  * @cw_work:         for linking into workqueues
  * @cw_debug:        enables debug stats
+ * @cw_resched:      csched should reschedule sp3_work() if true
  * @cw_tree:         cn tree
  * @cw_node:         node within cn tree
  * @cw_mark:         oldest kvset to be compacted
@@ -120,6 +121,7 @@ struct cn_compaction_work {
     uint                     cw_iter_flags;
     uint                     cw_debug;
     bool                     cw_canceled;
+    bool                     cw_resched;
     uint8_t                  cw_qnum;
     merr_t                   cw_err;
     struct workqueue_struct *cw_io_workq;
@@ -184,6 +186,7 @@ struct cn_compaction_work {
         struct blk_list      *commit;    /* mblocks to commit - a list per output kvset */
         struct blk_list      *purge;     /* mblocks to purge - a list per source kvset */
         uint64_t             *dgen;      /* dgen array - one entry per output kvset */
+        uint32_t             *compc;     /* compc array - one entry per output kvset */
         struct cn_tree_node  *nodev[2];  /* node split output nodes */
         uint                  klen;      /* split key length */
     } cw_split;

--- a/lib/cn/node_split.c
+++ b/lib/cn/node_split.c
@@ -530,6 +530,7 @@ cn_split(struct cn_compaction_work *w)
             if (result.ks[k].blks->hblk.bk_blkid != 0) {
                 w->cw_kvsetidv[idx] = cndb_kvsetid_mint(cndb);
                 w->cw_split.dgen[idx] = ks->ks_dgen;
+                w->cw_split.compc[idx] = ks->ks_compc;
             }
         }
     }

--- a/lib/cn/route.h
+++ b/lib/cn/route.h
@@ -124,17 +124,6 @@ route_node_keycpy(struct route_node *node, void *kbuf, size_t kbuf_sz, uint *kle
     memcpy(kbuf, node->rtn_keybufp, min_t(size_t, kbuf_sz, node->rtn_keylen));
 }
 
-struct ekey_generator;
-
-struct ekey_generator *
-ekgen_create(const char *kvsname, struct kvs_cparams *cp);
-
-void
-ekgen_destroy(struct ekey_generator *egen);
-
-size_t
-ekgen_generate(struct ekey_generator *egen, void *ekbuf, size_t ekbufsz, uint32_t nodeoff);
-
 merr_t
 route_node_key_modify(
     struct route_map  *map,

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -299,11 +299,6 @@ cn_spill(struct cn_compaction_work *w)
     while (!err && more) {
         bool new_key = true;
 
-        if (atomic_read(w->cw_cancel_request)) {
-            err = merr(ESHUTDOWN);
-            break;
-        }
-
         if (!child) {
             err = get_kvset_builder(w, output_nodec, &child);
             if (err)
@@ -491,6 +486,11 @@ cn_spill(struct cn_compaction_work *w)
                     tprog = now;
                     w->cw_progress(w);
                 }
+            }
+
+            if (atomic_read(w->cw_cancel_request)) {
+                err = merr(ESHUTDOWN);
+                break;
             }
         }
 

--- a/lib/cndb/omf.c
+++ b/lib/cndb/omf.c
@@ -65,7 +65,6 @@ cndb_omf_kvs_add_write(
 
     cndb_hdr_omf_init(&omf.hdr, CNDB_TYPE_KVS_ADD, sizeof(omf));
 
-    omf_set_kvs_add_fanout(&omf, cp->fanout);
     omf_set_kvs_add_pfxlen(&omf, cp->pfx_len);
     omf_set_kvs_add_cnid(&omf, cnid);
     omf_set_kvs_add_flags(&omf, flags);
@@ -253,7 +252,6 @@ cndb_omf_kvs_add_read(
     char                    *namebuf,
     size_t                   namebufsz)
 {
-    cp->fanout = omf_kvs_add_fanout(omf);
     cp->pfx_len = omf_kvs_add_pfxlen(omf);
     cp->kvs_ext01 = omf_kvs_add_flags(omf) & CN_CFLAG_CAPPED;
 

--- a/lib/cndb/omf.h
+++ b/lib/cndb/omf.h
@@ -83,15 +83,12 @@ OMF_SETGET(struct cndb_ver_omf, cnver_captgt, 64);
 
 struct cndb_kvs_add_omf {
     struct cndb_hdr_omf hdr;
-    uint32_t            kvs_add_fanout;
     uint32_t            kvs_add_pfxlen;
     uint32_t            kvs_add_flags;
-    uint32_t            kvs_add_pad;
     uint64_t            kvs_add_cnid;
     uint8_t             kvs_add_name[HSE_KVS_NAME_LEN_MAX];
 } HSE_PACKED;
 
-OMF_SETGET(struct cndb_kvs_add_omf, kvs_add_fanout, 32);
 OMF_SETGET(struct cndb_kvs_add_omf, kvs_add_pfxlen, 32);
 OMF_SETGET(struct cndb_kvs_add_omf, kvs_add_flags, 32);
 OMF_SETGET(struct cndb_kvs_add_omf, kvs_add_cnid, 64);

--- a/lib/include/hse_ikvdb/kvs_cparams.h
+++ b/lib/include/hse_ikvdb/kvs_cparams.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_KVS_CPARAMS_H
@@ -15,7 +15,6 @@
 #include <error/merr.h>
 
 struct kvs_cparams {
-    uint32_t  fanout;
     uint32_t  pfx_len;
     uint32_t  sfx_len;
     uint32_t  kvs_ext01;

--- a/lib/include/hse_ikvdb/kvset_view.h
+++ b/lib/include/hse_ikvdb/kvset_view.h
@@ -88,7 +88,7 @@ struct kvset_view {
     struct kvset *kvset;
     uint64_t      nodeid;
     uint          eklen;
-    char          ekbuf[44]; /* 64 - offsetof(struct kvset_view, ekbuf) */
+    char          ekbuf[28];
 };
 
 #if HSE_MOCKING

--- a/lib/include/hse_ikvdb/limits.h
+++ b/lib/include/hse_ikvdb/limits.h
@@ -78,10 +78,6 @@
 #define VBLOCK_MIN_SIZE             (32ul << 20)
 #define VBLOCK_MAX_SIZE             (32ul << 20)
 
-/*
- * Min and max fanouts.
- */
-#define CN_FANOUT_MIN               (2)
 #define CN_FANOUT_MAX               (1024)
 
 #define CN_SMALL_VALUE_THRESHOLD    (8)

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -1893,28 +1893,6 @@ ikvdb_kvs_create(struct ikvdb *handle, const char *kvs_name, struct kvs_cparams 
 
     strlcpy(kvs->kk_name, kvs_name, sizeof(kvs->kk_name));
 
-    /* HSE_REVISIT: The following block is transitional code
-     * to assist with initializing the hard-coded route map.
-     * Make params arg const after removing this block.
-     */
-    if (1) {
-        char path[128], buf[128];
-        uint fanout;
-        ssize_t cc;
-        int n;
-
-        n = snprintf(path, sizeof(path), "/var/tmp/routemap-%s", kvs_name);
-        if (n < 1 || n >= sizeof(path))
-            abort();
-
-        cc = hse_readfile(-1, path, buf, sizeof(buf), O_RDONLY);
-        if (cc > 0) {
-            n = sscanf(buf, "%u", &fanout);
-            if (n == 1)
-                params->fanout = fanout;
-        }
-    }
-
     mutex_lock(&self->ikdb_lock);
 
     if (self->ikdb_kvs_cnt >= HSE_KVS_COUNT_MAX) {

--- a/lib/kvdb/kvdb_rest.c
+++ b/lib/kvdb/kvdb_rest.c
@@ -847,7 +847,8 @@ print_tree(struct ctx *ctx, struct kvset_view *v)
         ctx->node_nodeid = v->nodeid;
         ctx->eklen = v->eklen;
         if (ctx->eklen > 0)
-            fmt_hexp(ctx->ekbuf, sizeof(ctx->ekbuf), v->ekbuf, v->eklen, "0x", 2, ".", "");
+            fmt_hexp(ctx->ekbuf, sizeof(ctx->ekbuf), v->ekbuf,
+                     min_t(size_t, sizeof(v->ekbuf), v->eklen), "0x", 2, ".", "");
 
         if (ctx->eklen > ctx->eklen_max)
             ctx->eklen_max = ctx->eklen;

--- a/lib/kvs/kvs_cparams.c
+++ b/lib/kvs/kvs_cparams.c
@@ -14,27 +14,6 @@
 
 static const struct param_spec pspecs[] = {
     {
-        .ps_name = "fanout",
-        .ps_description = "cN tree fanout",
-        .ps_flags = PARAM_FLAG_EXPERIMENTAL,
-        .ps_type = PARAM_TYPE_U32,
-        .ps_offset = offsetof(struct kvs_cparams, fanout),
-        .ps_size = PARAM_SZ(struct kvs_cparams, fanout),
-        .ps_convert = param_default_converter,
-        .ps_validate = param_default_validator,
-        .ps_stringify = param_default_stringify,
-        .ps_jsonify = param_default_jsonify,
-        .ps_default_value = {
-            .as_uscalar = 16,
-        },
-        .ps_bounds = {
-            .as_uscalar = {
-                .ps_min = CN_FANOUT_MIN,
-                .ps_max = CN_FANOUT_MAX,
-            },
-        },
-    },
-    {
         .ps_name = "prefix.length",
         .ps_description = "Key prefix length",
         .ps_flags = 0,

--- a/tests/functional/smoke/droptomb2.sh
+++ b/tests/functional/smoke/droptomb2.sh
@@ -13,7 +13,7 @@ kvdb_create
 
 keys=10
 
-kvs=$(kvs_create smoke-0 fanout=2)
+kvs=$(kvs_create smoke-0)
 
 # Set rspill params to 0x0404 (min/max of 4/4) so that we generate
 # two cn root spills for each group of eight calls to putbin.

--- a/tests/functional/smoke/prefix-tree-shape1.sh
+++ b/tests/functional/smoke/prefix-tree-shape1.sh
@@ -66,7 +66,7 @@ for fanout in 2 4 8 16; do
         *) exit 2;;
     esac
 
-    kvs=$(kvs_create smoke-"$fanout" prefix.length=4 fanout="$fanout")
+    kvs=$(kvs_create smoke-"$fanout" prefix.length=4)
 
 
     cmd kmt -j32 -f 'xxxx%016lx' "-l$vlen:$vlen" -s1 "-i$nkeys" "$home" "$kvs" "${oparms[@]}"

--- a/tests/unit/c0/cn_mock.c
+++ b/tests/unit/c0/cn_mock.c
@@ -131,7 +131,6 @@ create_mock_cn(
 
     mapi_inject_list_set(inject_list);
 
-    mock_cn->cp->fanout = 16;
     mock_cn->cp->pfx_len = pfx_len;
 
 

--- a/tests/unit/cn/cn_api_test.c
+++ b/tests/unit/cn/cn_api_test.c
@@ -30,6 +30,7 @@ pre(struct mtf_test_info *info)
 
     mapi_inject_ptr(mapi_idx_ikvdb_get_mclass_policy, (void *)5);
     mapi_inject(mapi_idx_cndb_cn_instantiate, 0);
+    mapi_inject(mapi_idx_cndb_nodeid_mint, 1);
 
     return 0;
 }
@@ -61,7 +62,6 @@ MTF_DEFINE_UTEST_PRE(cn_api, basic, pre)
 
     kk.kk_parent = (void *)&dummy_ikvdb;
     kk.kk_cparams = &cp;
-    kk.kk_cparams->fanout = 4;
 
     mapi_inject(mapi_idx_ikvdb_get_csched, 0);
     mapi_inject(mapi_idx_mpool_props_get, 0);
@@ -76,10 +76,6 @@ MTF_DEFINE_UTEST_PRE(cn_api, basic, pre)
 
     tree = cn_get_tree(cn);
     ASSERT_NE(tree, NULL);
-
-    struct kvs_cparams *c = cn_get_cparams(cn);
-
-    ASSERT_EQ(c->fanout, 4);
 
     struct kvs_rparams *rp_out;
 

--- a/tests/unit/cn/cn_ingest_test.c
+++ b/tests/unit/cn/cn_ingest_test.c
@@ -246,7 +246,6 @@ MTF_DEFINE_UTEST_PRE(cn_ingest_test, worker, test_pre)
     cn.cn_dataset = mock_ds;
     atomic_set(&cn.cn_ingest_dgen, 41);
 
-    cp.fanout = 4;
     cp.pfx_len = 0;
     cp.sfx_len = 0;
     err = cn_tree_create(&cn.cn_tree, NULL, 0, &cp, &mock_health, &rp);
@@ -282,7 +281,6 @@ MTF_DEFINE_UTEST_PRE(cn_ingest_test, fail_cleanup, test_pre)
     cn.cn_dataset = mock_ds;
     atomic_set(&cn.cn_ingest_dgen, 41);
 
-    cp.fanout = 4;
     cp.pfx_len = 0;
     cp.sfx_len = 0;
     err = cn_tree_create(&cn.cn_tree, NULL, 0, &cp, &mock_health, &rp);

--- a/tests/unit/cn/cn_make_test.c
+++ b/tests/unit/cn/cn_make_test.c
@@ -48,21 +48,12 @@ MTF_DEFINE_UTEST_PREPOST(cn_make_test, cn_make1, pre, post)
 {
     struct mpool *     ds = (void *)-1;
     merr_t             err;
-    u32                i;
     struct kvs_cparams cp;
 
     cp = kvs_cparams_defaults();
 
-    for (i = CN_FANOUT_MAX - 1; i < CN_FANOUT_MAX + 1; i++) {
-        cp.fanout = i;
-
-        err = cn_make(ds, &cp, &health);
-        if (err) {
-            ASSERT_TRUE(i < CN_FANOUT_MAX || i > CN_FANOUT_MAX || (1u << ilog2(i)) != i);
-        } else {
-            ASSERT_TRUE(i >= CN_FANOUT_MIN && i <= CN_FANOUT_MAX);
-        }
-    }
+    err = cn_make(ds, &cp, &health);
+    ASSERT_EQ(0, err);
 }
 
 MTF_END_UTEST_COLLECTION(cn_make_test)

--- a/tests/unit/cn/cn_open_test.c
+++ b/tests/unit/cn/cn_open_test.c
@@ -43,7 +43,6 @@ const char *       kvs;
 struct kvdb_health health, *h;
 uint               flags;
 struct kvs_cparams cp = {
-    .fanout = 16,
 };
 
 #define CN_OPEN_ARGS cn_kvdb, ds, kk, cndb, cnid, rp, mp, kvs, h, flags
@@ -67,6 +66,7 @@ struct mapi_injection inject_list[] = {
     { mapi_idx_kvdb_kvs_flags, MAPI_RC_SCALAR, 0 },
 
     { mapi_idx_cndb_cn_instantiate, MAPI_RC_SCALAR, 0 },
+    { mapi_idx_cndb_nodeid_mint, MAPI_RC_SCALAR, 1 },
 
     { mapi_idx_cn_tree_set_initial_dgen, MAPI_RC_SCALAR, 0 },
 

--- a/tests/unit/cn/cn_tree_cursor_test.c
+++ b/tests/unit/cn/cn_tree_cursor_test.c
@@ -261,12 +261,13 @@ MTF_DEFINE_UTEST_PREPOST(cn_tree_cursor_test, empty, pre_test, post_test)
 {
     merr_t err;
     struct cn_cursor cur = {};
-    struct kvs_cparams cp = kvs_cparams_defaults();
     struct cn_tree_node tn;
     struct route_node *rnode;
     const char ekey = 'z';
 
-    tree.ct_route_map = route_map_create(cp.fanout);
+    tree.ct_route_map = route_map_create(CN_FANOUT_MAX);
+    ASSERT_NE(NULL, tree.ct_route_map);
+
     rnode = route_map_insert(tree.ct_route_map, &tn, &ekey, sizeof(ekey));
     ASSERT_NE(NULL, rnode);
 
@@ -298,14 +299,15 @@ MTF_DEFINE_UTEST_PREPOST(cn_tree_cursor_test, basic, pre_test, post_test)
     struct cn_cursor cur = {
         .cncur_seqno = 10,
     };
-    struct kvs_cparams cp = kvs_cparams_defaults();
     struct cn_tree_node tn;
     struct route_node *rnode;
     const char ekey = 'z';
 
     struct kv kv[2];
 
-    tree.ct_route_map = route_map_create(cp.fanout);
+    tree.ct_route_map = route_map_create(CN_FANOUT_MAX);
+    ASSERT_NE(NULL, tree.ct_route_map);
+
     rnode = route_map_insert(tree.ct_route_map, &tn, &ekey, sizeof(ekey));
     ASSERT_NE(NULL, rnode);
 
@@ -366,7 +368,6 @@ MTF_DEFINE_UTEST_PREPOST(cn_tree_cursor_test, dups, pre_test, post_test)
     struct cn_cursor cur = {
         .cncur_seqno = 10,
     };
-    struct kvs_cparams cp = kvs_cparams_defaults();
     struct cn_tree_node tn;
     struct route_node *rnode;
     const char ekey = 'z';
@@ -380,7 +381,9 @@ MTF_DEFINE_UTEST_PREPOST(cn_tree_cursor_test, dups, pre_test, post_test)
     kv_add(&kv[3], "key02", 1, vtype_val);
     kv_end();
 
-    tree.ct_route_map = route_map_create(cp.fanout);
+    tree.ct_route_map = route_map_create(CN_FANOUT_MAX);
+    ASSERT_NE(NULL, tree.ct_route_map);
+
     rnode = route_map_insert(tree.ct_route_map, &tn, &ekey, sizeof(ekey));
     ASSERT_NE(NULL, rnode);
 
@@ -436,7 +439,6 @@ MTF_DEFINE_UTEST_PREPOST(cn_tree_cursor_test, with_ptomb, pre_test, post_test)
         .cncur_pfx = pfxstr,
         .cncur_pfxlen = strlen(pfxstr),
     };
-    struct kvs_cparams cp = kvs_cparams_defaults();
     struct cn_tree_node tn;
     struct route_node *rnode;
     const char ekey = 'z';
@@ -460,7 +462,9 @@ MTF_DEFINE_UTEST_PREPOST(cn_tree_cursor_test, with_ptomb, pre_test, post_test)
     kv_add(&kv[9], "bb01", 4,  vtype_val);    /* Hidden: Does not match cursor pfx */
     kv_end();
 
-    tree.ct_route_map = route_map_create(cp.fanout);
+    tree.ct_route_map = route_map_create(CN_FANOUT_MAX);
+    ASSERT_NE(NULL, tree.ct_route_map);
+
     rnode = route_map_insert(tree.ct_route_map, &tn, &ekey, sizeof(ekey));
     ASSERT_NE(NULL, rnode);
 

--- a/tests/unit/cn/csched_sp3_test.c
+++ b/tests/unit/cn/csched_sp3_test.c
@@ -139,7 +139,6 @@ new_tree(uint fanout)
 
     tt = ttv + ttc;
 
-    cp.fanout = fanout;
     cp.pfx_len = pfx_len;
 
     err = cn_tree_create(&tt->tree, NULL, 0, &cp, &health, kvs_rp);

--- a/tests/unit/cn/kblock_builder_test.c
+++ b/tests/unit/cn/kblock_builder_test.c
@@ -32,7 +32,6 @@ const struct kvs_rparams mocked_rp_default = {
 };
 
 const struct kvs_cparams mocked_cp_default = {
-    .fanout = 16,
     .pfx_len = 0,
     .sfx_len = 0,
 };

--- a/tests/unit/cn/merge_test.c
+++ b/tests/unit/cn/merge_test.c
@@ -495,9 +495,6 @@ process_yaml(void)
     node2 = ydoc_map_lookup(doc, node, "pfx_len");
     if (node2)
         tp.pfx_len = ydoc_node_as_int(doc, node2);
-    node2 = ydoc_map_lookup(doc, node, "fanout");
-    if (node2)
-        tp.fanout = ydoc_node_as_u64(doc, node2);
 
     name = "output_kvset";
     node = ydoc_map_lookup(doc, root_node, name);
@@ -1159,7 +1156,7 @@ run_testcase(struct mtf_test_info *lcl_ti, int mode, const char *info)
         struct kvdb_health    health;
 
         struct kvs_cparams cp = {
-            .fanout = tp.fanout, .pfx_len = tp.pfx_len,
+            .pfx_len = tp.pfx_len,
         };
 
         err = cn_tree_create(&tree, "kvs", 0, &cp, &health, &rp);
@@ -1168,7 +1165,7 @@ run_testcase(struct mtf_test_info *lcl_ti, int mode, const char *info)
 
         cn_tree_setup(tree, NULL, NULL, &rp, NULL, 1234, 0);
 
-        for (i = 0; i < cp.fanout; i++) {
+        for (i = 0; i < tp.fanout; i++) {
             struct cn_tree_node *tn;
             char ekbuf[HSE_KVS_KEY_LEN_MAX];
             size_t eklen;

--- a/tests/unit/cn/route_test.c
+++ b/tests/unit/cn/route_test.c
@@ -21,8 +21,8 @@ MTF_DEFINE_UTEST(route_test, route_api_test)
     struct route_map *map;
     struct cn_tree_node tn;
     static const uint nodec = 16;
-    struct route_node *rnodev[2 * nodec], *rnode = NULL, *rnode2;
-    char ekbuf[2 * nodec][sizeof(rnode->rtn_keybuf)];
+    struct route_node *rnodev[2 * nodec + 1], *rnode = NULL, *rnode2;
+    char ekbuf[2 * nodec + 1][sizeof(rnode->rtn_keybuf)];
     uint eklen = 5, idx;
     char ekbuf_large[sizeof(rnode->rtn_keybuf) + 1];
     merr_t err;
@@ -30,7 +30,7 @@ MTF_DEFINE_UTEST(route_test, route_api_test)
     map = route_map_create(0);
     ASSERT_EQ(NULL, map);
 
-    map = route_map_create(nodec);
+    map = route_map_create(nodec * 2 + 1);
     ASSERT_NE(NULL, map);
 
     for (uint i = 0; i < 2 * nodec; i++) {

--- a/tests/unit/cndb/cndb_test.c
+++ b/tests/unit/cndb/cndb_test.c
@@ -670,19 +670,16 @@ MTF_DEFINE_UTEST(cndb_test, multiple_kvs)
     /* Test */
     ASSERT_EQ(0, cndb_kvs_count(cndb));
 
-    cp.fanout = 1;
     err = cndb_record_kvs_add(cndb, &cp, &cnid, "kvs-01");
     ASSERT_EQ(0, err);
     ASSERT_EQ(1, cnid);
     ASSERT_EQ(1, cndb_kvs_count(cndb));
 
-    cp.fanout = 2;
     err = cndb_record_kvs_add(cndb, &cp, &cnid, "kvs-02");
     ASSERT_EQ(0, err);
     ASSERT_EQ(2, cnid);
     ASSERT_EQ(2, cndb_kvs_count(cndb));
 
-    cp.fanout = 3;
     err = cndb_record_kvs_add(cndb, &cp, &cnid, "kvs-03");
     ASSERT_EQ(0, err);
     ASSERT_EQ(3, cnid);
@@ -692,7 +689,6 @@ MTF_DEFINE_UTEST(cndb_test, multiple_kvs)
     ASSERT_EQ(0, err);
     ASSERT_EQ(2, cndb_kvs_count(cndb));
 
-    cp.fanout = 42;
     err = cndb_record_kvs_add(cndb, &cp, &cnid, "kvs-02");
     ASSERT_EQ(0, err);
     ASSERT_EQ(4, cnid);

--- a/tests/unit/config/argv_test.c
+++ b/tests/unit/config/argv_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <hse_ikvdb/param.h>
@@ -14,7 +14,7 @@ MTF_BEGIN_UTEST_COLLECTION(argv_test)
 MTF_DEFINE_UTEST(argv_test, deserialize_to_params_malformed_kv_pair)
 {
     merr_t             err;
-    const char * const paramv[] = { "fanout", "fanout=" };
+    const char * const paramv[] = { "prefix.length", "prefix.length=" };
     struct kvs_cparams params;
 
     err = argv_deserialize_to_kvs_cparams(1, paramv, &params);
@@ -37,32 +37,21 @@ MTF_DEFINE_UTEST(argv_test, deserialize_to_params_invalid_param)
 MTF_DEFINE_UTEST(argv_test, deserialize_to_params_invalid_value)
 {
     merr_t             err;
-    const char * const paramv[] = { "fanout=0" };
+    const char * const paramv[] = { "prefix.length=-1" };
     struct kvs_cparams params;
 
     err = argv_deserialize_to_kvs_cparams(1, paramv, &params);
     ASSERT_NE(0, err);
 }
 
-MTF_DEFINE_UTEST(argv_test, deserialize_to_params_invalid_relation_validation)
-{
-    merr_t             err;
-    const char * const paramv[] = { "cn_node_size_hi=49" };
-    struct kvs_rparams params;
-
-    err = argv_deserialize_to_kvs_rparams(NELEM(paramv), paramv, &params);
-    ASSERT_NE(0, err);
-}
-
 MTF_DEFINE_UTEST(argv_test, deserialize_to_params)
 {
     merr_t             err;
-    const char * const paramv[] = { "fanout=8", "prefix.length=7" };
+    const char * const paramv[] = { "prefix.length=7" };
     struct kvs_cparams params;
 
-    err = argv_deserialize_to_kvs_cparams(2, paramv, &params);
+    err = argv_deserialize_to_kvs_cparams(NELEM(paramv), paramv, &params);
     ASSERT_EQ(0, err);
-    ASSERT_EQ(8, params.fanout);
     ASSERT_EQ(7, params.pfx_len);
 }
 
@@ -72,7 +61,7 @@ MTF_DEFINE_UTEST(argv_test, deserialize_overwrite)
     const char * const paramv[] = { "prefix.length=8", "prefix.length=7" };
     struct kvs_cparams params;
 
-    err = argv_deserialize_to_kvs_cparams(2, paramv, &params);
+    err = argv_deserialize_to_kvs_cparams(NELEM(paramv), paramv, &params);
     ASSERT_EQ(0, err);
     ASSERT_EQ(7, params.pfx_len);
 }

--- a/tests/unit/kvs/kvs_cparams_test.c
+++ b/tests/unit/kvs/kvs_cparams_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <mtf/framework.h>
@@ -38,25 +38,6 @@ ps_get(const char *name)
     }
 
     return NULL;
-}
-
-MTF_DEFINE_UTEST_PRE(kvs_cparams_test, fanout, test_pre)
-{
-    const struct param_spec *ps = ps_get("fanout");
-
-    ASSERT_NE(NULL, ps);
-    ASSERT_NE(NULL, ps->ps_description);
-    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U32, ps->ps_type);
-    ASSERT_EQ(offsetof(struct kvs_cparams, fanout), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint32_t), ps->ps_size);
-    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
-    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
-    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
-    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
-    ASSERT_EQ(16, params.fanout);
-    ASSERT_EQ(CN_FANOUT_MIN, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(CN_FANOUT_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvs_cparams_test, prefix_length, test_pre)

--- a/tools/cndb_log/cndb_log.c
+++ b/tools/cndb_log/cndb_log.c
@@ -110,8 +110,8 @@ cndb_print_record(struct cndb_reader *reader)
         uint64_t cnid;
 
         cndb_omf_kvs_add_read(reader->buf, &cp, &cnid, name, sizeof(name));
-        printf("%-8s name %s cnid %lu fanout %u pfxlen %u capped %c\n",
-               "kvs_add", name, cnid, cp.fanout, cp.pfx_len, cp.kvs_ext01 ? 'y' : 'n');
+        printf("%-8s name %s cnid %lu pfxlen %u capped %c\n",
+               "kvs_add", name, cnid, cp.pfx_len, cp.kvs_ext01 ? 'y' : 'n');
 
     } else if (rec_type == CNDB_TYPE_KVS_DEL) {
         uint64_t cnid;

--- a/tools/kmt/kmt.c
+++ b/tools/kmt/kmt.c
@@ -227,7 +227,7 @@ hse_err_to_errno(hse_err_t err);
 const char *   cf_dir = "/var/tmp";
 char           chk_path[PATH_MAX];
 char           kvdb_home_realpath[PATH_MAX];
-uint64_t       chk_recmax = 192 * 1024 * 1024;
+uint64_t       chk_recmax = 1024 * 1024 * 1024;
 struct timeval tv_init;
 const char *   progname;
 char *         randbuf;


### PR DESCRIPTION
- Node split integration
- Determine compc for new kvsets while holding the tree lock in sp3_work().
