### PR TITLE
Place fixture headers under hse/test/fixtures

### DIFF
--- a/tests/fixtures/include/hse/test/fixtures/kvdb.h
+++ b/tests/fixtures/include/hse/test/fixtures/kvdb.h
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
  */
 
-#ifndef FIXTURES_KVDB_H
-#define FIXTURES_KVDB_H
+#ifndef HSE_TEST_FIXTURES_KVDB_H
+#define HSE_TEST_FIXTURES_KVDB_H
 
 #include <stddef.h>
 

--- a/tests/fixtures/include/hse/test/fixtures/kvs.h
+++ b/tests/fixtures/include/hse/test/fixtures/kvs.h
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
  */
 
-#ifndef FIXTURES_KVS_H
-#define FIXTURES_KVS_H
+#ifndef HSE_TEST_FIXTURES_KVS_H
+#define HSE_TEST_FIXTURES_KVS_H
 
 #include <stddef.h>
 

--- a/tests/fixtures/lib/kvdb.c
+++ b/tests/fixtures/lib/kvdb.c
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
  */
 
 #include <hse/hse.h>
-#include <fixtures/kvdb.h>
+#include <hse/test/fixtures/kvdb.h>
 
 hse_err_t
 fxt_kvdb_setup(

--- a/tests/fixtures/lib/kvs.c
+++ b/tests/fixtures/lib/kvs.c
@@ -1,12 +1,12 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
  */
 
 #include <errno.h>
 
 #include <hse/hse.h>
-#include <fixtures/kvs.h>
+#include <hse/test/fixtures/kvs.h>
 
 hse_err_t
 fxt_kvs_setup(

--- a/tests/functional/api/cursor_api_test.c
+++ b/tests/functional/api/cursor_api_test.c
@@ -6,8 +6,8 @@
 #include <hse/hse.h>
 
 #include <mtf/framework.h>
-#include <fixtures/kvdb.h>
-#include <fixtures/kvs.h>
+#include <hse/test/fixtures/kvdb.h>
+#include <hse/test/fixtures/kvs.h>
 
 #include <hse_util/base.h>
 

--- a/tests/functional/api/kvdb_api_test.c
+++ b/tests/functional/api/kvdb_api_test.c
@@ -8,9 +8,9 @@
 
 #include <hse/hse.h>
 #include <hse/experimental.h>
+#include <hse/test/fixtures/kvdb.h>
 
 #include <mtf/framework.h>
-#include <fixtures/kvdb.h>
 
 #include <hse_util/base.h>
 

--- a/tests/functional/api/kvs_api_test.c
+++ b/tests/functional/api/kvs_api_test.c
@@ -7,10 +7,10 @@
 
 #include <hse/hse.h>
 #include <hse/experimental.h>
+#include <hse/test/fixtures/kvdb.h>
+#include <hse/test/fixtures/kvs.h>
 
 #include <mtf/framework.h>
-#include <fixtures/kvdb.h>
-#include <fixtures/kvs.h>
 
 #include <hse_util/base.h>
 

--- a/tests/functional/api/transaction_api_test.c
+++ b/tests/functional/api/transaction_api_test.c
@@ -6,9 +6,9 @@
 #include <errno.h>
 
 #include <hse/hse.h>
+#include <hse/test/fixtures/kvdb.h>
 
 #include <mtf/framework.h>
-#include <fixtures/kvdb.h>
 
 struct hse_kvdb *kvdb_handle = NULL;
 struct hse_kvs  *kvs_handle = NULL;


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
