### PR TITLE
Fix codeql workflow dependencies

### DIFF
--- a/.github/workflows/codeql.ignore.yaml
+++ b/.github/workflows/codeql.ignore.yaml
@@ -6,7 +6,9 @@ on:
       - "**.c"
       - "**.cc"
       - "**.h"
+      - "**.h.in"
       - "**.py"
+      - "**/meson.build"
       - .github/workflows/codeql.yaml
 
 concurrency:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -6,11 +6,16 @@ on:
       - master
       - "v[0-9]+.[0-9]+"
   pull_request:
+    branches:
+      - master
+      - "v[0-9]+.[0-9]+"
     paths:
       - "**.c"
       - "**.cc"
       - "**.h"
+      - "**.h.in"
       - "**.py"
+      - "**/meson.build"
       - .github/workflows/codeql.yaml
   schedule:
     - cron: 0 0 * * SUN
@@ -20,7 +25,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  packages: read
   security-events: write
 
 jobs:
@@ -67,7 +71,7 @@ jobs:
       # https://bugzilla.redhat.com/show_bug.cgi?id=2117773
       - name: Setup
         run: |
-          meson builddir --fatal-meson-warnings --werror \
+          meson setup builddir --fatal-meson-warnings --werror \
             -Dwrap_mode=nofallback -Dforce_fallback_for=cjson -Dbindings=none \
             -Ddocs=disabled
 


### PR DESCRIPTION
Should also run when a meson.build file changes or a .h.in file changes.

Signed-off-by: Tristan Partin <tpartin@micron.com>
