### PR TITLE
Add LOG_DOMAIN to logging infrastructure

### DIFF
--- a/lib/util/include/hse_util/printbuf.h
+++ b/lib/util/include/hse_util/printbuf.h
@@ -1,11 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_PLATFORM_PRINTBUF_H
 #define HSE_PLATFORM_PRINTBUF_H
 
+#include <hse_util/compiler.h>
 #include <hse_util/inttypes.h>
 
 /**
@@ -32,7 +33,7 @@
  * Return: The return code from vsnprintf().
  */
 int
-snprintf_append(char *buf, size_t buf_sz, size_t *offset, const char *format, ...);
+snprintf_append(char *buf, size_t buf_sz, size_t *offset, const char *format, ...) HSE_PRINTF(4, 5);
 
 /**
  * sprintbuf - append a formatted char string to a buffer.
@@ -57,7 +58,7 @@ snprintf_append(char *buf, size_t buf_sz, size_t *offset, const char *format, ..
  * Returns: void.
  */
 void
-sprintbuf(char *buf, size_t *remainder, size_t *offset, const char *format, ...);
+sprintbuf(char *buf, size_t *remainder, size_t *offset, const char *format, ...) HSE_PRINTF(4, 5);
 
 /**
  * vsnprintf_append - append a varargs-formatted char string to a buffer.

--- a/lib/util/src/logging_impl.h
+++ b/lib/util/src/logging_impl.h
@@ -140,6 +140,7 @@ vpreprocess_fmt_string(
     const char *              fmt,
     char *                    new_fmt,
     s32                       new_len,
+    const char *              domain,
     void **                   hse_args,
     va_list                   args);
 

--- a/tests/mocks/repository/lib/mock_log.c
+++ b/tests/mocks/repository/lib/mock_log.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include "util/src/logging_impl.h"
@@ -32,7 +32,7 @@ test_preprocess_fmt_string(
 
     va_start(args, hse_args);
 
-    vpreprocess_fmt_string(state, func, fmt, new_fmt, new_len, hse_args, args);
+    vpreprocess_fmt_string(state, func, fmt, new_fmt, new_len, LOG_DOMAIN, hse_args, args);
 
     va_end(args);
 }
@@ -53,7 +53,7 @@ test_finalize_log_structure(
 
     va_start(args, hse_args);
 
-    vpreprocess_fmt_string(state, __func__, fmt, new_fmt, new_len, hse_args, args);
+    vpreprocess_fmt_string(state, __func__, fmt, new_fmt, new_len, LOG_DOMAIN, hse_args, args);
 
     va_end(args);
 

--- a/tests/unit/util/logging_test.c
+++ b/tests/unit/util/logging_test.c
@@ -251,11 +251,16 @@ _test_add(struct hse_log_fmt_state *state, void *obj)
 
 MTF_DEFINE_UTEST(hse_logging_test, Test_string)
 {
+    char domain[64];
+    const char *dbasename = log_domain_basename(__FILE__);
     const char str[] = "A string with no special characters.";
 
     hse_log_notice("A string with no special characters.");
+    snprintf(domain, sizeof(domain), "[HSE%s%s]", dbasename ? "/" : "", dbasename ? dbasename : "");
+    printf("%s\n", shared_result.msg_buffer);
 
     ASSERT_TRUE(strstr(shared_result.msg_buffer, str));
+    ASSERT_TRUE(strstr(shared_result.msg_buffer, domain));
 }
 
 MTF_DEFINE_UTEST(hse_logging_test, Test_register)


### PR DESCRIPTION
Domain logging is an idea I ripped from GLib. In GLib, you have a
preprocessor macro that you can define called G_LOG_DOMAIN. If you
define it, all logs that you emit will be prepended with your custom
static string. By default, I think GLib uses the short program name.

In our case, the define is LOG_DOMAIN and you can use it like so:

\#define LOG_DOMAIN "HSE/my-domain"

\#include <hse_util/logging.h>

int
func(void)
{
    log_info("hello world");
}

This log will appear as:

[HSE/my-domain] func: hello world

This should help when grepping for related logs across files and
functions.

Signed-off-by: Tristan Partin <tpartin@micron.com>
