### PR TITLE
Remove rarely used KVDB stats (NFSE-5303)

### DIFF
--- a/lib/cn/cn_kvdb.c
+++ b/lib/cn/cn_kvdb.c
@@ -23,13 +23,6 @@ cn_kvdb_create(uint cn_maint_threads, uint cn_io_threads, struct cn_kvdb **out)
     if (ev(!self))
         return merr(ENOMEM);
 
-    atomic_set(&self->cnd_hblk_cnt, 0);
-    atomic_set(&self->cnd_kblk_cnt, 0);
-    atomic_set(&self->cnd_vblk_cnt, 0);
-    atomic_set(&self->cnd_hblk_size, 0);
-    atomic_set(&self->cnd_kblk_size, 0);
-    atomic_set(&self->cnd_vblk_size, 0);
-
     self->cn_maint_wq = alloc_workqueue("hse_cn_maint", 0, 3, cn_maint_threads);
     if (ev(!self->cn_maint_wq)) {
         free(self);

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -788,14 +788,6 @@ kvset_open2(
     kvset_get_ref(ks);
     ks->ks_deleted = DEL_NONE;
 
-    atomic_add(&cn_kvdb->cnd_hblk_size, ks->ks_st.kst_halen);
-    atomic_add(&cn_kvdb->cnd_kblk_size, ks->ks_st.kst_kalen);
-    atomic_add(&cn_kvdb->cnd_vblk_size, ks->ks_st.kst_valen);
-
-    atomic_inc(&cn_kvdb->cnd_hblk_cnt);
-    atomic_add(&cn_kvdb->cnd_kblk_cnt, ks->ks_st.kst_kblks);
-    atomic_add(&cn_kvdb->cnd_vblk_cnt, ks->ks_st.kst_vblks);
-
     blk_list_init(&ks->ks_purge);
 
 #define ra_willneed(_ra)    ((_ra) & 0x01u)
@@ -1027,20 +1019,7 @@ kvset_close(struct kvset *ks)
     assert(ks);
     assert(atomic_read(&ks->ks_ref) == 0);
 
-    if (ks->ks_cn_kvdb) {
-        struct cn_kvdb *cnd = ks->ks_cn_kvdb;
-
-        atomic_dec(&cnd->cnd_hblk_cnt);
-        atomic_sub(&cnd->cnd_kblk_cnt, ks->ks_st.kst_kblks);
-        atomic_sub(&cnd->cnd_vblk_cnt, ks->ks_st.kst_vblks);
-
-        atomic_sub(&cnd->cnd_hblk_size, ks->ks_st.kst_halen);
-        atomic_sub(&cnd->cnd_kblk_size, ks->ks_st.kst_kalen);
-        atomic_sub(&cnd->cnd_vblk_size, ks->ks_st.kst_valen);
-    }
-
     cleanup_hblock(ks);
-
     cleanup_kblocks(ks);
 
     if (ks->ks_deleted == DEL_LIST)

--- a/lib/include/hse_ikvdb/cn_kvdb.h
+++ b/lib/include/hse_ikvdb/cn_kvdb.h
@@ -13,22 +13,9 @@
 /* MTF_MOCK_DECL(cn_kvdb) */
 
 /**
- * struct cn_kvdb - public portion of per kvdb cN object
- * @cnd_hblk_cnt:  number of cn hblocks in kvdb
- * @cnd_kblk_cnt:  number of cn kblocks in kvdb
- * @cnd_vblk_cnt:  number of cn vblocks in kvdb
- * @cnd_kblk_size: sum of on-media sizes of all cn hblocks in kvdb (bytes)
- * @cnd_kblk_size: sum of on-media sizes of all cn kblocks in kvdb (bytes)
- * @cnd_vblk_size: sum of on-media sizes of all cn vblocks in kvdb (bytes)
+ * Public portion of per kvdb cN object
  */
 struct cn_kvdb {
-    atomic_ulong cnd_hblk_cnt;
-    atomic_ulong cnd_kblk_cnt;
-    atomic_ulong cnd_vblk_cnt;
-    atomic_ulong cnd_hblk_size;
-    atomic_ulong cnd_kblk_size;
-    atomic_ulong cnd_vblk_size;
-
     struct workqueue_struct *cn_maint_wq;
     struct workqueue_struct *cn_io_wq;
 };


### PR DESCRIPTION
HSE maintains a small set of KVDB stats that are only used to show stats about
each KVS when the KVS is opened.  These KVDB stats are not maintained at
runtime, so they're not useful for anything except the log message during KVS
open.

The inaccurate KVDB stats have been removed, and the stats needed for the log
message are computed locally in cn_open().

Signed-off-by: Alex Tomlinson <4172734+alexttx@users.noreply.github.com>
