### PR TITLE
Move vtypes into their own OMF file, make enum values all caps

### DIFF
--- a/lib/cn/cn_tree_cursor.c
+++ b/lib/cn/cn_tree_cursor.c
@@ -731,7 +731,7 @@ cn_tree_cursor_read(struct cn_cursor *cur, struct kvs_cursor_element *elem, bool
             }
         }
 
-        if (vtype == vtype_ptomb) {
+        if (vtype == VTYPE_PTOMB) {
             found = false;
 
             /* In case of duplicate ptombs, we need just the first (newest) ptomb in the cursor's

--- a/lib/cn/kcompact.c
+++ b/lib/cn/kcompact.c
@@ -162,18 +162,18 @@ kcompact(struct cn_compaction_work *w, struct kvset_builder *bldr)
                 if (pt_set && seq < pt_seq)
                     continue; /* skip value */
 
-                if (vtype == vtype_ptomb) {
+                if (vtype == VTYPE_PTOMB) {
                     pt_set = true;
                     pt_kobj = curr->kobj;
                     assert(key_obj_len(&curr->kobj) == w->cw_pfx_len);
                     pt_seq = seq;
                 }
 
-                if (w->cw_drop_tombs && (vtype == vtype_tomb || vtype == vtype_ptomb))
+                if (w->cw_drop_tombs && (vtype == VTYPE_TOMB || vtype == VTYPE_PTOMB))
                     continue; /* skip value */
             }
 
-            if (vtype == vtype_ptomb)
+            if (vtype == VTYPE_PTOMB)
                 should_emit = !emitted_seq_pt || seq < emitted_seq_pt;
             else
                 should_emit = !emitted_seq || seq < emitted_seq;
@@ -186,13 +186,13 @@ kcompact(struct cn_compaction_work *w, struct kvset_builder *bldr)
              */
             if (should_emit) {
                 switch (vtype) {
-                case vtype_val:
-                case vtype_cval:
+                case VTYPE_UCVAL:
+                case VTYPE_CVAL:
                     err = kvset_builder_add_vref(
                         bldr, seq, vbidx + w->cw_vbmap.vbm_map[idx], vboff, vlen, complen);
                     break;
-                case vtype_zval:
-                case vtype_ival:
+                case VTYPE_ZVAL:
+                case VTYPE_IVAL:
                     err = kvset_builder_add_val(bldr, &curr->kobj, vdata, vlen, seq, 0);
                     break;
                 default:
@@ -203,7 +203,7 @@ kcompact(struct cn_compaction_work *w, struct kvset_builder *bldr)
                     goto done;
                 emitted_val = true;
 
-                if (vtype == vtype_ptomb)
+                if (vtype == VTYPE_PTOMB)
                     emitted_seq_pt = seq;
                 else
                     emitted_seq = seq;

--- a/lib/cn/kvcompact.c
+++ b/lib/cn/kvcompact.c
@@ -200,7 +200,7 @@ cn_kvcompact(struct cn_compaction_work *w)
                                       &vboff, &vdata, &vlen, &complen))
                 break;
 
-            omlen = (vtype == vtype_val) ? vlen : ((vtype == vtype_cval) ? complen : 0);
+            omlen = (vtype == VTYPE_UCVAL) ? vlen : ((vtype == VTYPE_CVAL) ? complen : 0);
 
             direct = omlen > direct_read_len;
             if (direct) {

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -1474,17 +1474,17 @@ kvset_lookup_val(struct kvset *ks, struct kvs_vtuple_ref *vref, struct kvs_buf *
     uint                omlen, copylen;
     bool direct;
 
-    assert(vref->vr_type == vtype_ival
-        || vref->vr_type == vtype_zval
-        || vref->vr_type == vtype_val
-        || vref->vr_type == vtype_cval);
+    assert(vref->vr_type == VTYPE_IVAL
+        || vref->vr_type == VTYPE_ZVAL
+        || vref->vr_type == VTYPE_UCVAL
+        || vref->vr_type == VTYPE_CVAL);
 
-    if (HSE_UNLIKELY(vref->vr_type == vtype_zval)) {
+    if (HSE_UNLIKELY(vref->vr_type == VTYPE_ZVAL)) {
         vbuf->b_len = 0;
         return 0;
     }
 
-    if (vref->vr_type == vtype_ival)
+    if (vref->vr_type == VTYPE_IVAL)
         return kvset_get_immediate_value(vref, vbuf);
 
     vbd = lvx2vbd(ks, vref->vb.vr_index);
@@ -1642,9 +1642,9 @@ get_more:
             wbt_read_kmd_vref(kmd, ks->ks_use_vgmap ? ks->ks_vgmap : NULL, &off, &vseq, &vref);
             if (seq >= vseq) {
                 /* can't be  a ptomb, b/c they're in their own WBT */
-                assert(vref.vr_type != vtype_ptomb);
+                assert(vref.vr_type != VTYPE_PTOMB);
                 vref.vr_seq = vseq;
-                if (vref.vr_type == vtype_tomb)
+                if (vref.vr_type == VTYPE_TOMB)
                     *res = FOUND_TMB;
                 else
                     *res = FOUND_VAL;
@@ -3329,25 +3329,25 @@ kvset_iter_next_vref(
 
     kmd_type_seq(vc->kmd, &vc->off, vtype, seq);
     switch (*vtype) {
-        case vtype_val:
+        case VTYPE_UCVAL:
             kmd_val(vc->kmd, &vc->off, vbidx, vboff, vlen);
             break;
-        case vtype_cval:
+        case VTYPE_CVAL:
             kmd_cval(vc->kmd, &vc->off, vbidx, vboff, vlen, complen);
             break;
-        case vtype_ival:
+        case VTYPE_IVAL:
             kmd_ival(vc->kmd, &vc->off, vdata, vlen);
             break;
-        case vtype_zval:
-        case vtype_tomb:
-        case vtype_ptomb:
+        case VTYPE_ZVAL:
+        case VTYPE_TOMB:
+        case VTYPE_PTOMB:
             break;
         default:
             assert(0);
             break;
     }
 
-    if ((*vtype == vtype_val || *vtype == vtype_cval) && ks->ks_use_vgmap) {
+    if ((*vtype == VTYPE_UCVAL || *vtype == VTYPE_CVAL) && ks->ks_use_vgmap) {
         merr_t err;
 
         /* This ugly cast is because we use a mix of 32 and 16-bit bytes to represent
@@ -3550,26 +3550,26 @@ kvset_iter_val_get(
     uint *                  complen)
 {
     switch (vtype) {
-        case vtype_val:
+        case VTYPE_UCVAL:
             return kvset_iter_get_valptr(handle, vbidx, vboff, *vlen, vdata);
-        case vtype_cval:
+        case VTYPE_CVAL:
             return kvset_iter_get_valptr(handle, vbidx, vboff, *complen, vdata);
-        case vtype_zval:
+        case VTYPE_ZVAL:
             *vdata = 0;
             *vlen = 0;
             *complen = 0;
             return 0;
-        case vtype_tomb:
+        case VTYPE_TOMB:
             *vdata = HSE_CORE_TOMB_REG;
             *vlen = 0;
             *complen = 0;
             return 0;
-        case vtype_ptomb:
+        case VTYPE_PTOMB:
             *vdata = HSE_CORE_TOMB_PFX;
             *vlen = 0;
             *complen = 0;
             return 0;
-        case vtype_ival:
+        case VTYPE_IVAL:
             assert(*vdata);
             assert(*vlen);
             *complen = 0;

--- a/lib/cn/kvset_builder.c
+++ b/lib/cn/kvset_builder.c
@@ -256,10 +256,10 @@ kvset_builder_add_val(
 }
 
 /**
- * kvset_builder_add_vref() - add a vtype_val or vtype_cval entry its a kvset
+ * kvset_builder_add_vref() - add a VTYPE_UCVAL or VTYPE_CVAL entry its a kvset
  *
- * If @complen > 0, a vtype_cval entry will written to media.
- * If @complen == 0, a vtype_val entry will written to media.
+ * If @complen > 0, a VTYPE_CVAL entry will written to media.
+ * If @complen == 0, a VTYPE_UCVAL entry will written to media.
  */
 merr_t
 kvset_builder_add_vref(
@@ -294,17 +294,17 @@ kvset_builder_add_vref(
 merr_t
 kvset_builder_add_nonval(struct kvset_builder *self, u64 seq, enum kmd_vtype vtype)
 {
-    struct kmd_info *ki = vtype == vtype_ptomb ? &self->hblk_kmd : &self->kblk_kmd;
+    struct kmd_info *ki = vtype == VTYPE_PTOMB ? &self->hblk_kmd : &self->kblk_kmd;
 
     if (reserve_kmd(ki))
         return merr(ev(ENOMEM));
 
-    assert(vtype != vtype_zval);
-    if (vtype == vtype_tomb) {
+    assert(vtype != VTYPE_ZVAL);
+    if (vtype == VTYPE_TOMB) {
         kmd_add_tomb(self->kblk_kmd.kmd, &self->kblk_kmd.kmd_used, seq);
         self->key_stats.ntombs++;
         self->key_stats.nvals++;
-    } else if (vtype == vtype_ptomb) {
+    } else if (vtype == VTYPE_PTOMB) {
         kmd_add_ptomb(self->hblk_kmd.kmd, &self->hblk_kmd.kmd_used, seq);
         self->key_stats.nptombs++;
     } else {

--- a/lib/cn/kvset_split.c
+++ b/lib/cn/kvset_split.c
@@ -163,26 +163,26 @@ kblock_copy_range(
             wbt_read_kmd_vref(kmd, NULL, &off, &vseq, &vref);
 
             switch (vref.vr_type) {
-            case vtype_val:
-            case vtype_cval:
+            case VTYPE_UCVAL:
+            case VTYPE_CVAL:
                 omlen = (vref.vb.vr_complen ? vref.vb.vr_complen : vref.vb.vr_len);
                 stats.tot_vlen += omlen;
                 stats.tot_vused += omlen;
                 *vused += omlen;
                 break;
 
-            case vtype_ival:
+            case VTYPE_IVAL:
                 stats.tot_vlen += vref.vi.vr_len;
                 break;
 
-            case vtype_tomb:
+            case VTYPE_TOMB:
                 ++stats.ntombs;
                 break;
 
-            case vtype_zval:
+            case VTYPE_ZVAL:
                 break;
 
-            case vtype_ptomb:
+            case VTYPE_PTOMB:
                 abort();
             }
         }

--- a/lib/cn/omf.h
+++ b/lib/cn/omf.h
@@ -21,7 +21,7 @@
  *
  * Supported versions:
  *     v6: Added support for compressed values. Uses a new value type
- *         (vtype_cval) which affects KMD format. Unfortunately,
+ *         (VTYPE_CVAL) which affects KMD format. Unfortunately,
  *         there is no version field for KMD, so we bump the WBTree
  *         version even though the actual WBTree header, leaf and
  *         internal nodes are no different from OMF v5.

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -319,7 +319,7 @@ cn_subspill(
                                       &vboff, &vdata, &vlen, &complen))
                 break;
 
-            omlen = (vtype == vtype_val) ? vlen : ((vtype == vtype_cval) ? complen : 0);
+            omlen = (vtype == VTYPE_UCVAL) ? vlen : ((vtype == VTYPE_CVAL) ? complen : 0);
 
             direct = omlen > direct_read_len;
             if (direct) {

--- a/lib/cn/wbt_reader.c
+++ b/lib/cn/wbt_reader.c
@@ -53,7 +53,7 @@ wbt_read_kmd_vref(
     kmd_type_seq(kmd, off, &vtype, seq);
 
     switch (vtype) {
-        case vtype_val:
+        case VTYPE_UCVAL:
             kmd_val(kmd, off, &vbidx, &vboff, &vlen);
             /* assert no truncation */
             assert(vbidx <= U16_MAX);
@@ -64,7 +64,7 @@ wbt_read_kmd_vref(
             vref->vb.vr_len = vlen;
             vref->vb.vr_complen = 0;
             break;
-        case vtype_cval:
+        case VTYPE_CVAL:
             kmd_cval(kmd, off, &vbidx, &vboff, &vlen, &complen);
             /* assert no truncation */
             assert(vbidx <= U16_MAX);
@@ -76,20 +76,20 @@ wbt_read_kmd_vref(
             vref->vb.vr_len = vlen;
             vref->vb.vr_complen = complen;
             break;
-        case vtype_ival:
+        case VTYPE_IVAL:
             kmd_ival(kmd, off, &vdata, &vlen);
             /* assert no truncation */
             assert(vlen <= U32_MAX);
             vref->vi.vr_data = vdata;
             vref->vi.vr_len = vlen;
             break;
-        case vtype_zval:
-        case vtype_tomb:
-        case vtype_ptomb:
+        case VTYPE_ZVAL:
+        case VTYPE_TOMB:
+        case VTYPE_PTOMB:
             break;
     }
 
-    if ((vtype == vtype_val || vtype == vtype_cval) && vgmap) {
+    if ((vtype == VTYPE_UCVAL || vtype == VTYPE_CVAL) && vgmap) {
         merr_t err;
 
         err = vgmap_vbidx_src2out(vgmap, vref->vb.vr_index, &vref->vb.vr_index);
@@ -830,9 +830,9 @@ wbtr_read_vref(
                 assert(off <= wbd->wbd_kmd_pgc * PAGE_SIZE);
                 if (seq >= vseq) {
                     vref->vr_seq = vseq;
-                    if (vref->vr_type == vtype_tomb)
+                    if (vref->vr_type == VTYPE_TOMB)
                         *lookup_res = FOUND_TMB;
-                    else if (vref->vr_type == vtype_ptomb)
+                    else if (vref->vr_type == VTYPE_PTOMB)
                         *lookup_res = FOUND_PTMB;
                     else
                         *lookup_res = FOUND_VAL;

--- a/lib/include/hse_ikvdb/omf_kmd_vtype.h
+++ b/lib/include/hse_ikvdb/omf_kmd_vtype.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
+ */
+
+#ifndef HSE_KVDB_OMF_KMD_VTYPE_H
+#define HSE_KVDB_OMF_KMD_VTYPE_H
+
+/* Each value has a type indicating how it is stored on media.
+ * Do not change this enum without considering the impact on backward
+ * compatibility.
+ */
+enum kmd_vtype {
+    VTYPE_UCVAL = 0u,  // uncompressed value stored in a vblock
+    VTYPE_ZVAL = 1,    // zero-length value (i.e., a key with no value)
+    VTYPE_TOMB = 2,    // tombstone
+    VTYPE_PTOMB = 3,   // prefix tombstone
+    VTYPE_IVAL = 4,    // immediate value, uncompressed, stored in a kblock
+    VTYPE_CVAL = 5,    // an LZ4 compressed value stored in a vblock
+};
+
+#define NUM_KMD_VTYPES 6
+
+#endif

--- a/tests/mocks/repository/lib/mock_kvset.c
+++ b/tests/mocks/repository/lib/mock_kvset.c
@@ -576,18 +576,18 @@ _kvset_iter_next_vref(
 
     if (entry->val_len == 0 && entry->val == -1) {
         *vdata = HSE_CORE_TOMB_REG;
-        *vtype = vtype_tomb;
+        *vtype = VTYPE_TOMB;
     } else {
         if (entry->val_len == 0) {
-            *vtype = vtype_zval;
+            *vtype = VTYPE_ZVAL;
             *vdata = 0;
         } else if (entry->val_len <= CN_SMALL_VALUE_THRESHOLD) {
-            *vtype = vtype_ival;
+            *vtype = VTYPE_IVAL;
             valbuf[0] = entry->val;
             *vdata = valbuf;
             *vlen = entry->val_len;
         } else {
-            *vtype = vtype_val;
+            *vtype = VTYPE_UCVAL;
             *vlen = entry->val_len;
             *vboff = vc->off;
         }

--- a/tests/unit/cn/cn_tree_cursor_test.c
+++ b/tests/unit/cn/cn_tree_cursor_test.c
@@ -106,7 +106,7 @@ _bin_heap_peek(struct bin_heap *bh, void **item)
     curr->item.vctx.next = 0;
     curr->item.vctx.nvals = 1;
     curr->item.src = &dummy_kviter.kvi_es;
-    curr->item.vctx.is_ptomb = (curr->vtype == vtype_ptomb);
+    curr->item.vctx.is_ptomb = (curr->vtype == VTYPE_PTOMB);
 
     *item = &curr->item;
     return true;
@@ -151,21 +151,21 @@ _kvset_iter_val_get(
     struct kv *kv = (void *)vc->kmd;
 
     switch (vtype) {
-    case vtype_ival:
-    case vtype_val:
-    case vtype_cval:
+    case VTYPE_IVAL:
+    case VTYPE_UCVAL:
+    case VTYPE_CVAL:
         *vdata = kv->kdata;
         *vlen = kv->klen;
         break;
-    case vtype_tomb:
+    case VTYPE_TOMB:
         *vlen = 0;
         *vdata = HSE_CORE_TOMB_REG;
         break;
-    case vtype_ptomb:
+    case VTYPE_PTOMB:
         *vlen = 0;
         *vdata = HSE_CORE_TOMB_PFX;
         break;
-    case vtype_zval:
+    case VTYPE_ZVAL:
         *vdata = 0;
         *vlen = 0;
         break;
@@ -312,8 +312,8 @@ MTF_DEFINE_UTEST_PREPOST(cn_tree_cursor_test, basic, pre_test, post_test)
     ASSERT_NE(NULL, rnode);
 
     kv_start();
-    kv_add(&kv[0], "key01", 1, vtype_val);
-    kv_add(&kv[1], "key02", 1, vtype_val);
+    kv_add(&kv[0], "key01", 1, VTYPE_UCVAL);
+    kv_add(&kv[1], "key02", 1, VTYPE_UCVAL);
     kv_end();
 
     err = cn_tree_cursor_create(&cur);
@@ -375,10 +375,10 @@ MTF_DEFINE_UTEST_PREPOST(cn_tree_cursor_test, dups, pre_test, post_test)
     struct kv kv[4];
 
     kv_start();
-    kv_add(&kv[0], "key01", 2, vtype_val);
-    kv_add(&kv[1], "key01", 1, vtype_val);
-    kv_add(&kv[2], "key02", 2, vtype_tomb);
-    kv_add(&kv[3], "key02", 1, vtype_val);
+    kv_add(&kv[0], "key01", 2, VTYPE_UCVAL);
+    kv_add(&kv[1], "key01", 1, VTYPE_UCVAL);
+    kv_add(&kv[2], "key02", 2, VTYPE_TOMB);
+    kv_add(&kv[3], "key02", 1, VTYPE_UCVAL);
     kv_end();
 
     tree.ct_route_map = route_map_create(CN_FANOUT_MAX);
@@ -450,16 +450,16 @@ MTF_DEFINE_UTEST_PREPOST(cn_tree_cursor_test, with_ptomb, pre_test, post_test)
      */
 
     kv_start();
-    kv_add(&kv[0], "ab",   4,  vtype_val);    /* Seen */
-    kv_add(&kv[1], "ab",   4,  vtype_ptomb);  /* Hidden: Not passed up the stack, only affects future keys */
-    kv_add(&kv[2], "ab",   1,  vtype_ptomb);  /* Hidden: dup pt, first pt takes precendence */
-    kv_add(&kv[3], "ab01", 3,  vtype_val);    /* Hidden */
-    kv_add(&kv[4], "ab02", 5,  vtype_val);    /* Seen:   seqno larger than ptomb seqno */
-    kv_add(&kv[5], "ab03", 11, vtype_val);    /* Hidden: seqno larger than cursor seqno */
-    kv_add(&kv[6], "ab03", 3,  vtype_val);    /* Hidden */
-    kv_add(&kv[7], "ab04", 4,  vtype_val);    /* Seen:   pt should NOT hide key */
-    kv_add(&kv[8], "ac01", 4,  vtype_val);    /* Seen:   Does not match ptomb's pfx */
-    kv_add(&kv[9], "bb01", 4,  vtype_val);    /* Hidden: Does not match cursor pfx */
+    kv_add(&kv[0], "ab",   4,  VTYPE_UCVAL);    /* Seen */
+    kv_add(&kv[1], "ab",   4,  VTYPE_PTOMB);  /* Hidden: Not passed up the stack, only affects future keys */
+    kv_add(&kv[2], "ab",   1,  VTYPE_PTOMB);  /* Hidden: dup pt, first pt takes precendence */
+    kv_add(&kv[3], "ab01", 3,  VTYPE_UCVAL);    /* Hidden */
+    kv_add(&kv[4], "ab02", 5,  VTYPE_UCVAL);    /* Seen:   seqno larger than ptomb seqno */
+    kv_add(&kv[5], "ab03", 11, VTYPE_UCVAL);    /* Hidden: seqno larger than cursor seqno */
+    kv_add(&kv[6], "ab03", 3,  VTYPE_UCVAL);    /* Hidden */
+    kv_add(&kv[7], "ab04", 4,  VTYPE_UCVAL);    /* Seen:   pt should NOT hide key */
+    kv_add(&kv[8], "ac01", 4,  VTYPE_UCVAL);    /* Seen:   Does not match ptomb's pfx */
+    kv_add(&kv[9], "bb01", 4,  VTYPE_UCVAL);    /* Hidden: Does not match cursor pfx */
     kv_end();
 
     tree.ct_route_map = route_map_create(CN_FANOUT_MAX);

--- a/tests/unit/cn/kcompact_test.c
+++ b/tests/unit/cn/kcompact_test.c
@@ -132,9 +132,9 @@ verify(struct kvset_builder *bld)
     VERIFY_TRUE_RET(nvals == 1, __LINE__);
 
     if (st.vwant == -1) {
-        VERIFY_TRUE_RET(vtype == vtype_tomb, __LINE__);
+        VERIFY_TRUE_RET(vtype == VTYPE_TOMB, __LINE__);
     } else {
-        VERIFY_TRUE_RET((vtype == vtype_val) || (vtype == vtype_ival), __LINE__);
+        VERIFY_TRUE_RET((vtype == VTYPE_UCVAL) || (vtype == VTYPE_IVAL), __LINE__);
         if (vlen == 4)
             VERIFY_EQ_RET(st.vwant, st.have.value, __LINE__);
         if (!mixed)
@@ -173,7 +173,7 @@ _kvset_builder_add_vref(struct kvset_builder *self, u64 seq,
     VERIFY_EQ_RET(st.have.nvals, 0, __LINE__);
 
     st.have.nvals++;
-    st.have.vtype = vtype_val;
+    st.have.vtype = VTYPE_UCVAL;
     st.have.vlen = vlen;
     if (vlen == 4)
         st.have.value = *(int *)mock_vref_to_vdata(itv[vbidx], vboff);
@@ -207,7 +207,7 @@ _kvset_builder_add_val(
     VERIFY_EQ_RET(st.have.nvals, 0, __LINE__);
 
     st.have.nvals++;
-    st.have.vtype = vtype_val;
+    st.have.vtype = VTYPE_UCVAL;
     st.have.vlen = vlen;
     if (vlen == 4)
         st.have.value = *(int *)vdata;

--- a/tests/unit/cn/kvset_builder_test.c
+++ b/tests/unit/cn/kvset_builder_test.c
@@ -156,12 +156,12 @@ MTF_DEFINE_UTEST_PREPOST(test, t_kvset_builder_add_entry1, pre, post)
     /*
      * Two flavors for add_nonval
      */
-    err = kvset_builder_add_nonval(bld, seq2, vtype_tomb);
+    err = kvset_builder_add_nonval(bld, seq2, VTYPE_TOMB);
     ASSERT_EQ(err, 0);
-    err = kvset_builder_add_nonval(bld, seq2, vtype_ptomb);
+    err = kvset_builder_add_nonval(bld, seq2, VTYPE_PTOMB);
     ASSERT_EQ(err, 0);
     /* plus invalid cases */
-    err = kvset_builder_add_nonval(bld, seq2, vtype_val);
+    err = kvset_builder_add_nonval(bld, seq2, VTYPE_UCVAL);
     ASSERT_NE(err, 0);
     err = kvset_builder_add_nonval(bld, seq2, 1234);
     ASSERT_NE(err, 0);
@@ -271,7 +271,7 @@ MTF_DEFINE_UTEST_PREPOST(test, t_reserve_kmd2, pre, post)
 
     /* Repeat with kvset_builder_add_nonval */
     for (i = 0; i < 100; i++) {
-        err = kvset_builder_add_nonval(bld, seq, vtype_zval);
+        err = kvset_builder_add_nonval(bld, seq, VTYPE_ZVAL);
         if (err)
             break;
     }

--- a/tools/cn_kbdump/cn_kbdump.c
+++ b/tools/cn_kbdump/cn_kbdump.c
@@ -456,7 +456,7 @@ val_get_next(void *kmd, size_t *off, struct kmd_vref *vref)
     kmd_type_seq(kmd, off, &vref->vtype, &vref->seq);
 
     switch (vref->vtype) {
-        case vtype_val:
+        case VTYPE_UCVAL:
             kmd_val(kmd, off, &vref->vbidx, &vref->vboff, &vref->vlen);
             snprintf(
                 vref->vinfo,
@@ -466,17 +466,17 @@ val_get_next(void *kmd, size_t *off, struct kmd_vref *vref)
                 vref->vboff,
                 vref->vlen);
             break;
-        case vtype_ival:
+        case VTYPE_IVAL:
             kmd_ival(kmd, off, &vdata, &vlen);
             snprintf(vref->vinfo, sizeof(vref->vinfo), "type=iv %u", vlen);
             break;
-        case vtype_zval:
+        case VTYPE_ZVAL:
             strlcpy(vref->vinfo, "type=zv", sizeof(vref->vinfo));
             break;
-        case vtype_tomb:
+        case VTYPE_TOMB:
             strlcpy(vref->vinfo, "type=t", sizeof(vref->vinfo));
             break;
-        case vtype_ptomb:
+        case VTYPE_PTOMB:
             strlcpy(vref->vinfo, "type=pt", sizeof(vref->vinfo));
             break;
         default:


### PR DESCRIPTION
Signed-off-by: Alex Tomlinson <4172734+alexttx@users.noreply.github.com>
