### PR TITLE
Add HSE_KVS_PUT_VCOMP_ON

### DIFF
--- a/include/hse/flags.h
+++ b/include/hse/flags.h
@@ -19,6 +19,7 @@ extern "C" {
 /* hse_kvs_put() flags */
 #define HSE_KVS_PUT_PRIO      (1u << 0)
 #define HSE_KVS_PUT_VCOMP_OFF (1u << 1)
+#define HSE_KVS_PUT_VCOMP_ON  (1u << 2)
 
 /* hse_kvs_cursor_create() flags */
 #define HSE_CURSOR_CREATE_REV (1u << 0)

--- a/include/hse/hse.h
+++ b/include/hse/hse.h
@@ -693,15 +693,20 @@ hse_kvs_prefix_delete(
  * issue. On the other hand, doing 1K small puts per second marked as PRIO is
  * almost certainly fine.
  *
- * If compression is enabled for the given kvs, then hse_kvs_put() will attempt
- * to compress the value unless the HSE_KVS_PUT_VCOMP_OFF flag is given.
+ * If compression is on by default for the given kvs, then hse_kvs_put() will
+ * attempt to compress the value unless the HSE_KVS_PUT_VCOMP_OFF flag is given.
  * Otherwise, the HSE_KVS_PUT_VCOMP_OFF flag is ignored.
+ *
+ * If compression is off by default for the given kvs, then hse_kvs_put() will
+ * not attempt to compress a value unless the HSE_KVS_PUT_VCOMP_ON flag is
+ * given. Otherwise, the HSE_KVS_PUT_VCOMP_ON flag is ignored.
  *
  * @note This function is thread safe.
  *
  * <b>Flags:</b>
  * @arg HSE_KVS_PUT_PRIO - Operation will not be throttled.
  * @arg HSE_KVS_PUT_VCOMP_OFF - Value will not be compressed.
+ * @arg HSE_KVS_PUT_VCOMP_ON - Value may be compressed.
  *
  * @param kvs: KVS handle from hse_kvdb_kvs_open().
  * @param flags: Flags for operation specialization.

--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -39,7 +39,8 @@
 
 #define HSE_KVDB_COMPACT_MASK  (HSE_KVDB_COMPACT_CANCEL | HSE_KVDB_COMPACT_SAMP_LWM)
 #define HSE_KVDB_SYNC_MASK     (HSE_KVDB_SYNC_ASYNC)
-#define HSE_KVS_PUT_MASK       (HSE_KVS_PUT_PRIO | HSE_KVS_PUT_VCOMP_OFF)
+#define HSE_KVS_PUT_MASK       (HSE_KVS_PUT_PRIO | HSE_KVS_PUT_VCOMP_OFF | HSE_KVS_PUT_VCOMP_ON)
+#define HSE_KVS_PUT_VCOMP_MASK (HSE_KVS_PUT_VCOMP_OFF | HSE_KVS_PUT_VCOMP_ON)
 #define HSE_CURSOR_CREATE_MASK (HSE_CURSOR_CREATE_REV)
 
 /* clang-format on */
@@ -863,7 +864,8 @@ hse_kvs_put(
     struct kvs_vtuple vt;
     merr_t            err;
 
-    if (HSE_UNLIKELY(!handle || !key || (val_len > 0 && !val) || flags & ~HSE_KVS_PUT_MASK))
+    if (HSE_UNLIKELY(!handle || !key || (val_len > 0 && !val) || flags & ~HSE_KVS_PUT_MASK ||
+            (flags & HSE_KVS_PUT_VCOMP_MASK) == HSE_KVS_PUT_VCOMP_MASK))
         return merr(EINVAL);
 
     if (HSE_UNLIKELY(key_len > HSE_KVS_KEY_LEN_MAX))

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -1054,11 +1054,10 @@ cn_open(
         vszsuf = suffixes[vshift];
 
         log_info(
-            "opened kvs %s/%s cnid %lu pfx_len %u vcomp %u,%u"
+            "opened kvs %s/%s cnid %lu pfx_len %u vcomp %u"
             " hb %lu%c/%lu kb %lu%c/%lu vb %lu%c/%lu %s%s%s%s%s%s",
             cn->cn_kvdb_alias, cn->cn_kvsname, (ulong)cnid,
-            cn->cp->pfx_len,
-            cn->rp->value_compression, cn->rp->vcompmin,
+            cn->cp->pfx_len, cn->rp->compression.algorithm,
             (ulong)kvs_stats.kst_halen >> (hshift * 10), hszsuf, (ulong)kvs_stats.kst_hblks,
             (ulong)kvs_stats.kst_kalen >> (kshift * 10), kszsuf, (ulong)kvs_stats.kst_kblks,
             (ulong)kvs_stats.kst_valen >> (vshift * 10), vszsuf, (ulong)kvs_stats.kst_vblks,

--- a/lib/cn/cn_metrics.h
+++ b/lib/cn/cn_metrics.h
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020,2022 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_KVDB_CN_METRICS_H
 #define HSE_KVDB_CN_METRICS_H
+
+#include <stdint.h>
+#include <sys/types.h>
 
 /**
  * Kvset statistics.

--- a/lib/cn/vcomp_params.c
+++ b/lib/cn/vcomp_params.c
@@ -1,11 +1,11 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2020-2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2020-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <hse_ikvdb/vcomp_params.h>
 #include <hse_util/compression_lz4.h>
 
 const struct compress_ops *vcomp_compress_ops[VCOMP_ALGO_COUNT] = {
-    NULL, &compress_lz4_ops,
+    &compress_lz4_ops,
 };

--- a/lib/include/hse_ikvdb/kvs_rparams.h
+++ b/lib/include/hse_ikvdb/kvs_rparams.h
@@ -70,8 +70,10 @@ struct kvs_rparams {
 
     uint64_t capped_evict_ttl;
 
-    uint32_t             vcompmin;
-    enum vcomp_algorithm value_compression;
+    struct {
+        enum vcomp_default deflt;
+        enum vcomp_algorithm algorithm;
+    } compression;
 
     char mclass_policy[HSE_MPOLICY_NAME_LEN_MAX];
 };

--- a/lib/include/hse_ikvdb/tuple.h
+++ b/lib/include/hse_ikvdb/tuple.h
@@ -157,7 +157,7 @@ kvs_vtuple_vlen(const struct kvs_vtuple *vt)
     const uint32_t clen = vt->vt_xlen >> 32;
     const uint32_t vlen = vt->vt_xlen & 0xfffffffful;
 
-    return clen ?: vlen;
+    return clen ? clen : vlen;
 }
 
 static HSE_ALWAYS_INLINE uint32_t

--- a/lib/include/hse_ikvdb/vcomp_params.h
+++ b/lib/include/hse_ikvdb/vcomp_params.h
@@ -1,21 +1,31 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_VCOMP_PARAMS_H
 #define HSE_VCOMP_PARAMS_H
 
-#define VCOMP_PARAM_NONE    "none"
-#define VCOMP_PARAM_LZ4     "lz4"
+#include <stdint.h>
 
-enum vcomp_algorithm
-{
-	VCOMP_ALGO_NONE,
-	VCOMP_ALGO_LZ4,
+#define VCOMP_PARAM_OFF "off"
+#define VCOMP_PARAM_ON  "on"
+#define VCOMP_PARAM_LZ4 "lz4"
+
+enum vcomp_default {
+    VCOMP_DEFAULT_OFF,
+    VCOMP_DEFAULT_ON,
 };
 
-#define VCOMP_ALGO_MIN   VCOMP_ALGO_NONE
+#define VCOMP_DEFAULT_MIN   VCOMP_DEFAULT_OFF
+#define VCOMP_DEFAULT_MAX   VCOMP_DEFAULT_ON
+#define VCOMP_DEFAULT_COUNT (VCOMP_DEFAULT_MAX + 1)
+
+enum vcomp_algorithm {
+    VCOMP_ALGO_LZ4,
+};
+
+#define VCOMP_ALGO_MIN   VCOMP_ALGO_LZ4
 #define VCOMP_ALGO_MAX   VCOMP_ALGO_LZ4
 #define VCOMP_ALGO_COUNT (VCOMP_ALGO_MAX + 1)
 

--- a/lib/kvdb/kvdb_kvs.h
+++ b/lib/kvdb/kvdb_kvs.h
@@ -8,6 +8,7 @@
 
 #include <hse/limits.h>
 
+#include <hse_ikvdb/vcomp_params.h>
 #include <hse_util/atomic.h>
 #include <hse_util/inttypes.h>
 #include <hse_util/list.h>
@@ -22,7 +23,6 @@ struct kvdb_kvs;
  * struct kvdb_kvs - Describes a kvs in the kvdb - open or closed
  * @kk_ikvs:         kvs handle. NULL if closed.
  * @kk_parent:       pointer to parent kvdb_impl instance.
- * @kk_vcompmin:     value length above which compression is considered
  * @kk_vcompbnd:     compression output buffer size estimate for tls_vbuf[]
  * @kk_vcompress:    ptr to value compression function
  * @kk_cnid:         id of the cn associated with kvdb.
@@ -36,7 +36,7 @@ struct kvdb_kvs {
     struct ikvs            *kk_ikvs;
     struct viewset         *kk_viewset;
     struct ikvdb_impl      *kk_parent;
-    u32                     kk_vcompmin;
+    enum vcomp_default      kk_vcomp_default;
     u32                     kk_vcompbnd;
     compress_op_compress_t *kk_vcompress;
     u64                     kk_cnid;

--- a/tests/functional/api/kvs_api_test.c
+++ b/tests/functional/api/kvs_api_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <errno.h>
@@ -13,6 +13,8 @@
 #include <mtf/framework.h>
 
 #include <hse_util/base.h>
+#include <hse_ikvdb/limits.h>
+#include <hse_ikvdb/vcomp_params.h>
 
 struct hse_kvdb *kvdb_handle;
 struct hse_kvs  *kvs_handle;
@@ -749,6 +751,29 @@ MTF_DEFINE_UTEST(kvs_api_test, put_val_len_too_long)
     err = hse_kvs_put(
         (struct hse_kvs *)-1, 0, NULL, (void *)-1, 1, (void *)-1, HSE_KVS_VALUE_LEN_MAX + 1);
     ASSERT_EQ(EMSGSIZE, hse_err_to_errno(err));
+}
+
+MTF_DEFINE_UTEST_PREPOST(kvs_api_test, put_vcomp_on, kvs_setup_with_data, kvs_teardown)
+{
+    hse_err_t err;
+    char buf[CN_SMALL_VALUE_THRESHOLD];
+
+    memset(buf, 1, sizeof(buf));
+
+    err = hse_kvs_put(kvs_handle, HSE_KVS_PUT_VCOMP_ON, NULL, "vcomp", 5, buf, sizeof(buf));
+    ASSERT_EQ(0, merr_errno(err));
+}
+
+MTF_DEFINE_UTEST_PREPOST(kvs_api_test, put_vcomp_exclusivity, kvs_setup_with_data, kvs_teardown)
+{
+    hse_err_t err;
+    char buf[CN_SMALL_VALUE_THRESHOLD];
+
+    memset(buf, 1, sizeof(buf));
+
+    err = hse_kvs_put(kvs_handle, HSE_KVS_PUT_VCOMP_ON | HSE_KVS_PUT_VCOMP_OFF, NULL, "vcomp", 5,
+        buf, sizeof(buf));
+    ASSERT_EQ(EINVAL, merr_errno(err));
 }
 
 MTF_DEFINE_UTEST(kvs_api_test, prefix_probe_null_kvs)

--- a/tests/functional/kvs_compressed_values_take_less_space.py
+++ b/tests/functional/kvs_compressed_values_take_less_space.py
@@ -22,7 +22,7 @@ try:
         kvs1_ctx = lifecycle.KvsContext(kvdb, kvs1_name)
         kvs1 = stack.enter_context(kvs1_ctx)
         kvs2_ctx = lifecycle.KvsContext(kvdb, kvs2_name).rparams(
-            "compression.value.algorithm=lz4"
+            "compression.algorithm=lz4"
         )
         kvs2 = stack.enter_context(kvs2_ctx)
 

--- a/tests/functional/kvs_compression_flags.py
+++ b/tests/functional/kvs_compression_flags.py
@@ -19,7 +19,7 @@ try:
         kvs1_ctx = lifecycle.KvsContext(kvdb, "no-compression")
         kvs1 = stack.enter_context(kvs1_ctx)
         kvs2_ctx = lifecycle.KvsContext(kvdb, "compression").rparams(
-            "compression.value.algorithm=lz4"
+            "compression.algorithm=lz4"
         )
         kvs2 = stack.enter_context(kvs2_ctx)
 

--- a/tests/unit/kvdb/ikvdb_test.c
+++ b/tests/unit/kvdb/ikvdb_test.c
@@ -2036,10 +2036,10 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, get_kvs_param, test_pre, test_post)
     ASSERT_NE(NULL, kvs);
     mapi_inject_unset(mapi_idx_mpool_mclass_props_get);
 
-    err = ikvdb_kvs_param_get(kvs, "compression.value.algorithm", buf, sizeof(buf), &needed_sz);
+    err = ikvdb_kvs_param_get(kvs, "compression.algorithm", buf, sizeof(buf), &needed_sz);
     ASSERT_EQ(0, merr_errno(err));
-    ASSERT_STREQ("\"none\"", buf);
-    ASSERT_EQ(6, needed_sz);
+    ASSERT_STREQ("\"lz4\"", buf);
+    ASSERT_EQ(5, needed_sz);
 
     err = ikvdb_kvs_param_get(kvs, "prefix.length", buf, sizeof(buf), &needed_sz);
     ASSERT_EQ(0, merr_errno(err));

--- a/tools/kvt/kvt.c
+++ b/tools/kvt/kvt.c
@@ -721,7 +721,7 @@ int
 parm_vec_init(void)
 {
     char *txn = testtxn ? "transactions.enabled=true" : "transactions.enabled=false";
-    char *cmp = vcomp ? "compression.value.algorithm=lz4" : "";
+    char *cmp = vcomp ? "compression.algorithm=lz4" : "";
     char rids_pfx[64] = {};
     int rc = 0;
 


### PR DESCRIPTION
VCOMP_ON will allow a user to compress a value even if compression is off by default.

This change necessitated removing compression.value.algorithm=none in favor of compression.value.default=on/off. The logic previously around setting up the compression infrastructure would have not worked in the previous way of setting up value compression.

Signed-off-by: Tristan Partin <tpartin@micron.com>
