### PR TITLE
Add clang-tidy checking to lib/error and lib/logging

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,9 @@
 ---
 # https://clang.llvm.org/extra/clang-tidy/checks/list.html
-Checks: <-
+Checks: >
   clang-diagnostic-*,
   clang-analyzer-*,
   -clang-analyzer-valist.Uninitialized,
-  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  -clang-diagnostic-unused-function
 FormatStyle: none

--- a/lib/error/lib/merr.c
+++ b/lib/error/lib/merr.c
@@ -13,6 +13,8 @@
 #include <hse_util/assert.h>
 #include <hse_util/page.h>
 
+#define HSE_SW_BUG_MSG "HSE software bug"
+
 char hse_merr_bug0[] _merr_attributes = "hse_merr_bug0";
 char hse_merr_bug1[] _merr_attributes = "hse_merr_bug1";
 char hse_merr_bug2[] _merr_attributes = "hse_merr_bug2";
@@ -94,13 +96,21 @@ merr_strerror(const merr_t err, char *const buf, const size_t buf_sz)
     char errbuf[1024], *errmsg;
     int errno_value = merr_errno(err);
 
-    if (errno_value == EBUG)
-        return strlcpy(buf, "HSE software bug", buf_sz);
+    if (errno_value == EBUG) {
+        if (!buf)
+            return sizeof(HSE_SW_BUG_MSG) - 1;
+
+        return strlcpy(buf, HSE_SW_BUG_MSG, buf_sz);
+    }
 
     /* GNU strerror only modifies errbuf if errno_value is invalid.
      * It will only return NULL if errbuf is NULL.
      */
     errmsg = strerror_r(errno_value, errbuf, sizeof(errbuf));
+    assert(errmsg);
+
+    if (!buf)
+        return strlen(errmsg);
 
     return strlcpy(buf, errmsg, buf_sz);
 }

--- a/scripts/dev/clang-tidy.sh
+++ b/scripts/dev/clang-tidy.sh
@@ -16,7 +16,10 @@ fi
 
 source_root=$(realpath "$(dirname "$(dirname "$(dirname "$0")")")")
 
-files=$(find "$source_root/include" "$source_root/cli" "$source_root/samples" -name "*.[ch]" -type f -print0 | xargs --null)
+files=$(find "$source_root/include" "$source_root/cli" "$source_root/samples" \
+    "$source_root/lib/error" "$source_root/lib/logging" -name "*.[ch]" -type f \
+    -print0 | xargs --null)
 
 # shellcheck disable=SC2086 disable=SC2154 # Need word splitting for $files
-clang-tidy -p $MESON_BUILD_ROOT --warnings-as-errors --config-file="$source_root/.clang-tidy" --format-style=none $files
+clang-tidy -p $MESON_BUILD_ROOT --warnings-as-errors \
+    --config-file="$source_root/.clang-tidy" --format-style=none $files

--- a/tests/unit/error/merr_test.c
+++ b/tests/unit/error/merr_test.c
@@ -139,9 +139,12 @@ MTF_DEFINE_UTEST(hse_err_test, no_buf)
     size_t needed_sz;
 
     err = merr(EINVAL);
-
     merr_strinfo(err, NULL, 0, ctx_strerror, &needed_sz);
     ASSERT_EQ(55, needed_sz);
+
+    err = merr(EBUG);
+    merr_strinfo(err, NULL, 0, ctx_strerror, &needed_sz);
+    ASSERT_EQ(56, needed_sz);
 }
 
 MTF_END_UTEST_COLLECTION(hse_err_test)


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
