### PR TITLE
Hide details of CNDB callback context during cn_open()

### DIFF
--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -920,18 +920,6 @@ done:
     return err;
 }
 
-u64
-cn_tree_initial_dgen(const struct cn_tree *tree)
-{
-    return tree->ct_dgen_init;
-}
-
-void
-cn_tree_set_initial_dgen(struct cn_tree *tree, u64 dgen)
-{
-    tree->ct_dgen_init = dgen;
-}
-
 bool
 cn_tree_is_capped(const struct cn_tree *tree)
 {

--- a/lib/cn/cn_tree.h
+++ b/lib/cn/cn_tree.h
@@ -43,16 +43,6 @@ cn_tree_lookup(
     struct kvs_buf *     kbuf,
     struct kvs_buf *     vbuf);
 
-/**
- * cn_tree_initial_dgen() - return most current dgen in tree
- * @tree: tree to query
- *
- * The dgen returned is the largest dgen value seen during MDC replay.
- */
-/* MTF_MOCK */
-u64
-cn_tree_initial_dgen(const struct cn_tree *tree);
-
 /* Return true if the cn_tree is capped. */
 bool
 cn_tree_is_capped(const struct cn_tree *tree);

--- a/lib/cn/cn_tree_create.h
+++ b/lib/cn/cn_tree_create.h
@@ -72,17 +72,6 @@ cn_tree_setup(
     struct cn_kvdb *    cn_kvdb);
 
 /**
- * cn_tree_set_initial_dgen() - set most current dgen in tree
- * @tree: tree to update
- * @dgen: new dgen
- *
- * This sets dgen in the cn_tree, used to initialize cn_ingest_dgen.
- */
-/* MTF_MOCK */
-void
-cn_tree_set_initial_dgen(struct cn_tree *tree, u64 dgen);
-
-/**
  * cn_tree_insert_kvset() - Add kvset to a tree node during tree initialization
  * @tree:   cn tree structure
  * @kvset:  kvset to add

--- a/lib/cn/cn_tree_internal.h
+++ b/lib/cn/cn_tree_internal.h
@@ -107,7 +107,6 @@ struct cn_tree {
     struct cn_kvdb *    cn_kvdb;
     struct kvs_cparams *ct_cp;
     u64                 cnid;
-    u64                 ct_dgen_init;
 
     uint                 ct_lvl_max;
     struct cn_samp_stats ct_samp;

--- a/tests/unit/cn/cn_open_test.c
+++ b/tests/unit/cn/cn_open_test.c
@@ -68,8 +68,6 @@ struct mapi_injection inject_list[] = {
     { mapi_idx_cndb_cn_instantiate, MAPI_RC_SCALAR, 0 },
     { mapi_idx_cndb_nodeid_mint, MAPI_RC_SCALAR, 1 },
 
-    { mapi_idx_cn_tree_set_initial_dgen, MAPI_RC_SCALAR, 0 },
-
     { mapi_idx_csched_tree_add, MAPI_RC_SCALAR, 0 },
     { mapi_idx_csched_tree_remove, MAPI_RC_SCALAR, 0 },
     { mapi_idx_ikvdb_read_only, MAPI_RC_SCALAR, 0 },

--- a/tests/unit/cn/cn_tree_test.c
+++ b/tests/unit/cn/cn_tree_test.c
@@ -438,12 +438,6 @@ MTF_DEFINE_UTEST_PRE(test, t_simple_api, test_setup)
     out = cn_tree_get_cparams(tree);
     ASSERT_EQ(12, out->pfx_len);
 
-    ASSERT_EQ(0, cn_tree_initial_dgen(tree));
-
-    cn_tree_set_initial_dgen(tree, 42);
-
-    ASSERT_EQ(42, cn_tree_initial_dgen(tree));
-
     cn_tree_destroy(tree);
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Tomlinson <4172734+alexttx@users.noreply.github.com>
