### PR TITLE
cndb compact bugfix

### DIFF
--- a/lib/cndb/cndb.c
+++ b/lib/cndb/cndb.c
@@ -52,7 +52,7 @@ struct cndb {
     uint64_t          cndb_captgt;
     uint64_t          oid1;
     uint64_t          oid2;
-    uint32_t          cndb_hwm;
+    double            cndb_hwm;
 
     /* Current id values */
     uint64_t         txid_curr;
@@ -143,7 +143,7 @@ cndb_open(struct mpool *mp, uint64_t oid1, uint64_t oid2, struct kvdb_rparams *r
     cndb->ingestid_max = 0;
     cndb->txhorizon_max = 0;
     cndb->replaying = false;
-    cndb->cndb_hwm = rp->cndb_compact_hwm;
+    cndb->cndb_hwm = rp->cndb_compact_hwm_pct;
     cndb->rdonly = rp->read_only;
 
     cndb->tx_map = map_create(1024);
@@ -265,14 +265,14 @@ static bool
 cndb_needs_compaction(struct cndb *cndb)
 {
     merr_t err;
-    uint64_t size, allocated, used, hwm;
-    const uint64_t base = 100 * 100;
+    uint64_t size, allocated, used;
+    double hwm;
 
     err = mpool_mdc_usage(cndb->mdc, &size, &allocated, &used);
     if (ev(err))
         return false;
 
-    hwm = (cndb->cndb_hwm * size) / base;
+    hwm = (cndb->cndb_hwm * size) / 100;
 
     return used > hwm;
 }

--- a/lib/cndb/cndb.c
+++ b/lib/cndb/cndb.c
@@ -869,12 +869,11 @@ cndb_compact(struct cndb *cndb)
     map_iter_init(&txiter, cndb->tx_map);
 
     while (map_iter_next(&txiter, &txid, (uintptr_t *)&tx)) {
-        bool can_rollforward = cndb_txn_can_rollforward(tx);
         uint16_t add_cnt, del_cnt;
 
         cndb_txn_cnt_get(tx, &add_cnt, &del_cnt);
 
-        if (can_rollforward) {
+        if (cndb_txn_can_rollforward(tx)) {
             add_cnt = 0;
             assert(del_cnt);
         }

--- a/lib/cndb/txn.c
+++ b/lib/cndb/txn.c
@@ -268,13 +268,13 @@ cndb_txn_needs_rollback(struct cndb_txn *tx)
 bool
 cndb_txn_can_rollforward(struct cndb_txn *tx)
 {
-    return tx->add_cnt_seen == tx->add_ack_cnt_seen;
+    return !list_empty(&tx->kvset_list) && tx->add_cnt_seen == tx->add_ack_cnt_seen;
 }
 
 bool
 cndb_txn_is_complete(struct cndb_txn *tx)
 {
-    return tx->add_cnt_seen + tx->del_cnt_seen == tx->add_ack_cnt_seen + tx->del_ack_cnt_seen;
+    return cndb_txn_can_rollforward(tx) && tx->del_cnt_seen == tx->del_ack_cnt_seen;
 }
 
 void

--- a/lib/include/hse_ikvdb/cndb.h
+++ b/lib/include/hse_ikvdb/cndb.h
@@ -41,7 +41,7 @@ cndb_destroy(struct mpool *mp, uint64_t oid1, uint64_t oid2);
 
 /* MTF_MOCK */
 merr_t
-cndb_open(struct mpool *mp, u64 oid1, u64 oid2, bool rdonly, struct cndb **cndb_out);
+cndb_open(struct mpool *mp, u64 oid1, u64 oid2, struct kvdb_rparams *rp, struct cndb **cndb_out);
 
 /* MTF_MOCK */
 merr_t

--- a/lib/include/hse_ikvdb/kvdb_rparams.h
+++ b/lib/include/hse_ikvdb/kvdb_rparams.h
@@ -95,7 +95,7 @@ struct kvdb_rparams {
     uint32_t c0_ingest_threads;
     uint16_t cn_maint_threads;
     uint16_t cn_io_threads;
-    uint32_t cndb_compact_hwm;
+    uint32_t cndb_compact_hwm_pct;
 
     uint32_t keylock_tables;
 

--- a/lib/include/hse_ikvdb/kvdb_rparams.h
+++ b/lib/include/hse_ikvdb/kvdb_rparams.h
@@ -36,8 +36,6 @@
  * @c0_debug:         c0 debug flags (see param_debug_flags.h)
  * @keylock_tables:   number of keylock hash tables
  * @txn_wkth_delay:        delay (msecs) to invoke transaction worker thread
- * @cndb_entries:     max number of entries CNDB's in memory structures. Note
- *                    that this does not affect the MDC's size.
  *
  * The following tunable parameters can have a major impact on the way KVDB
  * operates.  Test thoroughly after any modifications.
@@ -53,7 +51,6 @@ struct kvdb_rparams {
     uint8_t perfc_enable;
     bool    c0_diag_mode;
     uint8_t c0_debug;
-    bool    cndb_debug;
 
     uint32_t c0_ingest_width;
 
@@ -94,11 +91,11 @@ struct kvdb_rparams {
      * and hence are extremely cold.
      */
     uint64_t txn_wkth_delay;
-    uint32_t cndb_entries;
     uint32_t c0_maint_threads;
     uint32_t c0_ingest_threads;
     uint16_t cn_maint_threads;
     uint16_t cn_io_threads;
+    uint32_t cndb_compact_hwm;
 
     uint32_t keylock_tables;
 

--- a/lib/include/hse_ikvdb/limits.h
+++ b/lib/include/hse_ikvdb/limits.h
@@ -29,7 +29,7 @@
 #define HSE_C0_MAINT_THREADS_MAX    (7)
 
 /* CNDB */
-#define HSE_CNDB_COMPACT_HWM_DEFAULT (80 * 100) /* 80 percent */
+#define HSE_CNDB_COMPACT_HWM_PCT_DEFAULT (80)
 
 /* The defines for the max number of entries in the viewset and snr
  * caches are totals for the entire cache.  Any given thread will

--- a/lib/include/hse_ikvdb/limits.h
+++ b/lib/include/hse_ikvdb/limits.h
@@ -28,6 +28,9 @@
 #define HSE_C0_MAINT_THREADS_DFLT   (3)
 #define HSE_C0_MAINT_THREADS_MAX    (7)
 
+/* CNDB */
+#define HSE_CNDB_COMPACT_HWM_DEFAULT (80 * 100) /* 80 percent */
+
 /* The defines for the max number of entries in the viewset and snr
  * caches are totals for the entire cache.  Any given thread will
  * likely be able to access only a fraction of the total.

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -1101,7 +1101,7 @@ ikvdb_diag_open(
         self->ikdb_mp,
         self->ikdb_cndb_oid1,
         self->ikdb_cndb_oid2,
-        self->ikdb_read_only,
+        &self->ikdb_rp,
         &self->ikdb_cndb);
     if (err)
         goto kvdb_pfxlock_cleanup;
@@ -1287,7 +1287,7 @@ ikvdb_cndb_open(struct ikvdb_impl *self, u64 *seqno, u64 *ingestid, u64 *txhoriz
         self->ikdb_mp,
         self->ikdb_cndb_oid1,
         self->ikdb_cndb_oid2,
-        self->ikdb_read_only,
+        &self->ikdb_rp,
         &self->ikdb_cndb);
     if (ev(err))
         return err;

--- a/lib/kvdb/kvdb_rparams.c
+++ b/lib/kvdb/kvdb_rparams.c
@@ -652,6 +652,27 @@ static const struct param_spec pspecs[] = {
         },
     },
     {
+        .ps_name = "cndb_compact_hwm",
+        .ps_description = "High water mark percentage (x100)",
+        .ps_flags = PARAM_FLAG_EXPERIMENTAL,
+        .ps_type = PARAM_TYPE_U32,
+        .ps_offset = offsetof(struct kvdb_rparams, cndb_compact_hwm),
+        .ps_size = PARAM_SZ(struct kvdb_rparams, cndb_compact_hwm),
+        .ps_convert = param_default_converter,
+        .ps_validate = param_default_validator,
+        .ps_stringify = param_default_stringify,
+        .ps_jsonify = param_default_jsonify,
+        .ps_default_value = {
+            .as_uscalar = HSE_CNDB_COMPACT_HWM_DEFAULT,
+        },
+        .ps_bounds = {
+            .as_uscalar = {
+                .ps_min = 0,
+                .ps_max = 100 * 100,
+            },
+        },
+    },
+    {
         .ps_name = "csched_policy",
         .ps_description = "csched (compaction scheduler) policy",
         .ps_flags = PARAM_FLAG_EXPERIMENTAL | PARAM_FLAG_WRITABLE,
@@ -1257,42 +1278,6 @@ static const struct param_spec pspecs[] = {
                 .ps_min = 0,
                 .ps_max = UINT64_MAX,
             },
-        },
-    },
-    {
-        .ps_name = "cndb_entries",
-        .ps_description = "number of entries in cndb's in-core representation (0: let system choose)",
-        .ps_flags = PARAM_FLAG_EXPERIMENTAL,
-        .ps_type = PARAM_TYPE_U32,
-        .ps_offset = offsetof(struct kvdb_rparams, cndb_entries),
-        .ps_size = PARAM_SZ(struct kvdb_rparams, cndb_entries),
-        .ps_convert = param_default_converter,
-        .ps_validate = param_default_validator,
-        .ps_stringify = param_default_stringify,
-        .ps_jsonify = param_default_jsonify,
-        .ps_default_value = {
-            .as_uscalar = 0,
-        },
-        .ps_bounds = {
-            .as_uscalar = {
-                .ps_min = 0,
-                .ps_max = UINT32_MAX,
-            },
-        },
-    },
-    {
-        .ps_name = "cndb_debug",
-        .ps_description = "enable cndb debug logs",
-        .ps_flags = PARAM_FLAG_EXPERIMENTAL,
-        .ps_type = PARAM_TYPE_BOOL,
-        .ps_offset = offsetof(struct kvdb_rparams, cndb_debug),
-        .ps_size = PARAM_SZ(struct kvdb_rparams, cndb_debug),
-        .ps_convert = param_default_converter,
-        .ps_validate = param_default_validator,
-        .ps_stringify = param_default_stringify,
-        .ps_jsonify = param_default_jsonify,
-        .ps_default_value = {
-            .as_bool = false,
         },
     },
     {

--- a/lib/kvdb/kvdb_rparams.c
+++ b/lib/kvdb/kvdb_rparams.c
@@ -652,23 +652,23 @@ static const struct param_spec pspecs[] = {
         },
     },
     {
-        .ps_name = "cndb_compact_hwm",
-        .ps_description = "High water mark percentage (x100)",
+        .ps_name = "cndb_compact_hwm_pct",
+        .ps_description = "CNDB compaction high water mark percentage",
         .ps_flags = PARAM_FLAG_EXPERIMENTAL,
-        .ps_type = PARAM_TYPE_U32,
-        .ps_offset = offsetof(struct kvdb_rparams, cndb_compact_hwm),
-        .ps_size = PARAM_SZ(struct kvdb_rparams, cndb_compact_hwm),
+        .ps_type = PARAM_TYPE_DOUBLE,
+        .ps_offset = offsetof(struct kvdb_rparams, cndb_compact_hwm_pct),
+        .ps_size = PARAM_SZ(struct kvdb_rparams, cndb_compact_hwm_pct),
         .ps_convert = param_default_converter,
         .ps_validate = param_default_validator,
         .ps_stringify = param_default_stringify,
         .ps_jsonify = param_default_jsonify,
         .ps_default_value = {
-            .as_uscalar = HSE_CNDB_COMPACT_HWM_DEFAULT,
+            .as_uscalar = HSE_CNDB_COMPACT_HWM_PCT_DEFAULT,
         },
         .ps_bounds = {
-            .as_uscalar = {
+            .as_double = {
                 .ps_min = 0,
-                .ps_max = 100 * 100,
+                .ps_max = 100,
             },
         },
     },

--- a/tests/functional/kvpy/cndb_compact.py
+++ b/tests/functional/kvpy/cndb_compact.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
+
+'''
+Set the cndb compaction high watermark to a very low percentage - 0.02%.
+
+Then load the kvs such that it undergoes multiple kvcompactions and use a cursor
+to pin down certain kvsets. This forces cndb compactions to deal with incomplete
+and rollforward-able transactions.
+'''
+
+from contextlib import ExitStack
+
+from utility import cli, lifecycle
+
+from hse3 import hse
+
+import time
+
+def run_test(kvdb: hse.Kvdb, kvs: hse.Kvs, validx: int, keycnt: int = 150):
+    val = f'val.{validx:0>4}'
+    cur = None
+
+    for i in range(keycnt):
+        key = f'key.{i:0>10}'
+        kvs.put(key, val)
+        kvdb.sync()
+
+        if i == 1:
+            cur = kvs.cursor()
+            k, v = cur.read()
+
+        if i == 90:
+            cur.destroy()
+
+        time.sleep(0.01);
+
+    pass
+
+hse.init(cli.CONFIG)
+
+try:
+    with ExitStack() as stack:
+        kvdb_ctx = lifecycle.KvdbContext().rparams("durability.enabled=false", "c0_debug=16", "cndb_compact_hwm=2")
+        kvdb = stack.enter_context(kvdb_ctx)
+
+        nkeys = 150
+        kvs_name = "test_kvs"
+
+        kvdb.kvs_create(kvs_name, "")
+        kvs = kvdb.kvs_open(kvs_name, "")
+
+        run_test(kvdb, kvs, 1, keycnt = nkeys)
+        run_test(kvdb, kvs, 2, keycnt = nkeys)
+        run_test(kvdb, kvs, 3, keycnt = nkeys)
+
+        kvs.close()
+
+        # Reopen kvs and verify the number of keys.
+        kvs = kvdb.kvs_open(kvs_name, "")
+        with kvs.cursor() as cur:
+            assert sum(1 for _ in cur.items()) == nkeys
+
+        kvs.close()
+finally:
+    hse.fini()
+

--- a/tests/functional/kvpy/cndb_compact.py
+++ b/tests/functional/kvpy/cndb_compact.py
@@ -44,7 +44,7 @@ hse.init(cli.CONFIG)
 
 try:
     with ExitStack() as stack:
-        kvdb_ctx = lifecycle.KvdbContext().rparams("durability.enabled=false", "c0_debug=16", "cndb_compact_hwm=2")
+        kvdb_ctx = lifecycle.KvdbContext().rparams("durability.enabled=false", "c0_debug=16", "cndb_compact_hwm_pct=0.02")
         kvdb = stack.enter_context(kvdb_ctx)
 
         nkeys = 150

--- a/tests/functional/kvpy/cndb_compact.py
+++ b/tests/functional/kvpy/cndb_compact.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021-2022 Micron Technology, Inc. All rights reserved.
+# Copyright (C) 2022 Micron Technology, Inc. All rights reserved.
 
 '''
 Set the cndb compaction high watermark to a very low percentage - 0.02%.
@@ -21,11 +21,11 @@ from hse3 import hse
 import time
 
 def run_test(kvdb: hse.Kvdb, kvs: hse.Kvs, validx: int, keycnt: int = 150):
-    val = f'val.{validx:0>4}'
+    val = f"val.{validx:0>4}"
     cur = None
 
     for i in range(keycnt):
-        key = f'key.{i:0>10}'
+        key = f"key.{i:0>10}"
         kvs.put(key, val)
         kvdb.sync()
 
@@ -50,8 +50,8 @@ try:
         nkeys = 150
         kvs_name = "test_kvs"
 
-        kvdb.kvs_create(kvs_name, "")
-        kvs = kvdb.kvs_open(kvs_name, "")
+        kvdb.kvs_create(kvs_name)
+        kvs = kvdb.kvs_open(kvs_name)
 
         run_test(kvdb, kvs, 1, keycnt = nkeys)
         run_test(kvdb, kvs, 2, keycnt = nkeys)
@@ -60,7 +60,7 @@ try:
         kvs.close()
 
         # Reopen kvs and verify the number of keys.
-        kvs = kvdb.kvs_open(kvs_name, "")
+        kvs = kvdb.kvs_open(kvs_name)
         with kvs.cursor() as cur:
             assert sum(1 for _ in cur.items()) == nkeys
 

--- a/tests/functional/kvpy/meson.build
+++ b/tests/functional/kvpy/meson.build
@@ -16,6 +16,7 @@ tests = {
     'cache_delay': {},
     'cn_seqno': {},
     'cn_update': {},
+    'cndb_compact': {},
     'delfail': {},
     'ingested_key': {},
     'multcur_multview': {},

--- a/tests/unit/cndb/cndb_test.c
+++ b/tests/unit/cndb/cndb_test.c
@@ -10,6 +10,8 @@
 #include <hse_util/list.h>
 
 #include <hse_ikvdb/cndb.h>
+#include <hse_ikvdb/kvdb_rparams.h>
+
 #include <mpool/mpool.h>
 
 #include <cn/kvset.h>
@@ -198,11 +200,12 @@ test_pre(struct mtf_test_info *lcl_ti)
     uint64_t oid1, oid2;
     struct mpool *mp = (void *)-1;
     merr_t err;
+    struct kvdb_rparams rp = kvdb_rparams_defaults();
 
     err = cndb_create(mp, 0, &oid1, &oid2);
     ASSERT_EQ_RET(0, err, -1);
 
-    err = cndb_open(mp, oid1, oid2, false, &cndb);
+    err = cndb_open(mp, oid1, oid2, &rp, &cndb);
     ASSERT_EQ_RET(0, err, -1);
 
     struct kvs_cparams cp = kvs_cparams_defaults();
@@ -440,7 +443,8 @@ MTF_DEFINE_UTEST_PREPOST(cndb_test, replay_full, test_pre, test_post)
     err = cndb_close(cndb);
     ASSERT_EQ(0, err);
 
-    err = cndb_open(mp, 0, 0, false, &cndb);
+    struct kvdb_rparams rp = kvdb_rparams_defaults();
+    err = cndb_open(mp, 0, 0, &rp, &cndb);
     ASSERT_EQ(0, err);
 
     uint64_t seqno_out, ingestid_out, txhorizon_out;
@@ -523,7 +527,8 @@ MTF_DEFINE_UTEST_PREPOST(cndb_test, rollback, test_pre, test_post)
     err = cndb_close(cndb);
     ASSERT_EQ(0, err);
 
-    err = cndb_open(mp, 0, 0, false, &cndb);
+    struct kvdb_rparams rp = kvdb_rparams_defaults();
+    err = cndb_open(mp, 0, 0, &rp, &cndb);
     ASSERT_EQ(0, err);
 
     uint64_t seqno_out, ingestid_out, txhorizon_out;
@@ -612,7 +617,8 @@ MTF_DEFINE_UTEST_PREPOST(cndb_test, rollforward, test_pre, test_post)
     err = cndb_close(cndb);
     ASSERT_EQ(0, err);
 
-    err = cndb_open(mp, 0, 0, false, &cndb);
+    struct kvdb_rparams rp = kvdb_rparams_defaults();
+    err = cndb_open(mp, 0, 0, &rp, &cndb);
     ASSERT_EQ(0, err);
 
     uint64_t seqno_out, ingestid_out, txhorizon_out;
@@ -639,7 +645,7 @@ MTF_DEFINE_UTEST_PREPOST(cndb_test, rollforward, test_pre, test_post)
     err = cndb_close(cndb);
     ASSERT_EQ(0, err);
 
-    err = cndb_open(mp, 0, 0, false, &cndb);
+    err = cndb_open(mp, 0, 0, &rp, &cndb);
     ASSERT_EQ(0, err);
 
     mapi_calls_clear(mapi_idx_mpool_mblock_delete);
@@ -661,7 +667,8 @@ MTF_DEFINE_UTEST(cndb_test, multiple_kvs)
     err = cndb_create(mp, 0, &oid1, &oid2);
     ASSERT_EQ(0, err);
 
-    err = cndb_open(mp, oid1, oid2, false, &cndb);
+    struct kvdb_rparams rp = kvdb_rparams_defaults();
+    err = cndb_open(mp, oid1, oid2, &rp, &cndb);
     ASSERT_EQ(0, err);
 
     uint64_t cnid;
@@ -698,7 +705,7 @@ MTF_DEFINE_UTEST(cndb_test, multiple_kvs)
     err = cndb_close(cndb);
     ASSERT_EQ(0, err);
 
-    err = cndb_open(mp, oid1, oid2, false, &cndb);
+    err = cndb_open(mp, oid1, oid2, &rp, &cndb);
     ASSERT_EQ(0, err);
 
     uint64_t seqno_out, ingestid_out, txhorizon_out;
@@ -793,7 +800,8 @@ MTF_DEFINE_UTEST_PREPOST(cndb_test, compact_no_recovery, test_pre, test_post)
     err = cndb_close(cndb);
     ASSERT_EQ(0, err);
 
-    err = cndb_open(mp, 0, 0, false, &cndb);
+    struct kvdb_rparams rp = kvdb_rparams_defaults();
+    err = cndb_open(mp, 0, 0, &rp, &cndb);
     ASSERT_EQ(0, err);
 
     mapi_calls_clear(mapi_idx_mpool_mblock_delete);
@@ -865,8 +873,9 @@ MTF_DEFINE_UTEST_PREPOST(cndb_test, only_deletes_rollforward, test_pre, test_pos
     ASSERT_EQ(0, err);
 
     struct mpool *mp = (void *)-1;
+    struct kvdb_rparams rp = kvdb_rparams_defaults();
 
-    err = cndb_open(mp, 0, 0, false, &cndb);
+    err = cndb_open(mp, 0, 0, &rp, &cndb);
     ASSERT_EQ(0, err);
 
     mapi_calls_clear(mapi_idx_mpool_mblock_delete);

--- a/tests/unit/kvdb/kvdb_rparams_test.c
+++ b/tests/unit/kvdb/kvdb_rparams_test.c
@@ -739,42 +739,6 @@ MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, txn_wkth_delay, test_pre)
     ASSERT_EQ(UINT64_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
-MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, cndb_entries, test_pre)
-{
-    const struct param_spec *ps = ps_get("cndb_entries");
-
-    ASSERT_NE(NULL, ps);
-    ASSERT_NE(NULL, ps->ps_description);
-    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_U32, ps->ps_type);
-    ASSERT_EQ(offsetof(struct kvdb_rparams, cndb_entries), ps->ps_offset);
-    ASSERT_EQ(sizeof(uint32_t), ps->ps_size);
-    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
-    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
-    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
-    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
-    ASSERT_EQ(0, params.cndb_entries);
-    ASSERT_EQ(0, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(UINT32_MAX, ps->ps_bounds.as_uscalar.ps_max);
-}
-
-MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, cndb_debug, test_pre)
-{
-    const struct param_spec *ps = ps_get("cndb_debug");
-
-    ASSERT_NE(NULL, ps);
-    ASSERT_NE(NULL, ps->ps_description);
-    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
-    ASSERT_EQ(PARAM_TYPE_BOOL, ps->ps_type);
-    ASSERT_EQ(offsetof(struct kvdb_rparams, cndb_debug), ps->ps_offset);
-    ASSERT_EQ(sizeof(bool), ps->ps_size);
-    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
-    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
-    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
-    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
-    ASSERT_EQ(false, params.cndb_debug);
-}
-
 MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, c0_maint_threads, test_pre)
 {
     const struct param_spec *ps = ps_get("c0_maint_threads");


### PR DESCRIPTION
## Description
When compacting cndb, do not rewrite kvsets from incomplete transactions if they've already been added to the kvset table.

## Issue(s) Addressed
[NFSE-5316](https://jira.micron.com/jira/browse/NFSE-5316)
