### PR TITLE
Remove newlines from log statements that were fprintf()s

### DIFF
--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -116,20 +116,20 @@ hse_init(const char *const config, const size_t paramc, const char *const *const
 
     err = argv_deserialize_to_hse_gparams(paramc, paramv, &hse_gparams);
     if (err) {
-        log_errx("Failed to deserialize paramv for HSE gparams\n", err);
+        log_errx("Failed to deserialize paramv for HSE gparams", err);
         goto out;
     }
 
     err = config_from_hse_conf(config, &conf);
     if (err) {
-        log_errx("Failed to read HSE config file (%s)\n", err, config);
+        log_errx("Failed to read HSE config file (%s)", err, config);
         goto out;
     }
 
     err = config_deserialize_to_hse_gparams(conf, &hse_gparams);
     config_destroy(conf);
     if (err) {
-        log_errx("Failed to deserialize config file (%s) for HSE gparams\n", err, config);
+        log_errx("Failed to deserialize config file (%s) for HSE gparams", err, config);
         goto out;
     }
 

--- a/lib/logging/lib/logging.c
+++ b/lib/logging/lib/logging.c
@@ -142,8 +142,8 @@ log_impl(
 
         merr_strerror(err, buf, sizeof(buf));
 
-        rc = snprintf(log_buffer_tls, sizeof(log_buffer_tls), "[HSE] %s:%d %s: %s: %s\n",
-            file, lineno, func, fmt, buf);
+        rc = snprintf(log_buffer_tls, sizeof(log_buffer_tls), "[HSE] %s:%d %s: %s: %s (%d)\n",
+            file, lineno, func, fmt, buf, merr_errno(err));
     } else {
         rc = snprintf(log_buffer_tls, sizeof(log_buffer_tls), "[HSE] %s:%d %s: %s\n",
             file, lineno, func, fmt);


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
