### PR TITLE
Use const for memory mapped mblock addresses

### DIFF
--- a/lib/cn/hblock_reader.c
+++ b/lib/cn/hblock_reader.c
@@ -106,7 +106,7 @@ hbr_read_desc(
     uint64_t blkid,
     struct kvs_mblk_desc *mblk_desc)
 {
-    void *base;
+    const void *base;
 
     /* There is only one hblock within the mcache map. */
     base = mpool_mcache_getbase(map, 0);
@@ -199,7 +199,7 @@ hblock_vgroup_map_valid(const struct vgroup_map_omf *omf)
 merr_t
 hbr_read_vgroup_cnt(const struct kvs_mblk_desc *hbd, uint32_t *nvgroups)
 {
-    struct vgroup_map_omf *vgm_omf;
+    const struct vgroup_map_omf *vgm_omf;
 
     if (ev(omf_hbh_vgmap_len_pg(hbd->map_base) == 0)) {
         *nvgroups = 0;
@@ -219,8 +219,8 @@ hbr_read_vgroup_cnt(const struct kvs_mblk_desc *hbd, uint32_t *nvgroups)
 merr_t
 hbr_read_vgroup_map(const struct kvs_mblk_desc *hbd, struct vgmap *vgmap, bool *use_vgmap)
 {
-    struct vgroup_map_omf *vgm_omf;
-    struct vgroup_map_entry_omf *vgme_omf;
+    const struct vgroup_map_omf *vgm_omf;
+    const struct vgroup_map_entry_omf *vgme_omf;
     int i;
 
     *use_vgmap = false;
@@ -255,7 +255,7 @@ void
 hbr_read_ptree(
     const struct kvs_mblk_desc *hbd,
     const struct wbt_desc      *ptd,
-    uint8_t                   **ptree,
+    const uint8_t             **ptree,
     uint32_t                   *ptree_pgc)
 {
     INVARIANT(hbd && ptd && ptree && ptree_pgc);

--- a/lib/cn/hblock_reader.h
+++ b/lib/cn/hblock_reader.h
@@ -144,7 +144,7 @@ void
 hbr_read_ptree(
     const struct kvs_mblk_desc *hbd,
     const struct wbt_desc      *ptd,
-    uint8_t                   **ptree,
+    const uint8_t             **ptree,
     uint32_t                   *ptree_pgc);
 
 #if HSE_MOCKING

--- a/lib/cn/kblock_reader.c
+++ b/lib/cn/kblock_reader.c
@@ -44,7 +44,7 @@ kbr_get_kblock_desc(
     u64                      kblkid,
     struct kvs_mblk_desc    *kblkdesc)
 {
-    void *base;
+    const void *base;
 
     base = mpool_mcache_getbase(map, map_idx);
     if (!base)

--- a/lib/cn/kvs_mblk_desc.h
+++ b/lib/cn/kvs_mblk_desc.h
@@ -14,7 +14,7 @@ struct mpool_mcache_map;
 struct mpool;
 
 struct kvs_mblk_desc {
-    void *                   map_base; /* base address of mcache map */
+    const void *             map_base; /* base address of mcache map */
     struct mpool_mcache_map *map;      /* mcache map */
     uint32_t                 map_idx;  /* index of mblk in map */
     enum hse_mclass          mclass;   /* media class */

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -224,7 +224,7 @@ kvset_hblk_init(
     struct mpool_mcache_map  *map,
     struct vgmap            **vgmap_out,
     bool                     *use_vgmap,
-    uint8_t                 **hlog,
+    const uint8_t           **hlog,
     struct kvset_hblk        *blk)
 {
     struct vgmap *vgmap = NULL;
@@ -306,7 +306,7 @@ kvset_kblk_init(
     struct kvset_kblk *      p)
 {
     struct kvs_mblk_desc * kbd = &p->kb_kblk_desc;
-    struct kblock_hdr_omf *hdr;
+    const struct kblock_hdr_omf *hdr;
     merr_t                 err;
 
     err = kbr_get_kblock_desc(ds, kmap, props, idx, p->kb_kblk.bk_blkid, kbd);
@@ -682,7 +682,7 @@ kvset_open2(
              * who might otherwise try to access it.
              */
 #if defined(HSE_BUILD_DEBUG) && !defined(NDEBUG)
-            mprotect(kb->kb_kblk_desc.map_base, PAGE_SIZE, PROT_NONE);
+            mprotect((void *)kb->kb_kblk_desc.map_base, PAGE_SIZE, PROT_NONE);
 #endif
         }
     }
@@ -1469,8 +1469,9 @@ kvset_lookup_val(struct kvset *ks, struct kvs_vtuple_ref *vref, struct kvs_buf *
 {
     struct vblock_desc *vbd;
     merr_t              err;
-    void               *src, *dst;
-    uint                omlen, copylen;
+    const void         *src;
+    void               *dst;
+    uint               omlen, copylen;
     bool direct;
 
     assert(vref->vr_type == VTYPE_IVAL
@@ -1797,7 +1798,7 @@ kvset_get_tree(struct kvset *ks)
     return ks->ks_tree;
 }
 
-u8 *
+const u8 *
 kvset_get_hlog(struct kvset *ks)
 {
     return ks->ks_hlog;
@@ -3503,7 +3504,7 @@ skip_read_ahead:
     return 0;
 }
 
-static void *
+static const void *
 kvset_iter_get_valptr_mcache(struct kvset_iterator *iter, uint vbidx, uint vboff, uint vlen)
 {
     struct kvset *      ks = iter->ks;

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -372,7 +372,7 @@ const struct kvset_stats *
 kvset_statsp(const struct kvset *ks);
 
 /* MTF_MOCK */
-u8 *
+const u8 *
 kvset_get_hlog(struct kvset *km);
 
 /* MTF_MOCK */

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -97,7 +97,7 @@ struct kvset {
     u64                 ks_kvsetid;
 
     /* new compaction metrics */
-    u8 * ks_hlog;
+    const u8 * ks_hlog;
 
     struct vgmap *ks_vgmap;
     bool          ks_use_vgmap; /* consult vgmap during query/compaction? */

--- a/lib/cn/kvset_split.c
+++ b/lib/cn/kvset_split.c
@@ -609,7 +609,7 @@ hblock_split(
     struct kvset_mblocks *blks_right = result->ks[RIGHT].blks;
     uint32_t num_ptombs, ptree_pgc;
     uint64_t min_seqno, max_seqno;
-    uint8_t *ptree;
+    const uint8_t *ptree;
     merr_t err = 0;
 
     min_seqno = ks->ks_hblk.kh_seqno_min;

--- a/lib/cn/node_split.c
+++ b/lib/cn/node_split.c
@@ -279,7 +279,7 @@ forward_wbt_leaf_iterator_next(struct element_source *source, void **data)
     if (iter->offset.leaf_idx == 0)
         kbr_madvise_wbt_leaf_nodes(&kblk->kb_kblk_desc, desc, MADV_WILLNEED);
 
-    *data = kblk->kb_kblk_desc.map_base + desc->wbd_first_page * PAGE_SIZE +
+    *data = (void *)kblk->kb_kblk_desc.map_base + desc->wbd_first_page * PAGE_SIZE +
         iter->offset.leaf_idx * WBT_NODE_SIZE;
 
     assert(((struct wbt_node_hdr_omf *)(*data))->wbn_magic == WBT_LFE_NODE_MAGIC);

--- a/lib/cn/vblock_reader.c
+++ b/lib/cn/vblock_reader.c
@@ -30,9 +30,9 @@ vbr_desc_read(
     struct mblock_props *    props,
     struct vblock_desc *     vblk_desc)
 {
-    struct vblock_footer_omf *footer;
+    const struct vblock_footer_omf *footer;
     bool     supported;
-    void    *base;
+    const void *base;
     u64      vgroup;
     uint32_t vers;
 
@@ -262,7 +262,7 @@ vbr_madvise(struct vblock_desc *vbd, uint off, uint len, int advice)
 }
 
 /* off, len version */
-void *
+const void *
 vbr_value(struct vblock_desc *vbd, uint vboff, uint vlen)
 {
     assert(vbd->vbd_mblkdesc.map_base);

--- a/lib/cn/vblock_reader.h
+++ b/lib/cn/vblock_reader.h
@@ -132,7 +132,7 @@ vbr_madvise(struct vblock_desc *vbd, uint off, uint len, int advice);
  * @vboff: offset of value within vblock
  * @vlen:  length of value
  */
-void *
+const void *
 vbr_value(struct vblock_desc *vbd, uint vboff, uint vlen);
 
 #endif

--- a/lib/mpool/include/mpool/mpool.h
+++ b/lib/mpool/include/mpool/mpool.h
@@ -497,7 +497,7 @@ mpool_mcache_madvise(
  * pages are not contiguous, return NULL.
  */
 /* MTF_MOCK */
-void *
+const void *
 mpool_mcache_getbase(struct mpool_mcache_map *map, const uint32_t mbidx);
 
 /**

--- a/lib/mpool/src/mcache.c
+++ b/lib/mpool/src/mcache.c
@@ -30,7 +30,7 @@ struct mpool_mcache_map {
     struct mpool *mp;
     size_t        mbidc;
     uint64_t     *mbidv;
-    void        **addrv;
+    const void  **addrv;
     uint32_t     *wlenv;
 };
 
@@ -141,14 +141,14 @@ mpool_mcache_madvise(struct mpool_mcache_map *map, uint mbidx, off_t off, size_t
     }
 
     do {
-        char *addr;
+        const void *addr;
         int   rc;
 
         addr = map->addrv[mbidx];
         if (!addr)
             return merr(EINVAL);
 
-        rc = madvise(addr + off, len, advice);
+        rc = madvise((void*)addr + off, len, advice);
         if (rc)
             return merr(errno);
 
@@ -162,7 +162,7 @@ mpool_mcache_madvise(struct mpool_mcache_map *map, uint mbidx, off_t off, size_t
     return 0;
 }
 
-void *
+const void *
 mpool_mcache_getbase(struct mpool_mcache_map *map, const uint mbidx)
 {
     if (!map || mbidx >= map->mbidc)
@@ -177,9 +177,9 @@ mpool_mcache_getpages(
     const uint               pagec,
     const uint               mbidx,
     const off_t              pagenumv[],
-    void                    *addrv[])
+    const void              *addrv[])
 {
-    char *addr;
+    const void *addr;
     int   i;
 
     if (!map || mbidx >= map->mbidc || !addrv)

--- a/tests/mocks/repository/lib/mock_mpool.c
+++ b/tests/mocks/repository/lib/mock_mpool.c
@@ -351,7 +351,7 @@ _mpool_mcache_munmap(struct mpool_mcache_map *handle)
     map->mapped = 0;
 }
 
-static void *
+static const void *
 _mpool_mcache_getbase(struct mpool_mcache_map *handle, u_int idx)
 {
     merr_t                err;

--- a/tests/unit/cn/vblock_reader_test.c
+++ b/tests/unit/cn/vblock_reader_test.c
@@ -262,7 +262,7 @@ MTF_DEFINE_UTEST_PRE(vblock_reader_test, t_vbr_value, pre)
     uint                     i, vlen = 123, n_entries = 19;
     u8 *                     vblk;
     size_t                   vbsz;
-    void *                   val;
+    const void *             val;
     uint                     vboff;
     struct mblock_props      props;
     uint                     vgroups = 0;


### PR DESCRIPTION
Signed-off-by: Alex Tomlinson <4172734+alexttx@users.noreply.github.com>
