### PR TITLE
Fixed ptomb propagation bug in root spill

### DIFF
--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -3647,11 +3647,11 @@ kvset_iter_release(struct kv_iterator *handle)
 
     wbti_destroy(iter->wbti);
     wbti_destroy(iter->pti);
-    kvset_put_ref(iter->ks);
 
     kvset_iter_free_buffers(iter, &iter->kreader);
     kvset_iter_free_buffers(iter, &iter->ptreader);
 
+    kvset_put_ref(iter->ks);
     kmem_cache_free(kvset_iter_cache, iter);
 }
 

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -239,13 +239,14 @@ cn_subspill(
     ss->ss_added = false;
     ss->ss_work = w;
 
-    if (!sctx->more || key_obj_cmp(&sctx->curr->kobj, &ekobj) > 0) {
-        if (!sctx->pt_set)
-            return 0; /* Nothing to do */
-    }
+    if (!sctx->more)
+        return 0;
 
-    if (!sctx->more || (key_obj_cmp(&sctx->curr->kobj, &ekobj) > 0 && !sctx->pt_set))
-        return 0; /* Nothing to do */
+    /* Proceed only if either the curr key belongs in this leaf node OR there's a ptomb that needs
+     * to be propagated to this child.
+     */
+    if (key_obj_cmp(&sctx->curr->kobj, &ekobj) > 0 && !sctx->pt_set)
+        return 0; /* curr key doesn't belong to this child AND there is no ptomb to propagate */
 
     w->cw_kvsetidv[0] = ss->ss_kvsetid = cndb_kvsetid_mint(cn_tree_get_cndb(w->cw_tree));
 

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -244,6 +244,9 @@ cn_subspill(
             return 0; /* Nothing to do */
     }
 
+    if (!sctx->more || (key_obj_cmp(&sctx->curr->kobj, &ekobj) > 0 && !sctx->pt_set))
+        return 0; /* Nothing to do */
+
     w->cw_kvsetidv[0] = ss->ss_kvsetid = cndb_kvsetid_mint(cn_tree_get_cndb(w->cw_tree));
 
     err = kvset_builder_create(&child, cn_tree_get_cn(w->cw_tree), w->cw_pc, ss->ss_kvsetid);
@@ -258,7 +261,8 @@ cn_subspill(
     /* Add ptomb to 'child' if a ptomb context is carried forward from the
      * previous node spill, i.e., this ptomb spans across multiple children.
      */
-    if (sctx->more && sctx->pt_set && (!w->cw_drop_tombs || sctx->pt_seq > w->cw_horizon)) {
+    assert(sctx->more);
+    if (sctx->pt_set && (!w->cw_drop_tombs || sctx->pt_seq > w->cw_horizon)) {
 
         err = kvset_builder_add_val(child, &sctx->pt_kobj, HSE_CORE_TOMB_PFX, 0, sctx->pt_seq, 0);
         if (!err)
@@ -294,6 +298,9 @@ cn_subspill(
             dbg_prev_idx = 0;
             dbg_nvals_this_key = 0;
             dbg_dup = false;
+
+            if (sctx->pt_set && key_obj_cmp_prefix(&sctx->pt_kobj, &sctx->curr->kobj) != 0)
+                sctx->pt_set = false; /* cached ptomb key is no longer valid */
         }
 
         while (!bg_val) {
@@ -432,8 +439,6 @@ cn_subspill(
                 new_key = false;
                 assert(dbg_prev_idx <= sctx->curr->src->es_sort);
                 continue;
-            } else if (sctx->pt_set && key_obj_cmp_prefix(&sctx->pt_kobj, &sctx->curr->kobj) != 0) {
-                sctx->pt_set = false; /* cached ptomb key is no longer valid */
             }
         }
 


### PR DESCRIPTION
Fix ptomb propagation in rspill | Release kvset ref after freeing kvset iter's buffers

Signed-off-by: Gaurav Ramdasi <10132364+gsramdasi@users.noreply.github.com>

## Description

If a ptomb 'ab' is cached, and binheap returns key az01, the key az01 may cause the subspill to end and move to the next child. Based on the key (az01), we should not rush to invalidate the ptomb ab since the next leaf node may contain keys with the prefix ab.

So invalidate a cached ptomb only after making sure that the new key that is invalidating the ptomb belongs in the current child.

## Issue(s) Addressed
NFSE-5356, NFSE-5352
