### PR TITLE
Move spill merge loop to bin_heap2

### DIFF
--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -147,7 +147,6 @@ struct cn_compaction_work {
     enum cn_action           cw_action;
     enum cn_rule             cw_rule;
     bool                     cw_have_token;
-    bool                     cw_rspill_conc;
     struct list_head         cw_rspill_link;
     atomic_int               cw_rspill_commit_in_progress;
     u64                      cw_dgen_hi;
@@ -155,7 +154,7 @@ struct cn_compaction_work {
 
     /* For scheduler */
     struct sts_job        cw_job;
-    cn_work_callback      cw_completion;
+    cn_work_callback      cw_checkpoint;
     cn_work_callback      cw_progress;
     void *                cw_sched;
     struct list_head      cw_sched_link;
@@ -195,6 +194,7 @@ struct cn_compaction_work {
     u64  cw_t2_prep;
     u64  cw_t3_build;
     u64  cw_t4_commit;
+    u64  cw_t5_finish;
     char cw_threadname[16];
 };
 

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -132,6 +132,7 @@ struct cn_compaction_work {
     struct kvs_rparams *     cw_rp;
     struct kvs_cparams *     cw_cp;
 
+    uint64_t                 cw_sgen;
     struct cn_tree *         cw_tree;
     struct cn_tree_node *    cw_node;
     struct kvset_list_entry *cw_mark;
@@ -148,7 +149,6 @@ struct cn_compaction_work {
     bool                     cw_have_token;
     bool                     cw_rspill_conc;
     struct list_head         cw_rspill_link;
-    atomic_int               cw_rspill_done;
     atomic_int               cw_rspill_commit_in_progress;
     u64                      cw_dgen_hi;
     u64                      cw_dgen_lo;
@@ -176,10 +176,7 @@ struct cn_compaction_work {
     struct cn_tree_node    **cw_output_nodev;
     struct vgmap           **cw_vgmap; /* used during k-compact and split */
     struct kvset_vblk_map    cw_vbmap; /* used only during k-compact */
-
-    struct cndb_txn      *cw_cndb_txn;
-    bool                  cw_keep_vblks;
-    void                **cw_cookie;
+    bool                     cw_keep_vblks;
 
     /* Used only for node split */
     struct {

--- a/lib/cn/cn_tree_cursor.c
+++ b/lib/cn/cn_tree_cursor.c
@@ -389,7 +389,7 @@ cn_lcur_advance(struct cn_level_cursor *lcur)
     if (lcur->cnlc_islast)
         return;
 
-    route_node_keycpy(rtn_ekey, &lcur->cnlc_next_ekey,
+    route_node_keycpy(rtn_ekey, lcur->cnlc_next_ekey,
                       sizeof(lcur->cnlc_next_ekey),
                       &lcur->cnlc_next_eklen);
 }

--- a/lib/cn/cn_tree_internal.h
+++ b/lib/cn/cn_tree_internal.h
@@ -105,6 +105,8 @@ struct cn_tree {
     struct kvs_cparams *ct_cp;
     u64                 cnid;
 
+    atomic_long         ct_sgen;
+
     uint                 ct_lvl_max;
     struct cn_samp_stats ct_samp;
     atomic_ulong         ct_rspill_dt;
@@ -148,6 +150,10 @@ struct cn_tree_node {
     atomic_int           tn_compacting;
     atomic_uint          tn_busycnt;
     atomic_uint          tn_rspill_sync;
+
+    atomic_long  tn_sgen;
+    struct cv    tn_spill_cv;
+    struct mutex tn_spill_mtx;
 
     union {
         struct sp3_node  tn_sp3n;

--- a/lib/cn/csched.c
+++ b/lib/cn/csched.c
@@ -69,6 +69,12 @@ csched_compact_status_get(struct csched *handle, struct hse_kvdb_compact_status 
     sp3_compact_status_get(handle, status);
 }
 
+void
+csched_node_dirty(struct csched *handle, struct cn_tree_node *node)
+{
+    sp3_dirty_node(handle, node);
+}
+
 #if HSE_MOCKING
 #include "csched_ut_impl.i"
 #endif /* HSE_MOCKING */

--- a/lib/cn/csched.c
+++ b/lib/cn/csched.c
@@ -70,9 +70,9 @@ csched_compact_status_get(struct csched *handle, struct hse_kvdb_compact_status 
 }
 
 void
-csched_node_dirty(struct csched *handle, struct cn_tree_node *node)
+csched_notify_compact(struct csched *handle, struct cn_compaction_work *w)
 {
-    sp3_dirty_node(handle, node);
+    sp3_work_complete(handle, w);
 }
 
 #if HSE_MOCKING

--- a/lib/cn/csched_sp3.h
+++ b/lib/cn/csched_sp3.h
@@ -26,6 +26,7 @@ struct cn_tree;
 struct cn_tree_node;
 struct throttle_sensor;
 struct hse_kvdb_compact_status;
+struct cn_compaction_work;
 
 struct sp3_rbe {
     struct rb_node rbe_node;
@@ -36,6 +37,7 @@ struct sp3_node {
     struct sp3_rbe   spn_rbe[wtype_MAX];
     struct list_head spn_rlink;
     struct list_head spn_alink;
+    struct list_head spn_dlink;
     bool             spn_initialized;
     uint             spn_cgen;
 };
@@ -46,6 +48,10 @@ struct sp3_tree {
     atomic_int       spt_enabled;
     atomic_ulong     spt_ingest_alen;
     atomic_ulong     spt_ingest_wlen;
+
+    /* Dirt node list */
+    struct mutex     spt_dlist_lock;
+    struct list_head spt_dlist;;
 };
 
 /* MTF_MOCK */
@@ -80,6 +86,10 @@ sp3_tree_add(struct csched *handle, struct cn_tree *tree);
 
 void
 sp3_tree_remove(struct csched *handle, struct cn_tree *tree, bool cancel);
+
+/* MTF_MOCK */
+void
+sp3_work_complete(struct csched *handle, struct cn_compaction_work *w);
 
 #if HSE_MOCKING
 #include "csched_sp3_ut.h"

--- a/lib/cn/csched_sp3.h
+++ b/lib/cn/csched_sp3.h
@@ -23,6 +23,7 @@ struct mpool;
 struct kvdb_health;
 struct csched;
 struct cn_tree;
+struct cn_tree_node;
 struct throttle_sensor;
 struct hse_kvdb_compact_status;
 
@@ -67,6 +68,9 @@ sp3_compact_request(struct csched *handle, int flags);
 
 void
 sp3_compact_status_get(struct csched *handle, struct hse_kvdb_compact_status *status);
+
+void
+sp3_dirty_node(struct csched *handle, struct cn_tree_node *tn);
 
 void
 sp3_notify_ingest(struct csched *handle, struct cn_tree *tree, size_t alen, size_t wlen);

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -756,12 +756,9 @@ sp3_work(
 
     INIT_LIST_HEAD(&w->cw_rspill_link);
 
-    if (w->cw_rspill_conc) {
-        /* ensure concurrent root spills complete in order */
-        mutex_lock(&tree->ct_rspills_lock);
-        list_add_tail(&w->cw_rspill_link, &tree->ct_rspills_list);
-        mutex_unlock(&tree->ct_rspills_lock);
-    }
+    /* ensure concurrent root spills complete in order */
+    if (w->cw_rspill_conc)
+        w->cw_sgen = atomic_inc_return(&w->cw_tree->ct_sgen);
 
     sp3_work_estimate(w);
 

--- a/lib/cn/kv_iterator.h
+++ b/lib/cn/kv_iterator.h
@@ -32,6 +32,7 @@ struct kv_iterator_ops {
  */
 struct kvset_iter_vctx {
     const void *kmd;
+    uint64_t    dgen;
     size_t      off;
     uint        nvals;
     uint        next;

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -2199,8 +2199,13 @@ kvset_iter_kblock_read(struct work_struct *rock)
     if (ev(err))
         goto done;
 
+    /* [HSE_REVISIT] kr->pc belongs to cn, this thread may be running after cn_close() and
+     * accessing kr->pc would cause a segfault. Uncomment after fixing this.
+     */
+#if 0
     perfc_inc(kr->pc, PERFC_RA_CNCOMP_RREQS);
     perfc_add(kr->pc, PERFC_RA_CNCOMP_RBYTES, iov.iov_len);
+#endif
 
     /* figure out kmd range that corresponds to leaf nodes */
     hdr = iov.iov_base;
@@ -2257,8 +2262,13 @@ kvset_iter_kblock_read(struct work_struct *rock)
     if (ev(err))
         goto done;
 
+    /* [HSE_REVISIT] kr->pc belongs to cn, this thread may be running after cn_close() and
+     * accessing kr->pc would cause a segfault. Uncomment after fixing this.
+     */
+#if 0
     perfc_inc(kr->pc, PERFC_RA_CNCOMP_RREQS);
     perfc_add(kr->pc, PERFC_RA_CNCOMP_RBYTES, iov.iov_len);
+#endif
 
     /* stash results in consumable form for caller */
     kr->iores.kr_ops = 2;
@@ -2355,8 +2365,13 @@ vr_read_work(struct work_struct *rock)
     if (ev(err))
         goto done;
 
+    /* [HSE_REVISIT] vr->pc belongs to cn, this thread may be running after cn_close() and
+     * accessing vr->pc would cause a segfault. Uncomment after fixing this.
+     */
+#if 0
     perfc_inc(vr->pc, PERFC_RA_CNCOMP_RREQS);
     perfc_add(vr->pc, PERFC_RA_CNCOMP_RBYTES, iov.iov_len);
+#endif
 
     vr->vr_buf[empty].idx = vr->vr_io_vbidx;
     vr->vr_buf[empty].off = vr->vr_io_offset;
@@ -3219,6 +3234,8 @@ kvset_iter_next_key(struct kv_iterator *handle, struct key_obj *kobj, struct kvs
 {
     merr_t                 err;
     struct kvset_iterator *iter = handle_to_kvset_iter(handle);
+
+    vc->dgen = kvset_get_dgen(iter->ks);
 
     if (handle->kvi_eof || (iter->pti_meta.eof && iter->wbti_meta.eof)) {
         handle->kvi_eof = true;

--- a/lib/cn/kvset_split.c
+++ b/lib/cn/kvset_split.c
@@ -304,7 +304,7 @@ kblocks_split(
     bool overlap = false;
     uint32_t split_idx;
     uint8_t *hlog;
-    merr_t err;
+    merr_t err = 0;
 
     split_idx = get_kblk_split_index(ks, split_kobj, &overlap);
     assert(split_idx <= ks->ks_st.kst_kblks);

--- a/lib/cn/spill.h
+++ b/lib/cn/spill.h
@@ -52,9 +52,11 @@ cn_spill(
     bool                      *added);
 
 
+/* MTF_MOCK */
 merr_t
 cn_spill_init(struct cn_compaction_work *w, struct spill_ctx **ctx);
 
+/* MTF_MOCK */
 void
 cn_spill_fini(struct spill_ctx *ctx);
 

--- a/lib/cn/spill.h
+++ b/lib/cn/spill.h
@@ -9,7 +9,10 @@
 #include <error/merr.h>
 #include <hse_util/inttypes.h>
 
+#include "route.h"
+
 struct cn_compaction_work;
+struct spill_ctx;
 
 /* MTF_MOCK_DECL(spill) */
 
@@ -40,7 +43,20 @@ struct cn_compaction_work;
  */
 /* MTF_MOCK */
 merr_t
-cn_spill(struct cn_compaction_work *w);
+cn_spill(
+    struct cn_compaction_work *w,
+    struct spill_ctx          *ctx,
+    uint64_t                   node_dgen,
+    void                      *ekey,
+    uint                      eklen,
+    bool                      *added);
+
+
+merr_t
+cn_spill_init(struct cn_compaction_work *w, struct spill_ctx **ctx);
+
+void
+cn_spill_fini(struct spill_ctx *ctx);
 
 #if HSE_MOCKING
 #include "spill_ut.h"

--- a/lib/include/hse_ikvdb/csched.h
+++ b/lib/include/hse_ikvdb/csched.h
@@ -15,6 +15,7 @@
 struct csched;
 struct kvdb_rparams;
 struct cn_tree;
+struct cn_tree_node;
 struct throttle_sensor;
 struct cn_samp_stats;
 struct mpool;
@@ -160,6 +161,10 @@ csched_compact_request(struct csched *handle, int flags);
 /* MTF_MOCK */
 void
 csched_compact_status_get(struct csched *handle, struct hse_kvdb_compact_status *status);
+
+/* MTF_MOCK */
+void
+csched_node_dirty(struct csched *handle, struct cn_tree_node *node);
 
 #if HSE_MOCKING
 #include "csched_ut.h"

--- a/lib/include/hse_ikvdb/csched.h
+++ b/lib/include/hse_ikvdb/csched.h
@@ -22,6 +22,7 @@ struct mpool;
 struct hse_kvdb_compact_status;
 struct kvdb_health;
 struct cn_tree_node;
+struct cn_compaction_work;
 
 /* clang-format off */
 
@@ -162,9 +163,8 @@ csched_compact_request(struct csched *handle, int flags);
 void
 csched_compact_status_get(struct csched *handle, struct hse_kvdb_compact_status *status);
 
-/* MTF_MOCK */
 void
-csched_node_dirty(struct csched *handle, struct cn_tree_node *node);
+csched_notify_compact(struct csched *handle, struct cn_compaction_work *w);
 
 #if HSE_MOCKING
 #include "csched_ut.h"

--- a/tests/mocks/repository/include/mocks/mock_kvset.h
+++ b/tests/mocks/repository/include/mocks/mock_kvset.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef MOCKS_MOCK_KVSET_H
@@ -8,9 +8,9 @@
 
 #include <hse_util/page.h>
 
-#include <arpa/inet.h> /* ntohl, htonl */
-
+#include <cn/cn_metrics.h>
 #include <cn/kv_iterator.h>
+#include <cn/kvset.h>
 
 /**
  * struct mock_kvset - test harness

--- a/tests/mocks/repository/lib/mock_kvset.c
+++ b/tests/mocks/repository/lib/mock_kvset.c
@@ -3,6 +3,8 @@
  * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
+#include <arpa/inet.h>
+
 #include <mock/api.h>
 
 #include <error/merr.h>

--- a/tests/unit/cn/cn_tree_test.c
+++ b/tests/unit/cn/cn_tree_test.c
@@ -689,7 +689,6 @@ cn_comp_work_init(
 
     w->cw_tree = t->tree;
     w->cw_node = tn;
-    w->cw_cndb_txn = (void *)-1;
 
     /* walk from tail (oldest), skip kvsets that are busy */
     for (le = list_last_entry(head, typeof(*le), le_link); &le->le_link != head;

--- a/tests/unit/cn/csched_sp3_test.c
+++ b/tests/unit/cn/csched_sp3_test.c
@@ -219,8 +219,8 @@ job_done(struct cn_compaction_work *w, int cancel)
     if (w->cw_have_token)
         cn_node_comp_token_put(w->cw_node);
 
-    if (w->cw_completion)
-        w->cw_completion(w);
+    if (w->cw_checkpoint)
+        w->cw_checkpoint(w);
     else
         mapi_safe_free(w);
 }

--- a/tests/unit/cn/hblock_builder_test.c
+++ b/tests/unit/cn/hblock_builder_test.c
@@ -145,7 +145,7 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, add_ptomb_success, test_pre, test_
     struct iovec iov[1];
     struct kvs_block blk;
     const void *pfx, *pfx_min, *pfx_max;
-    size_t pfx_min_len, pfx_max_len;
+    size_t pfx_min_len = 0, pfx_max_len = 0;
 
     char *buf = alloc_page_aligned(HBLOCK_HDR_PAGES * PAGE_SIZE);
     hdr = (struct hblock_hdr_omf *)buf;

--- a/tests/unit/cn/merge_test.c
+++ b/tests/unit/cn/merge_test.c
@@ -888,6 +888,9 @@ _kvset_iter_next_key(struct kv_iterator *kvi, struct key_obj *kobj, struct kvset
     vc->nvals = 0;
     vc->off = nth_key;
     vc->next = 0;
+    /* Spill is always called with a node_dgen of 0, set the kv-pair's dgen to something larger than 0.
+     */
+    vc->dgen = 10;
     return 0;
 }
 
@@ -1201,7 +1204,12 @@ run_testcase(struct mtf_test_info *lcl_ti, int mode, const char *info)
             tn = cn_node_alloc(tree, i + 1);
             ASSERT_NE(0, tn);
 
-            eklen = snprintf(ekbuf, sizeof(ekbuf), "a.%08d", i);
+            if (i < tp.fanout - 1)
+                eklen = snprintf(ekbuf, sizeof(ekbuf), "a.%08d", i);
+            else {
+                eklen = sizeof(ekbuf);
+                memset(ekbuf, 0xff, sizeof(ekbuf));
+            }
             tn->tn_route_node = route_map_insert(tree->ct_route_map, tn, ekbuf, eklen);
             list_add_tail(&tn->tn_link, &tree->ct_nodes);
         }
@@ -1229,8 +1237,28 @@ run_testcase(struct mtf_test_info *lcl_ti, int mode, const char *info)
         w.cw_action = CN_ACTION_SPILL;
         w.cw_cp = &cp;
 
-        err = cn_spill(&w);
-        ASSERT_EQ(err, 0);
+        struct spill_ctx *ctx;
+        unsigned char ekey[HSE_KVS_KEY_LEN_MAX];
+        uint eklen = 0;
+
+        err = cn_spill_init(&w, &ctx);
+        ASSERT_EQ(0, err);
+
+        while (1) {
+            struct route_node *rtn;
+            bool added;
+
+            rtn = route_map_lookupGT(tree->ct_route_map, ekey, eklen);
+            if (!rtn)
+                break;
+
+            route_node_keycpy(rtn, ekey, sizeof(ekey), &eklen);
+
+            err = cn_spill(&w, ctx, 0, ekey, eklen, &added);
+            ASSERT_EQ(0, err);
+        }
+
+        cn_spill_fini(ctx);
         cn_tree_destroy(tree);
     } else {
         /* kcompact */


### PR DESCRIPTION
bin_heap2 decreases the amount of copies during the merge loop. I
believe it is 2 copies for every key that enters the loop.

Signed-off-by: Tristan Partin <tpartin@micron.com>
