### PR TITLE
Fix an OOM failure when running the Socialite benchmark (NFSE-5310)

### DIFF
--- a/lib/cn/cn_tree_cursor.c
+++ b/lib/cn/cn_tree_cursor.c
@@ -389,7 +389,7 @@ cn_lcur_advance(struct cn_level_cursor *lcur)
     if (lcur->cnlc_islast)
         return;
 
-    route_node_keycpy(rtn_ekey, &lcur->cnlc_next_ekey,
+    route_node_keycpy(rtn_ekey, lcur->cnlc_next_ekey,
                       sizeof(lcur->cnlc_next_ekey),
                       &lcur->cnlc_next_eklen);
 }

--- a/lib/cn/kblock_reader.c
+++ b/lib/cn/kblock_reader.c
@@ -193,23 +193,6 @@ kbr_read_metrics(struct kvs_mblk_desc *kblkdesc, struct kblk_metrics *metrics)
     return 0;
 }
 
-merr_t
-kbr_read_hlog(struct kvs_mblk_desc *kblk, uint8_t **hlog)
-{
-    struct kblock_hdr_omf *hdr = NULL;
-
-    hdr = mpool_mcache_getbase(kblk->map, kblk->map_idx);
-    if (!hdr)
-        return merr(EINVAL);
-
-    if (!kblock_hdr_valid(hdr))
-        return merr(EPROTO);
-
-    *hlog = (uint8_t *)hdr + (omf_kbh_hlog_doff_pg(hdr) * PAGE_SIZE);
-
-    return 0;
-}
-
 static merr_t
 kbr_madvise_region(struct kvs_mblk_desc *kblkdesc, u32 pg, u32 pg_cnt, int advice)
 {

--- a/lib/cn/kblock_reader.h
+++ b/lib/cn/kblock_reader.h
@@ -87,9 +87,6 @@ kbr_read_blm_pages(
 merr_t
 kbr_read_metrics(struct kvs_mblk_desc *kblock_desc, struct kblk_metrics *metrics);
 
-merr_t
-kbr_read_hlog(struct kvs_mblk_desc *kblk, uint8_t **hlog);
-
 /**
  * kbr_madvise_wbt_leaf_nodes() - advise about caching of wbtree leaf nodes
  */

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -349,6 +349,8 @@ kvset_kblk_init(
     key_disc_init(p->kb_koff_max, p->kb_klen_max, &p->kb_kdisc_max);
     key_disc_init(p->kb_koff_min, p->kb_klen_min, &p->kb_kdisc_min);
 
+    p->kb_hlog = (uint8_t *)hdr + (omf_kbh_hlog_doff_pg(hdr) * PAGE_SIZE);
+
     /* Preload the wbtree nodes.
      */
     if (rp->cn_mcache_wbt > 0) {
@@ -678,7 +680,7 @@ kvset_open2(
              * to the kblock header in order to catch those
              * who might otherwise try to access it.
              */
-#ifndef NDEBUG
+#if defined(HSE_BUILD_DEBUG) && !defined(NDEBUG)
             mprotect(kb->kb_kblk_desc.map_base, PAGE_SIZE, PROT_NONE);
 #endif
         }

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -57,8 +57,9 @@ struct kvset_kblk {
     u8              kb_ksmall[64]; /* small key cache */
     struct key_disc kb_kdisc_max;  /* kdisc of largest key in kblk */
     struct key_disc kb_kdisc_min;  /* kdisc of smallest key */
-    const void *    kb_koff_max;   /* ptr to largest key in kblk */
-    const void *    kb_koff_min;   /* ptr to smallest key in kblk */
+    const uint8_t  *kb_hlog;       /* ptr to hlog region in kblk */
+    const void     *kb_koff_max;   /* ptr to largest key in kblk */
+    const void     *kb_koff_min;   /* ptr to smallest key in kblk */
     u16             kb_klen_max;   /* length of largest key */
     u16             kb_klen_min;   /* length of smallest key */
 

--- a/lib/cn/kvset_split.c
+++ b/lib/cn/kvset_split.c
@@ -303,7 +303,6 @@ kblocks_split(
     struct kvset_mblocks *blks_right = result->ks[RIGHT].blks;
     bool overlap = false;
     uint32_t split_idx;
-    uint8_t *hlog;
     merr_t err;
 
     split_idx = get_kblk_split_index(ks, split_kobj, &overlap);
@@ -317,8 +316,7 @@ kblocks_split(
         if (err)
             return err;
 
-        kbr_read_hlog(&ks->ks_kblks[i].kb_kblk_desc, &hlog);
-        hlog_union(hlog_left, hlog);
+        hlog_union(hlog_left, ks->ks_kblks[i].kb_hlog);
         blks_left->bl_vused += ks->ks_kblks[i].kb_metrics.tot_vused_bytes;
     }
 
@@ -373,9 +371,8 @@ kblocks_split(
 
         /* TODO: Would it be accurate to use the left and right kblock's hlog here?
          */
-        kbr_read_hlog(&kblk->kb_kblk_desc, &hlog);
-        hlog_union(hlog_left, hlog);
-        hlog_union(hlog_right, hlog);
+        hlog_union(hlog_left, kblk->kb_hlog);
+        hlog_union(hlog_right, kblk->kb_hlog);
 
         /* Add the source kblock to the purge list to be destroyed later */
         err = blk_list_append(result->blks_purge, kblk->kb_kblk.bk_blkid);
@@ -392,8 +389,7 @@ kblocks_split(
         if (err)
             return err;
 
-        kbr_read_hlog(&ks->ks_kblks[i].kb_kblk_desc, &hlog);
-        hlog_union(hlog_right, hlog);
+        hlog_union(hlog_right, ks->ks_kblks[i].kb_hlog);
         blks_right->bl_vused += ks->ks_kblks[i].kb_metrics.tot_vused_bytes;
     }
 

--- a/lib/util/include/hse_util/hlog.h
+++ b/lib/util/include/hse_util/hlog.h
@@ -41,7 +41,7 @@ hlog_data(struct hlog *hlog);
 
 /* MTF_MOCK */
 void
-hlog_union(struct hlog *hlog, u8 *new_regv);
+hlog_union(struct hlog *hlog, const uint8_t *new_regv);
 
 /* MTF_MOCK */
 uint

--- a/lib/util/src/hlog.c
+++ b/lib/util/src/hlog.c
@@ -118,7 +118,7 @@ hlog_precision(struct hlog *hlog)
 }
 
 void
-hlog_union(struct hlog *hlog, u8 *new)
+hlog_union(struct hlog *hlog, const uint8_t *new)
 {
     uint i;
 


### PR DESCRIPTION
When the KVS cursor cache is full each newly added cache entry
displaces the oldest cache entry. This displaced cache entry
is queued to be asynchronously released by a pruner thread.
When the pruner thread is unable to keep up with its backlog,
the number of active + displaced cache entries grows unbounded
resulting in OOM failures.

This patch ensures that the total number of entries (active + displaced)
in the cursor cache never exceeds the maximum number of entries that
can be cached. When the total number of entries reaches the maximum,
the cursor destroy threads starts freeing the displaced cache entries
in situ until the pruner thread catches up with its pending work.

This patch also caches a pointer to the hlog region of a kblock in
struct kvset_kblk to avoid accessing the kblock header post kvset open.

Signed-off-by: Nabeel M Mohamed <50154757+nabeelmmd@users.noreply.github.com>