### PR TITLE
Reset logging to defaults in logging_fini()

### DIFF
--- a/lib/logging/lib/logging.c
+++ b/lib/logging/lib/logging.c
@@ -102,7 +102,9 @@ logging_fini(void)
     if (log_file && log_file != stdout && log_file != stderr)
         fclose(log_file);
     log_file = NULL;
-
+    log_level = LOG_INFO;
+    log_squelch_ns = LOG_SQUELCH_NS_DEFAULT;
+    logging_enabled = true;
     logging_initialized = false;
 }
 


### PR DESCRIPTION
In a program that does:

hse_init()
hse_fini()
hse_init()

log messages will appear during the second hse_init() that were
suppressed in the first hse_init().

Signed-off-by: Tristan Partin <tpartin@micron.com>
