### PR TITLE
Rough-in spill/join synchronization

### DIFF
--- a/lib/cn/cn_metrics.h
+++ b/lib/cn/cn_metrics.h
@@ -26,6 +26,7 @@
 struct kvset_stats {
     uint64_t kst_keys;      //<! number of keys
     uint64_t kst_tombs;     //<! number of tombtones
+    uint64_t kst_ptombs;    //<! number of prefix tombtones
     uint64_t kst_halen;     //<! sum of mpr_alloc_cap for all hblocks
     uint64_t kst_hwlen;     //<! sum of mpr_write_len for all hblocks
     uint64_t kst_kalen;     //<! sum of mpr_alloc_cap for all kblocks
@@ -124,6 +125,15 @@ static inline uint64_t
 cn_ns_tombs(const struct cn_node_stats *ns)
 {
     return ns->ns_kst.kst_tombs;
+}
+
+/**
+ * Number of prefix tombstones in node.
+ */
+static inline uint64_t
+cn_ns_ptombs(const struct cn_node_stats *ns)
+{
+    return ns->ns_kst.kst_ptombs;
 }
 
 /**

--- a/lib/cn/cn_tree_compact.h
+++ b/lib/cn/cn_tree_compact.h
@@ -34,6 +34,7 @@ enum cn_action {
     CN_ACTION_COMPACT_KV,
     CN_ACTION_SPILL,
     CN_ACTION_SPLIT,
+    CN_ACTION_JOIN,
 };
 
 static inline const char *
@@ -50,6 +51,8 @@ cn_action2str(enum cn_action action)
         return "spill";
     case CN_ACTION_SPLIT:
         return "split";
+    case CN_ACTION_JOIN:
+        return "join";
     }
 
     return "invalid";
@@ -135,6 +138,7 @@ struct cn_compaction_work {
     uint64_t                 cw_sgen;
     struct cn_tree *         cw_tree;
     struct cn_tree_node *    cw_node;
+    struct cn_tree_node *    cw_join;
     struct kvset_list_entry *cw_mark;
     struct cn_node_stats     cw_ns;
     uint                     cw_kvset_cnt;

--- a/lib/cn/csched_sp3.h
+++ b/lib/cn/csched_sp3.h
@@ -16,8 +16,6 @@
 
 /* MTF_MOCK_DECL(csched_sp3) */
 
-#define CN_THROTTLE_MAX (THROTTLE_SENSOR_SCALE_MED + 50)
-
 struct kvdb_rparams;
 struct mpool;
 struct kvdb_health;
@@ -37,11 +35,14 @@ struct sp3_node {
     struct sp3_rbe   spn_rbe[wtype_MAX];
     struct list_head spn_rlink;
     struct list_head spn_alink;
-    struct list_head spn_dlink;
     bool             spn_initialized;
     uint             spn_cgen;
 };
 
+/* Each sp3_tree maintains a list of dirty nodes (spt_dnode_listv).
+ * If the dirty node list is not empty then the tree will be linked
+ * into sp's dirty tree list (sp_dtree_listv) via spt_dtree_linkv.
+ */
 struct sp3_tree {
     struct list_head spt_tlink;
     uint             spt_job_cnt;
@@ -49,9 +50,8 @@ struct sp3_tree {
     atomic_ulong     spt_ingest_alen;
     atomic_ulong     spt_ingest_wlen;
 
-    /* Dirty node list */
-    struct mutex     spt_dlist_lock;
-    struct list_head spt_dlist;;
+    struct list_head spt_dnode_listv[2] HSE_L1D_ALIGNED;
+    struct list_head spt_dtree_linkv[2];
 };
 
 /* MTF_MOCK */

--- a/lib/cn/csched_sp3_work.h
+++ b/lib/cn/csched_sp3_work.h
@@ -40,9 +40,9 @@
 #define SP3_LCOMP_RUNLEN_MAX_MAX        (UINT8_MAX)
 #define SP3_LCOMP_RUNLEN_MAX_DEFAULT    (12u)
 
-#define SP3_LCOMP_SPLIT_PCT_MIN         (1u)
-#define SP3_LCOMP_SPLIT_PCT_MAX         (UINT_MAX)
-#define SP3_LCOMP_SPLIT_PCT_DEFAULT     (100u)
+#define SP3_LCOMP_JOIN_PCT_MIN         (0u)
+#define SP3_LCOMP_JOIN_PCT_MAX         (100u)
+#define SP3_LCOMP_JOIN_PCT_DEFAULT     (75u)
 
 #define SP3_LCOMP_SPLIT_KEYS_MIN        (1u)
 #define SP3_LCOMP_SPLIT_KEYS_MAX        (UINT_MAX)
@@ -61,6 +61,7 @@ enum sp3_work_type {
     wtype_garbage,      /* leaf nodes: kv-compact to reduce garbage */
     wtype_scatter,      /* leaf nodes: kv-compact to reduce vgroup scatter */
     wtype_split,        /* leaf nodes: split to eliminate large nodes */
+    wtype_join,         /* leaf nodes: join to eliminate small nodes */
     wtype_idle,         /* root+leaf nodes: kv-compact idle nodes */
     wtype_root,         /* root node: spill to leaves */
     wtype_MAX
@@ -71,7 +72,7 @@ struct sp3_thresholds {
     uint8_t  rspill_runlen_min;
     uint8_t  rspill_runlen_max;
     uint8_t  lcomp_runlen_max;
-    uint     lcomp_split_pct;     /* leaf node split-by-clen percentage threshold */
+    uint     lcomp_join_pct;      /* leaf node join-by-wlen percentage threshold */
     uint     lcomp_split_keys;    /* leaf node split-by-keys threshold */
     uint8_t  lscat_hwm;
     uint8_t  lscat_runlen_max;
@@ -90,6 +91,13 @@ sp3_work(
     struct sp3_thresholds      *thresholds,
     uint                        debug,
     struct cn_compaction_work **wp);
+
+
+struct cn_tree_node *
+sp3_work_joinable(struct cn_tree_node *right, const struct sp3_thresholds *thresh);
+
+bool
+sp3_work_splittable(struct cn_tree_node *tn, const struct sp3_thresholds *thresh);
 
 #if HSE_MOCKING
 #include "csched_sp3_work_ut.h"

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -596,6 +596,7 @@ kvset_open2(
         /* kvset_stats from kblocks */
         ks->ks_st.kst_halen += props.mpr_alloc_cap;
         ks->ks_st.kst_hwlen += props.mpr_write_len;
+        ks->ks_st.kst_ptombs += ks->ks_hblk.kh_metrics.hm_nptombs;
     }
 
     ks->ks_seqno_min = ks->ks_hblk.kh_seqno_min;
@@ -1826,6 +1827,7 @@ kvset_stats_add(const struct kvset_stats *add, struct kvset_stats *result)
 {
     result->kst_keys += add->kst_keys;
     result->kst_tombs += add->kst_tombs;
+    result->kst_ptombs += add->kst_ptombs;
     result->kst_kvsets += add->kst_kvsets;
 
     result->kst_hblks += add->kst_hblks;

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -190,7 +190,7 @@ cn_subspill(
     struct spillctx           *sctx,
     struct cn_tree_node       *node,
     uint64_t                   node_dgen,
-    void                      *ekey,
+    const void               *ekey,
     uint                       eklen)
 {
     struct cn_compaction_work *w = sctx->work;

--- a/lib/cn/spill.h
+++ b/lib/cn/spill.h
@@ -61,7 +61,7 @@ cn_subspill(
     struct spillctx           *sctx,
     struct cn_tree_node       *node,
     uint64_t                   node_dgen,
-    void                      *ekey,
+    const void                *ekey,
     uint                       eklen);
 
 

--- a/lib/include/hse_ikvdb/csched.h
+++ b/lib/include/hse_ikvdb/csched.h
@@ -62,6 +62,7 @@ enum cn_rule {
     CN_RULE_SPLIT,          /* big leaf (near split threshold, split in progress) */
     CN_RULE_LSPLIT,         /* left node kvset after a split */
     CN_RULE_RSPLIT,         /* right ndoe kvset after a split */
+    CN_RULE_JOIN,           /* prev node is very small */
 };
 
 static inline const char *
@@ -110,6 +111,8 @@ cn_rule2str(enum cn_rule rule)
         return "left";
     case CN_RULE_RSPLIT:
         return "right";
+    case CN_RULE_JOIN:
+        return "join";
     }
 
     return "invalid";

--- a/tests/unit/cn/csched_sp3_test.c
+++ b/tests/unit/cn/csched_sp3_test.c
@@ -161,6 +161,8 @@ new_tree(uint fanout)
         if (!tn)
             return NULL;
 
+        tn->tn_route_node = (void *)(-1);
+
         list_add_tail(&tn->tn_link, &tt->tree->ct_nodes);
     }
 


### PR DESCRIPTION
- Move per-node tn_ss_lock and tn_ss_cv to tree level ct_ss_lock and ct_ss_cv.
- Rough-in spill/join synchronization...
- Allow small nodes with one or more kvsets to be joined.
- Use edge key of previous subspill to find next route node.
