### PR TITLE
Robust handling of ptomb-only node/kvsets (NFSE-5347)

### DIFF
--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -957,6 +957,10 @@ cn_open(
     cn_tree_foreach_leaf(tn, cn->cn_tree) {
         cn_tree_node_get_max_key(tn, kbuf, sizeof(kbuf), &klen);
 
+        /* TODO: Handle a ptomb-only node
+         */
+        assert(klen > 0);
+
         tn->tn_route_node = route_map_insert(cn->cn_tree->ct_route_map, tn, kbuf, klen);
         if (!tn->tn_route_node) {
             err = merr(EINVAL);

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -957,7 +957,7 @@ cn_open(
     cn_tree_foreach_leaf(tn, cn->cn_tree) {
         cn_tree_node_get_max_key(tn, kbuf, sizeof(kbuf), &klen);
 
-        /* TODO: Handle a ptomb-only node
+        /* TODO: Handle a ptomb-only node (NFSE-5351)
          */
         assert(klen > 0);
 

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1589,7 +1589,7 @@ cn_comp_commit(struct cn_compaction_work *w)
         w->cw_keep_vblks = false;
 
     alloc_len = sizeof(*kvsets) * w->cw_outc;
-    if (use_mbsets) {
+    if (use_mbsets && w->cw_keep_vblks) {
         /* For k-compaction, create new kvset with references to
          * mbsets from input kvsets instead of creating new mbsets.
          * We need extra allocations for this.
@@ -1606,7 +1606,7 @@ cn_comp_commit(struct cn_compaction_work *w)
 
     cookiev = (void *)kvsets + alloc_len;
 
-    if (use_mbsets) {
+    if (use_mbsets && w->cw_keep_vblks) {
         struct kvset_list_entry *le;
         uint i;
 
@@ -1711,7 +1711,7 @@ cn_comp_commit(struct cn_compaction_work *w)
 
         if (use_mbsets) {
             err = kvset_open2(w->cw_tree, w->cw_kvsetidv[i], &km,
-                                      w->cw_kvset_cnt, cnts, vecs, &kvsets[i]);
+                              w->cw_keep_vblks ? w->cw_kvset_cnt : 0, cnts, vecs, &kvsets[i]);
         } else {
             err = kvset_open(w->cw_tree, w->cw_kvsetidv[i], &km, &kvsets[i]);
         }

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1639,9 +1639,6 @@ cn_comp_commit(struct cn_compaction_work *w)
         err = cn_split_nodes_alloc(w, split_nodeidv, split_nodev);
         if (err)
             goto done;
-
-        atomic_set(&split_nodev[0]->tn_sgen, w->cw_node->tn_sgen);
-        atomic_set(&split_nodev[1]->tn_sgen, w->cw_node->tn_sgen);
     }
 
     for (i = 0; i < w->cw_outc; i++) {
@@ -2380,18 +2377,18 @@ cn_tree_node_get_max_key(struct cn_tree_node *tn, void *kbuf, size_t kbuf_sz, ui
     list_for_each_entry (le, &tn->tn_kvset_list, le_link) {
         struct kvset *kvset = le->le_kvset;
         const void *key;
-        uint klen;
+        uint klen = 0;
 
         kvset_get_max_key(kvset, &key, &klen);
 
-        if (!max_key || keycmp(key, klen, max_key, *max_klen) > 0) {
+        if (klen > 0 && (!max_key || keycmp(key, klen, max_key, *max_klen) > 0)) {
             max_key = key;
             *max_klen = klen;
         }
     }
-    assert(max_key && *max_klen > 0);
 
-    memcpy(kbuf, max_key, min_t(size_t, kbuf_sz, *max_klen));
+    if (max_key)
+        memcpy(kbuf, max_key, min_t(size_t, kbuf_sz, *max_klen));
     rmlock_runlock(lock);
 }
 

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -505,8 +505,7 @@ sp3_work_wtype_length(
         /* Start from oldest kvset, find first run of 'runlen_min' kvsets
          * with the same 'compc' value, then k-compact those kvsets and up
          * to 'runlen_max' newer.  Skip kvsets with enormous key counts.
-         * Include contiguous ptomb-only kvsets in the run if the oldest
-         * kvset is also in the run.
+         * Include contiguous ptomb-only kvsets in the run.
          */
         list_for_each_entry_reverse(le, head, le_link) {
             if (runlen < runlen_min) {
@@ -525,7 +524,7 @@ sp3_work_wtype_length(
             vwlen += stats->kst_vwlen;
             wlen += stats->kst_kwlen + stats->kst_vwlen;
 
-            if ((*mark == list_last_entry(head, typeof(*le), le_link)) && stats->kst_keys == 0)
+            if (stats->kst_keys == 0)
                 ++runlen_max;
 
             if (++runlen >= runlen_max)

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -275,9 +275,11 @@ sp3_work_wtype_idle(
         return kvsets;
     }
 
-    /* Compact if the preponderance of keys appears to be tombs.
+    /* Compact the node if the preponderance of keys appears to be tombs or
+     * if all kvsets are ptomb-only.
      */
-    if (cn_ns_tombs(&tn->tn_ns) * 100 > cn_ns_keys_uniq(&tn->tn_ns) * 90) {
+    if ((cn_ns_tombs(&tn->tn_ns) * 100 > cn_ns_keys_uniq(&tn->tn_ns) * 90) ||
+        cn_ns_keys(&tn->tn_ns) == 0) {
         *rule = CN_RULE_IDLE_TOMB;
         return kvsets;
     }
@@ -503,6 +505,8 @@ sp3_work_wtype_length(
         /* Start from oldest kvset, find first run of 'runlen_min' kvsets
          * with the same 'compc' value, then k-compact those kvsets and up
          * to 'runlen_max' newer.  Skip kvsets with enormous key counts.
+         * Include contiguous ptomb-only kvsets in the run if the oldest
+         * kvset is also in the run.
          */
         list_for_each_entry_reverse(le, head, le_link) {
             if (runlen < runlen_min) {
@@ -520,6 +524,9 @@ sp3_work_wtype_length(
             stats = kvset_statsp(le->le_kvset);
             vwlen += stats->kst_vwlen;
             wlen += stats->kst_kwlen + stats->kst_vwlen;
+
+            if ((*mark == list_last_entry(head, typeof(*le), le_link)) && stats->kst_keys == 0)
+                ++runlen_max;
 
             if (++runlen >= runlen_max)
                 break;

--- a/lib/cn/hblock_builder.h
+++ b/lib/cn/hblock_builder.h
@@ -22,6 +22,7 @@ struct kvs_block;
 struct key_stats;
 struct vgmap;
 struct perfc_set;
+struct wbt_desc;
 
 /* MTF_MOCK */
 merr_t
@@ -55,6 +56,7 @@ hbb_finish(
     const uint32_t         num_ptombs,
     const uint8_t         *hlog,
     const uint8_t         *ptree,
+    struct wbt_desc       *ptree_desc,
     uint32_t               ptree_pgc);
 
 merr_t

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -1910,9 +1910,10 @@ kvset_get_max_key(struct kvset *ks, const void **max_key, uint *max_klen)
 {
     struct kvset_kblk *kb;
 
-    INVARIANT(max_key && max_klen);
+    INVARIANT(ks && max_key && max_klen);
 
     if (ks->ks_st.kst_kblks == 0) {
+        *max_key = NULL;
         *max_klen = 0;
         return;
     }

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -1908,10 +1908,16 @@ kvset_get_vbsetv(struct kvset *ks, uint *vbsetc)
 void
 kvset_get_max_key(struct kvset *ks, const void **max_key, uint *max_klen)
 {
-    struct kvset_kblk *kb = &ks->ks_kblks[ks->ks_st.kst_kblks - 1];
+    struct kvset_kblk *kb;
 
     INVARIANT(max_key && max_klen);
 
+    if (ks->ks_st.kst_kblks == 0) {
+        *max_klen = 0;
+        return;
+    }
+
+    kb = &ks->ks_kblks[ks->ks_st.kst_kblks - 1];
     *max_key = kb->kb_koff_max;
     *max_klen = kb->kb_klen_max;
 }

--- a/lib/cn/kvset_builder.c
+++ b/lib/cn/kvset_builder.c
@@ -423,6 +423,12 @@ kvset_builder_finish(struct kvset_builder *imp)
          */
         vbb_destroy(imp->vbb);
         imp->vbb = NULL;
+
+        if (adopted_vbs) {
+            blk_list_free(&imp->vblk_list);
+            vgmap_free(imp->vgmap);
+            imp->vgmap = NULL;
+        }
     }
 
     err = kbb_finish(imp->kbb, &imp->kblk_list);

--- a/lib/cn/kvset_builder.c
+++ b/lib/cn/kvset_builder.c
@@ -435,7 +435,7 @@ kvset_builder_finish(struct kvset_builder *imp)
 
     err = hbb_finish(imp->hbb, &imp->hblk, imp->vgmap, NULL, NULL, imp->seqno_min, imp->seqno_max,
                      imp->kblk_list.n_blks, imp->vblk_list.n_blks, hbb_get_nptombs(imp->hbb),
-                     kbb_get_composite_hlog(imp->kbb), NULL, 0);
+                     kbb_get_composite_hlog(imp->kbb), NULL, NULL, 0);
     if (err) {
         delete_mblocks(cn_get_dataset(imp->cn), &imp->kblk_list);
         if (!adopted_vbs)

--- a/lib/cn/node_split.c
+++ b/lib/cn/node_split.c
@@ -570,7 +570,7 @@ cn_split(struct cn_compaction_work *w)
     while (inflight > 0)
         usleep(100 * 1000);
 
-    for (int64_t i = w->cw_kvset_cnt - 1; !err && i >= 0; i--) {
+    for (i = w->cw_kvset_cnt; !err && i-- > 0;) {
         if (wargs[i].err) {
             err = wargs[i].err;
             break;
@@ -586,11 +586,11 @@ cn_split(struct cn_compaction_work *w)
                     drop_ptomb_ks[k] = false;
 
                 if (HSE_UNLIKELY(drop_ptomb_ks[k])) {
-                    /* Drop contiguous kvsets containing only ptombs, starting from the oldest.
-                     */
                     assert(blks->vblks.n_blks == 0);
                     assert(result->ks[k].blks_commit->n_blks == 1);
 
+                    /* Drop contiguous kvsets containing only ptombs, starting from the oldest.
+                     */
                     delete_mblock(w->cw_mp, &blks->hblk);
                     blk_list_free(result->ks[k].blks_commit);
                 } else {
@@ -602,7 +602,7 @@ cn_split(struct cn_compaction_work *w)
         }
     }
 
-    ev(drop_ptomb_ks[0] || drop_ptomb_ks[1]);
+    ev_info(drop_ptomb_ks[0] || drop_ptomb_ks[1]);
 
     for (i = 0; err && i < w->cw_kvset_cnt; i++)
         kvset_split_res_free(wargs[i].ks, &wargs[i].result);

--- a/lib/cn/wbt_builder.c
+++ b/lib/cn/wbt_builder.c
@@ -18,6 +18,7 @@
 
 #define MTF_MOCK_IMPL_wbt_builder
 #include "wbt_builder.h"
+#include "wbt_reader.h"
 #include "wbt_internal.h"
 #include "intern_builder.h"
 
@@ -502,6 +503,18 @@ wbb_hdr_init(struct wbt_hdr_omf *hdr)
 {
     omf_set_wbt_magic(hdr, WBT_TREE_MAGIC);
     omf_set_wbt_version(hdr, WBT_TREE_VERSION);
+}
+
+void
+wbb_hdr_set(struct wbt_hdr_omf *hdr, struct wbt_desc *desc)
+{
+    memset(hdr, 0, sizeof(*hdr));
+    omf_set_wbt_magic(hdr, WBT_TREE_MAGIC);
+    omf_set_wbt_version(hdr, desc->wbd_version);
+    omf_set_wbt_leaf(hdr, desc->wbd_leaf);
+    omf_set_wbt_leaf_cnt(hdr, desc->wbd_leaf_cnt);
+    omf_set_wbt_root(hdr, desc->wbd_root);
+    omf_set_wbt_kmd_pgc(hdr, desc->wbd_kmd_pgc);
 }
 
 merr_t

--- a/lib/cn/wbt_builder.h
+++ b/lib/cn/wbt_builder.h
@@ -14,6 +14,7 @@
 struct key_obj;
 struct wbb;
 struct wbt_hdr_omf;
+struct wbt_desc;
 
 /* Create a wbtree builder
  *
@@ -81,6 +82,9 @@ wbb_add_entry(
 
 void
 wbb_hdr_init(struct wbt_hdr_omf *hdr);
+
+void
+wbb_hdr_set(struct wbt_hdr_omf *hdr, struct wbt_desc *desc);
 
 /**
  * wbb_freeze() - finalize a wbtree

--- a/tests/unit/cn/hblock_builder_test.c
+++ b/tests/unit/cn/hblock_builder_test.c
@@ -158,7 +158,7 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, add_ptomb_success, test_pre, test_
     err = hbb_create(&bld, cn, NULL);
     ASSERT_EQ(0, merr_errno(err));
 
-    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 0, hlog, NULL, 0);
+    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 0, hlog, NULL, NULL, 0);
     ASSERT_EQ(0, merr_errno(err));
 
     err = mpool_mblock_read(mpool, blk.bk_blkid, iov, NELEM(iov), 0);
@@ -179,7 +179,7 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, add_ptomb_success, test_pre, test_
     err = add_ptomb(bld, HSE_KVS_PFX_LEN_MAX, 9, &pfx);
     ASSERT_EQ(0, merr_errno(err));
 
-    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 1, hlog, NULL, 0);
+    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 1, hlog, NULL, NULL, 0);
     ASSERT_EQ(0, merr_errno(err));
 
     err = mpool_mblock_read(mpool, blk.bk_blkid, iov, NELEM(iov), 0);
@@ -231,7 +231,7 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, add_ptomb_success, test_pre, test_
         }
     }
 
-    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 190, hlog, NULL, 0);
+    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 190, hlog, NULL, NULL, 0);
     ASSERT_EQ(0, merr_errno(err));
 
     err = mpool_mblock_read(mpool, blk.bk_blkid, iov, NELEM(iov), 0);
@@ -261,7 +261,7 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, finish_null_hlog, test_pre, test_p
     err = hbb_create(&bld, cn, NULL);
     ASSERT_EQ(0, merr_errno(err));
 
-    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 0, NULL, NULL, 0);
+    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 0, NULL, NULL, NULL, 0);
     ASSERT_EQ(EINVAL, merr_errno(err));
 
     hbb_destroy(bld);


### PR DESCRIPTION
- Fix ptomb handling in kvset split
- Optimize node split to drop contiguous ptomb-only kvsets from both the left and right output nodes, starting from the oldest kvset
- Fix kvset_get_max_key() and the split-key algorithm to correctly handle ptomb-only kvsets
- Add compaction rules for a ptomb-only node and ptomb-only kvsets

Signed-off-by: Nabeel M Mohamed <nmeeramohide@micron.com>