### PR TITLE
Use meson setup

### DIFF
--- a/.github/workflows/abicheck.yaml
+++ b/.github/workflows/abicheck.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Setup current
         run: |
-          meson builddir-current --fatal-meson-warnings --werror \
+          meson setup builddir-current --fatal-meson-warnings --werror \
             -Doptimization=g -Dc_args="-g3" -Dcli=false -Dtools=disabled \
             -Dsamples=false -Ddocs=disabled -Dbindings=none -Dtests=false \
             -Dtools=disabled -Dpmem=enabled
@@ -57,7 +57,7 @@ jobs:
 
       - name: Setup previous
         run: |
-          meson builddir-previous --fatal-meson-warnings -Doptimization=g \
+          meson setup builddir-previous --fatal-meson-warnings -Doptimization=g \
             -Dwerror=true -Dc_args="-g3" -Dcli=false -Dtools=disabled \
             -Dsamples=false -Ddocs=disabled -Dbindings=none -Dtests=false \
             -Dtools=disabled -Dpmem=enabled

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -234,7 +234,7 @@ jobs:
       - name: Setup
         if: ${{ steps.to-skip.outputs.skip == 'false' }}
         run: |
-          meson builddir --fatal-meson-warnings $WERROR $CROSS_ARGS \
+          meson setup builddir --fatal-meson-warnings $WERROR $CROSS_ARGS \
             --buildtype=${{ matrix.buildtype }} -Dtools=enabled \
             -Ddocs=disabled -Dbindings=all
 
@@ -280,7 +280,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir --werror --buildtype=${{ matrix.buildtype }} \
+          meson setup builddir --werror --buildtype=${{ matrix.buildtype }} \
             -Db_sanitize=address,undefined -Dtools=enabled -Ddocs=disabled \
             -Dbindings=none
 

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir --fatal-meson-warnings --werror \
+          meson setup builddir --fatal-meson-warnings --werror \
             --buildtype=${{ matrix.buildtype }} -Dtools=enabled -Dpmem=enabled \
             -Ddocs=disabled -Dbindings=none
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir --fatal-meson-warnings -Dwerror=true -Ddocs=enabled \
+          meson setup builddir --fatal-meson-warnings -Dwerror=true -Ddocs=enabled \
             -Dtests=false -Dtools=disabled -Dbindings=none -Dcli=false \
             -Dsamples=false -Ddb_bench=false
 

--- a/.github/workflows/nightly_testing.yaml
+++ b/.github/workflows/nightly_testing.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson builddir --fatal-meson-warnings --werror \
+          meson setup builddir --fatal-meson-warnings --werror \
             --buildtype=${{ matrix.buildtype }} -Dtools=enabled \
             -Ddocs=disabled -Dbindings=all
 


### PR DESCRIPTION
Leaving out the setup command is deprecated in Meson master.

Signed-off-by: Tristan Partin <tpartin@micron.com>
