### PR TITLE
Remove bad returns_nonnull attribute in hsettp

### DIFF
--- a/tools/hsettp/hsettp.c
+++ b/tools/hsettp/hsettp.c
@@ -351,7 +351,7 @@ capitalized_method(const char *const method)
     abort();
 }
 
-static cJSON * HSE_RETURNS_NONNULL
+static cJSON *
 follow_ref(cJSON *const obj)
 {
     cJSON *ref;


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
