### PR TITLE
Fix a few -Wconversion warnings

### DIFF
--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -75,7 +75,7 @@ hse_lowmem_adjust(unsigned long *memgb)
     hse_meminfo(NULL, &mavail, 30);
 
     if (mavail <= HSE_LOWMEM_THRESHOLD_GB_DFLT) {
-        uint32_t scale = ikvdb_lowmem_scale(mavail);
+        unsigned long scale = ikvdb_lowmem_scale(mavail);
 
         /* Scale various caches based on the available memory */
         if (hse_gparams.gp_c0kvs_ccache_sz_max == gpdef.gp_c0kvs_ccache_sz_max)

--- a/lib/cn/csched.c
+++ b/lib/cn/csched.c
@@ -58,7 +58,7 @@ csched_throttle_sensor(struct csched *handle, struct throttle_sensor *sensor)
 }
 
 void
-csched_compact_request(struct csched *handle, int flags)
+csched_compact_request(struct csched *handle, unsigned int flags)
 {
     sp3_compact_request(handle, flags);
 }

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -2233,7 +2233,7 @@ sp3_throttle_sensor(struct csched *handle, struct throttle_sensor *sensor)
 }
 
 void
-sp3_compact_request(struct csched *handle, int flags)
+sp3_compact_request(struct csched *handle, unsigned int flags)
 {
     struct sp3 *sp = (struct sp3 *)handle;
 

--- a/lib/cn/csched_sp3.h
+++ b/lib/cn/csched_sp3.h
@@ -70,7 +70,7 @@ void
 sp3_throttle_sensor(struct csched *handle, struct throttle_sensor *sensor);
 
 void
-sp3_compact_request(struct csched *handle, int flags);
+sp3_compact_request(struct csched *handle, unsigned int flags);
 
 void
 sp3_compact_status_get(struct csched *handle, struct hse_kvdb_compact_status *status);

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -80,7 +80,7 @@ struct kvset {
     u64           ks_nodeid;
     u32           ks_vmin;
     u32           ks_vmax;
-    u32           ks_vra_len;
+    uint64_t      ks_vra_len;
     uint32_t      ks_compc;
 
     struct kvs_rparams *ks_rp;
@@ -108,7 +108,7 @@ struct kvset {
 
     struct key_disc ks_kdisc_max; /* max key in kvset */
     struct key_disc ks_kdisc_min; /* min key in kvset */
-    int             ks_lcp;       /* longest common prefix */
+    size_t          ks_lcp;       /* longest common prefix */
 
     struct kvset_hblk ks_hblk;
     struct mpool_mcache_map *ks_hmap; /* hblock mcache map */

--- a/lib/cn/wbt_reader.c
+++ b/lib/cn/wbt_reader.c
@@ -749,7 +749,6 @@ wbtr_read_vref(
     const void              *base,
     const struct wbt_desc   *wbd,
     const struct kvs_ktuple *kt,
-    uint                     lcp,
     uint64_t                 seq,
     enum key_lookup_res     *lookup_res,
     struct vgmap            *vgmap,

--- a/lib/cn/wbt_reader.h
+++ b/lib/cn/wbt_reader.h
@@ -64,7 +64,6 @@ struct wbti {
  * @base: base address of the block
  * @wbd: wbtree descriptor
  * @kt: key to search for
- * @lcp: longest common prefix common to %kt and all keys in the kblock
  * @lookup_res: (output) one of NOT_FOUND, FOUND_VAL,
  *              or FOUND_TMB (tombstone)
  * @vref: (output) value metadata if found
@@ -75,7 +74,6 @@ wbtr_read_vref(
     const void *base,
     const struct wbt_desc *wbd,
     const struct kvs_ktuple *kt,
-    uint lcp,
     u64 seq,
     enum key_lookup_res *lookup_res,
     struct vgmap *vgmap,

--- a/lib/include/hse_ikvdb/csched.h
+++ b/lib/include/hse_ikvdb/csched.h
@@ -160,7 +160,7 @@ csched_throttle_sensor(struct csched *csched, struct throttle_sensor *input);
 
 /* MTF_MOCK */
 void
-csched_compact_request(struct csched *handle, int flags);
+csched_compact_request(struct csched *handle, unsigned int flags);
 
 /* MTF_MOCK */
 void

--- a/lib/include/hse_ikvdb/encoders.h
+++ b/lib/include/hse_ikvdb/encoders.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_KVDB_CN_ENCODERS_H

--- a/lib/include/hse_ikvdb/ikvdb.h
+++ b/lib/include/hse_ikvdb/ikvdb.h
@@ -589,7 +589,7 @@ merr_t
 ikvdb_kvs_cursor_destroy(struct hse_kvs_cursor *cursor);
 
 void
-ikvdb_compact(struct ikvdb *self, int flags);
+ikvdb_compact(struct ikvdb *self, unsigned int flags);
 
 /* [HSE_REVISIT] - the ikvdb layer needs its own struct */
 
@@ -616,8 +616,8 @@ ikvdb_kvdb_handle(struct ikvdb_impl *self);
 merr_t
 ikvdb_kvs_query_tree(struct hse_kvs *kvs, struct yaml_context *yc, bool blkids, bool nodesonly);
 
-uint32_t
-ikvdb_lowmem_scale(uint32_t memgb);
+unsigned long
+ikvdb_lowmem_scale(unsigned long memgb);
 
 merr_t
 ikvdb_pmem_only_from_cparams(

--- a/lib/include/hse_ikvdb/omf_kmd.h
+++ b/lib/include/hse_ikvdb/omf_kmd.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_KVDB_OMF_KMD_H
@@ -155,7 +155,7 @@ kmd_add_cval(void *kmd, size_t *off, u64 seq, uint vbidx, uint vboff, uint vlen,
     encode_hg32_1024m(kmd, off, complen);
 }
 
-static inline uint
+static inline uint64_t
 kmd_count(const void *kmd, size_t *off)
 {
     return decode_hg32_1024m(kmd, off);

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -1304,10 +1304,10 @@ ikvdb_cndb_open(struct ikvdb_impl *self, u64 *seqno, u64 *ingestid, u64 *txhoriz
     return err;
 }
 
-uint32_t
-ikvdb_lowmem_scale(uint32_t memgb)
+unsigned long
+ikvdb_lowmem_scale(unsigned long memgb)
 {
-    return max_t(uint, 1, roundup_pow_of_two(memgb) / HSE_LOWMEM_THRESHOLD_GB_MIN);
+    return max_t(unsigned long, 1, roundup_pow_of_two(memgb) / HSE_LOWMEM_THRESHOLD_GB_MIN);
 }
 
 /**
@@ -3074,7 +3074,7 @@ ikvdb_kvs_cursor_destroy(struct hse_kvs_cursor *cur)
 }
 
 void
-ikvdb_compact(struct ikvdb *handle, int flags)
+ikvdb_compact(struct ikvdb *handle, unsigned int flags)
 {
     struct ikvdb_impl *self = ikvdb_h2r(handle);
 

--- a/lib/logging/lib/logging.c
+++ b/lib/logging/lib/logging.c
@@ -192,7 +192,7 @@ log_level_from_string(const char *name)
 
     name = strcasestr(list, name);
     if (name)
-        return (name - list) / 8;
+        return (int)((uintptr_t)name - (uintptr_t)list) / 8;
 
     return LOG_DEBUG;
 }

--- a/lib/util/include/hse_util/keycmp.h
+++ b/lib/util/include/hse_util/keycmp.h
@@ -30,7 +30,7 @@ keycmp(const void *key1, u32 len1, const void *key2, u32 len2)
      */
     size_t len = len1 < len2 ? len1 : len2;
     int    rc = memcmp(key1, key2, len);
-    return rc == 0 ? len1 - len2 : rc;
+    return rc == 0 ? (int)(len1 - len2) : rc;
 }
 
 /*

--- a/lib/util/include/hse_util/table.h
+++ b/lib/util/include/hse_util/table.h
@@ -65,7 +65,7 @@ table_len(struct table *tab)
  * @n:   index into table
  */
 static HSE_ALWAYS_INLINE void *
-table_at(struct table *tab, int n)
+table_at(struct table *tab, uint n)
 {
     if (!tab || !tab->data || n > tab->capacity)
         return NULL;

--- a/tests/framework/include/mtf/common.h
+++ b/tests/framework/include/mtf/common.h
@@ -73,7 +73,7 @@ struct mtf_test_coll_info {
     const char *         tci_failed_tests[___MTF_MAX_UTEST_INSTANCES];
     enum mtf_test_result tci_test_results[___MTF_MAX_UTEST_INSTANCES];
     void *               tci_outbuf;
-    int                  tci_outbuf_len;
+    size_t               tci_outbuf_len;
     unsigned long        tci_outbuf_pos;
 
     void *tci_rock;
@@ -89,18 +89,18 @@ inner_mtf_print(struct mtf_test_coll_info *tci, const char *fmt_str, ...)
 {
     va_list args;
     char *  tgt = tci->tci_outbuf + tci->tci_outbuf_pos;
-    int     rem = tci->tci_outbuf_len - tci->tci_outbuf_pos;
+    size_t  rem = tci->tci_outbuf_len - tci->tci_outbuf_pos;
     int     bc;
 
     va_start(args, fmt_str);
     bc = vsnprintf(tgt, rem - 1, fmt_str, args);
     va_end(args);
 
-    if (bc >= rem) {
+    if (bc >= rem || bc < 0) {
         *tgt = 0;
         return -1;
     } else {
-        tci->tci_outbuf_pos += bc;
+        tci->tci_outbuf_pos += (size_t)bc;
         return 0;
     }
 }

--- a/tests/unit/cn/wbt_reader_test.c
+++ b/tests/unit/cn/wbt_reader_test.c
@@ -105,7 +105,7 @@ t_wbtr_read_vref_helper(struct mtf_test_info *lcl_ti, const char *kblock_image_f
         ktuple.kt_len = strlen(keybuf);
         ktuple.kt_data = keybuf;
 
-        wbtr_read_vref(blkdesc.map_base, &desc, &ktuple, 0, seqno, &lookup_res, NULL, &vref);
+        wbtr_read_vref(blkdesc.map_base, &desc, &ktuple, seqno, &lookup_res, NULL, &vref);
         if (i < nkeys)
             ASSERT_EQ(FOUND_VAL, lookup_res);
         else

--- a/tests/unit/cn/wbt_test.c
+++ b/tests/unit/cn/wbt_test.c
@@ -291,7 +291,7 @@ get_verify(struct mtf_test_info *lcl_ti, void *tree, struct wbt_hdr_omf *hdr, st
         key2kobj(&ko_ref, k->kdata, k->klen);
 
         lookup_res = NOT_FOUND;
-        err = wbtr_read_vref(kbd.map_base, &wbd, &kt, 0, 1, &lookup_res, NULL, &vref);
+        err = wbtr_read_vref(kbd.map_base, &wbd, &kt, 1, &lookup_res, NULL, &vref);
         ASSERT_EQ_RET(0, err, 1);
 
         bool found = ref_tree_get(rtree, k->kdata, k->klen);


### PR DESCRIPTION
Wanted to play around with it, and we have a lot of issues. Some of them are pretty bad too. uint -> int -> uint type stuff. Crazy!

Obviously it is hard to throw -Wconversion on all at once, so here is an attempt at fixing a few issues that were pretty easy to reason about.

Signed-off-by: Tristan Partin <tpartin@micron.com>
