### PR TITLE
No longer use mpool mcache maps

### DIFF
--- a/lib/cn/blk_list.c
+++ b/lib/cn/blk_list.c
@@ -42,8 +42,8 @@ commit_mblocks(struct mpool *mp, struct blk_list *blks)
     INVARIANT(mp);
     INVARIANT(blks);
 
-    for (uint32_t i = 0; i < blks->n_blks; i++) {
-        err = commit_mblock(mp, blks->blks[i]);
+    for (uint32_t i = 0; i < blks->idc; i++) {
+        err = commit_mblock(mp, blks->idv[i]);
         if (err)
             return err;
     }
@@ -75,8 +75,8 @@ delete_mblocks(struct mpool *mp, struct blk_list *blks)
     INVARIANT(mp);
     INVARIANT(blks);
 
-    for (uint32_t i = 0; i < blks->n_blks; i++)
-        delete_mblock(mp, blks->blks[i]);
+    for (uint32_t i = 0; i < blks->idc; i++)
+        delete_mblock(mp, blks->idv[i]);
 }
 
 void
@@ -84,24 +84,24 @@ blk_list_init(struct blk_list *blkl)
 {
     INVARIANT(blkl);
 
-    blkl->blks = NULL;
+    blkl->idv = NULL;
     blkl->n_alloc = 0;
-    blkl->n_blks = 0;
+    blkl->idc = 0;
 }
 
 merr_t
 blk_list_append(struct blk_list *blks, u64 blkid)
 {
-    assert(blks->n_blks <= blks->n_alloc);
+    assert(blks->idc <= blks->n_alloc);
 
-    if (blks->n_blks == blks->n_alloc) {
+    if (blks->idc == blks->n_alloc) {
 
         size_t old_sz;
         size_t grow_sz;
         uint64_t *new_mbidv;
 
-        old_sz = sizeof(blks->blks[0]) * blks->n_alloc;
-        grow_sz = sizeof(blks->blks[0]) * BLK_LIST_PRE_ALLOC;
+        old_sz = sizeof(blks->idv[0]) * blks->n_alloc;
+        grow_sz = sizeof(blks->idv[0]) * BLK_LIST_PRE_ALLOC;
         new_mbidv = malloc(old_sz + grow_sz);
         if (!new_mbidv)
             return merr(ev(ENOMEM));
@@ -109,16 +109,16 @@ blk_list_append(struct blk_list *blks, u64 blkid)
         blks->n_alloc += BLK_LIST_PRE_ALLOC;
 
         if (old_sz) {
-            assert(blks->blks);
-            memcpy(new_mbidv, blks->blks, old_sz);
-            free(blks->blks);
+            assert(blks->idv);
+            memcpy(new_mbidv, blks->idv, old_sz);
+            free(blks->idv);
         }
 
-        blks->blks = new_mbidv;
+        blks->idv = new_mbidv;
     }
 
-    blks->blks[blks->n_blks] = blkid;
-    blks->n_blks++;
+    blks->idv[blks->idc] = blkid;
+    blks->idc++;
 
     return 0;
 }
@@ -129,9 +129,9 @@ blk_list_free(struct blk_list *blks)
     if (!blks)
         return;
 
-    free(blks->blks);
-    blks->blks = NULL;
-    blks->n_blks = 0;
+    free(blks->idv);
+    blks->idv = NULL;
+    blks->idc = 0;
 }
 
 #if HSE_MOCKING

--- a/lib/cn/blk_list.c
+++ b/lib/cn/blk_list.c
@@ -18,16 +18,16 @@
 #include "blk_list.h"
 
 merr_t
-commit_mblock(struct mpool *mp, struct kvs_block *blk)
+commit_mblock(struct mpool *mp, uint64_t mbid)
 {
     merr_t err;
 
-    INVARIANT(blk);
-    INVARIANT(blk->bk_blkid);
+    INVARIANT(mp);
+    INVARIANT(mbid);
 
-    err = mpool_mblock_commit(mp, blk->bk_blkid);
+    err = mpool_mblock_commit(mp, mbid);
     if (err) {
-        log_errx("Failed to commit mblock, blkid 0x%lx", err, blk->bk_blkid);
+        log_errx("Failed to commit mblock, blkid 0x%lx", err, mbid);
         return err;
     }
 
@@ -37,11 +37,13 @@ commit_mblock(struct mpool *mp, struct kvs_block *blk)
 merr_t
 commit_mblocks(struct mpool *mp, struct blk_list *blks)
 {
-    if (!mp || !blks)
-        return merr(EINVAL);
+    merr_t err;
+
+    INVARIANT(mp);
+    INVARIANT(blks);
 
     for (uint32_t i = 0; i < blks->n_blks; i++) {
-        merr_t err = commit_mblock(mp, &blks->blks[i]);
+        err = commit_mblock(mp, blks->blks[i]);
         if (err)
             return err;
     }
@@ -50,15 +52,19 @@ commit_mblocks(struct mpool *mp, struct blk_list *blks)
 }
 
 merr_t
-delete_mblock(struct mpool *mp, struct kvs_block *blk)
+delete_mblock(struct mpool *mp, uint64_t mbid)
 {
-    merr_t err = mpool_mblock_delete(mp, blk->bk_blkid);
-    if (err) {
-        log_errx("Failed to delete mblock, blkid 0x%lx", err, blk->bk_blkid);
-        return err;
-    }
+    merr_t err;
 
-    blk->bk_blkid = 0;
+    INVARIANT(mp);
+
+    if (mbid) {
+        err = mpool_mblock_delete(mp, mbid);
+        if (err) {
+            log_errx("Failed to delete mblock, blkid 0x%lx", err, mbid);
+            return err;
+        }
+    }
 
     return 0;
 }
@@ -66,17 +72,17 @@ delete_mblock(struct mpool *mp, struct kvs_block *blk)
 void
 delete_mblocks(struct mpool *mp, struct blk_list *blks)
 {
-    if (!mp || !blks)
-        return;
+    INVARIANT(mp);
+    INVARIANT(blks);
 
     for (uint32_t i = 0; i < blks->n_blks; i++)
-        delete_mblock(mp, &blks->blks[i]);
+        delete_mblock(mp, blks->blks[i]);
 }
 
 void
 blk_list_init(struct blk_list *blkl)
 {
-    assert(blkl);
+    INVARIANT(blkl);
 
     blkl->blks = NULL;
     blkl->n_alloc = 0;
@@ -92,26 +98,26 @@ blk_list_append(struct blk_list *blks, u64 blkid)
 
         size_t old_sz;
         size_t grow_sz;
-        struct kvs_block *new;
+        uint64_t *new_mbidv;
 
-        old_sz = sizeof(struct kvs_block) * blks->n_alloc;
-        grow_sz = sizeof(struct kvs_block) * BLK_LIST_PRE_ALLOC;
-        new = malloc(old_sz + grow_sz);
-        if (!new)
+        old_sz = sizeof(blks->blks[0]) * blks->n_alloc;
+        grow_sz = sizeof(blks->blks[0]) * BLK_LIST_PRE_ALLOC;
+        new_mbidv = malloc(old_sz + grow_sz);
+        if (!new_mbidv)
             return merr(ev(ENOMEM));
 
         blks->n_alloc += BLK_LIST_PRE_ALLOC;
 
         if (old_sz) {
             assert(blks->blks);
-            memcpy(new, blks->blks, old_sz);
+            memcpy(new_mbidv, blks->blks, old_sz);
             free(blks->blks);
         }
 
-        blks->blks = new;
+        blks->blks = new_mbidv;
     }
 
-    blks->blks[blks->n_blks].bk_blkid = blkid;
+    blks->blks[blks->n_blks] = blkid;
     blks->n_blks++;
 
     return 0;

--- a/lib/cn/blk_list.h
+++ b/lib/cn/blk_list.h
@@ -20,7 +20,7 @@ struct mpool;
 
 /* MTF_MOCK */
 merr_t
-delete_mblock(struct mpool *mp, struct kvs_block *blk);
+delete_mblock(struct mpool *mp, uint64_t mbid);
 
 /* MTF_MOCK */
 void
@@ -28,7 +28,7 @@ delete_mblocks(struct mpool *mp, struct blk_list *blk);
 
 /* MTF_MOCK */
 merr_t
-commit_mblock(struct mpool *mp, struct kvs_block *blk);
+commit_mblock(struct mpool *mp, uint64_t mbid);
 
 /* MTF_MOCK */
 merr_t

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -542,15 +542,15 @@ cn_ingest_prep(
      * that this is not a real kvset.
      */
     if (!mblocks->hblk_id) {
-        assert(mblocks->kblks.n_blks == 0);
-        assert(mblocks->vblks.n_blks == 0);
+        assert(mblocks->kblks.idc == 0);
+        assert(mblocks->vblks.idc == 0);
         goto done;
     }
 
     err = cndb_record_kvset_add(cn->cn_cndb, txn, cn->cn_cnid, km.km_nodeid, &km, kvsetid,
                                 mblocks->hblk_id,
-                                km.km_kblk_list.n_blks, km.km_kblk_list.blks,
-                                km.km_vblk_list.n_blks, km.km_vblk_list.blks,
+                                km.km_kblk_list.idc, km.km_kblk_list.idv,
+                                km.km_vblk_list.idc, km.km_vblk_list.idv,
                                 cookie);
     if (ev(err))
         goto done;

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1624,7 +1624,7 @@ cn_comp_commit(struct cn_compaction_work *w)
          *
          * [HSE_REVISIT] Are there any other corner cases?
          */
-        if (!w->cw_outv[i].hblk.bk_blkid) {
+        if (!w->cw_outv[i].hblk_id) {
             assert(w->cw_outv[i].kblks.n_blks == 0);
             continue;
         }
@@ -1636,7 +1636,7 @@ cn_comp_commit(struct cn_compaction_work *w)
          * Yes, the struct copy is a bit gross, but it works and
          * avoids unnecessary allocations of temporary lists.
          */
-        km.km_hblk = w->cw_outv[i].hblk;
+        km.km_hblk_id = w->cw_outv[i].hblk_id;
         km.km_kblk_list = w->cw_outv[i].kblks;
         km.km_vblk_list = w->cw_outv[i].vblks;
 
@@ -1661,9 +1661,9 @@ cn_comp_commit(struct cn_compaction_work *w)
          */
         err = cndb_record_kvset_add(
                         w->cw_tree->cndb, tx, w->cw_tree->cnid,
-                        km.km_nodeid, &km, w->cw_kvsetidv[i], km.km_hblk.bk_blkid,
-                        w->cw_outv[i].kblks.n_blks, (uint64_t *)w->cw_outv[i].kblks.blks,
-                        w->cw_outv[i].vblks.n_blks, (uint64_t *)w->cw_outv[i].vblks.blks,
+                        km.km_nodeid, &km, w->cw_kvsetidv[i], km.km_hblk_id,
+                        w->cw_outv[i].kblks.n_blks, w->cw_outv[i].kblks.blks,
+                        w->cw_outv[i].vblks.n_blks, w->cw_outv[i].vblks.blks,
                         &cookiev[i]);
 
         if (err) {
@@ -1716,7 +1716,7 @@ cn_comp_commit(struct cn_compaction_work *w)
     /* CNDB: Ack all the kvset add records.
      */
     for (i = 0; i < w->cw_outc; i++) {
-        if (!w->cw_outv[i].hblk.bk_blkid)
+        if (!w->cw_outv[i].hblk_id)
             continue;
 
         err = cndb_record_kvset_add_ack(w->cw_tree->cndb, tx, cookiev[i]);
@@ -1898,7 +1898,7 @@ cn_subspill_commit(struct subspill *ss)
     struct cn_compaction_work *w = ss->ss_work;
     struct cndb *cndb = w->cw_tree->cndb;
 
-    if (!mblks->hblk.bk_blkid) {
+    if (!mblks->hblk_id) {
         assert(mblks->kblks.n_blks == 0);
         return 0;
     }
@@ -1912,9 +1912,9 @@ cn_subspill_commit(struct subspill *ss)
     /* CNDB: Log kvset add records.
      */
     err = cndb_record_kvset_add(cndb, tx, w->cw_tree->cnid, km.km_nodeid,
-                                &km, ss->ss_kvsetid, km.km_hblk.bk_blkid,
-                                mblks->kblks.n_blks, (uint64_t *)mblks->kblks.blks,
-                                mblks->vblks.n_blks, (uint64_t *)mblks->vblks.blks, &cookie);
+                                &km, ss->ss_kvsetid, km.km_hblk_id,
+                                mblks->kblks.n_blks, mblks->kblks.blks,
+                                mblks->vblks.n_blks, mblks->vblks.blks, &cookie);
     if (err)
         goto done;
 

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1558,7 +1558,7 @@ cn_comp_commit(struct cn_compaction_work *w)
     assert(w->cw_outc);
 
     /* if k-compaction and no kblocks, then force keepv to false. */
-    if (is_kcompact && w->cw_outv[0].kblks.n_blks == 0)
+    if (is_kcompact && w->cw_outv[0].kblks.idc == 0)
         w->cw_keep_vblks = false;
 
     alloc_len = sizeof(*kvsets) * w->cw_outc;
@@ -1625,7 +1625,7 @@ cn_comp_commit(struct cn_compaction_work *w)
          * [HSE_REVISIT] Are there any other corner cases?
          */
         if (!w->cw_outv[i].hblk_id) {
-            assert(w->cw_outv[i].kblks.n_blks == 0);
+            assert(w->cw_outv[i].kblks.idc == 0);
             continue;
         }
 
@@ -1662,8 +1662,8 @@ cn_comp_commit(struct cn_compaction_work *w)
         err = cndb_record_kvset_add(
                         w->cw_tree->cndb, tx, w->cw_tree->cnid,
                         km.km_nodeid, &km, w->cw_kvsetidv[i], km.km_hblk_id,
-                        w->cw_outv[i].kblks.n_blks, w->cw_outv[i].kblks.blks,
-                        w->cw_outv[i].vblks.n_blks, w->cw_outv[i].vblks.blks,
+                        w->cw_outv[i].kblks.idc, w->cw_outv[i].kblks.idv,
+                        w->cw_outv[i].vblks.idc, w->cw_outv[i].vblks.idv,
                         &cookiev[i]);
 
         if (err) {
@@ -1899,7 +1899,7 @@ cn_subspill_commit(struct subspill *ss)
     struct cndb *cndb = w->cw_tree->cndb;
 
     if (!mblks->hblk_id) {
-        assert(mblks->kblks.n_blks == 0);
+        assert(mblks->kblks.idc == 0);
         return 0;
     }
 
@@ -1913,8 +1913,8 @@ cn_subspill_commit(struct subspill *ss)
      */
     err = cndb_record_kvset_add(cndb, tx, w->cw_tree->cnid, km.km_nodeid,
                                 &km, ss->ss_kvsetid, km.km_hblk_id,
-                                mblks->kblks.n_blks, mblks->kblks.blks,
-                                mblks->vblks.n_blks, mblks->vblks.blks, &cookie);
+                                mblks->kblks.idc, mblks->kblks.idv,
+                                mblks->vblks.idc, mblks->vblks.idv, &cookie);
     if (err)
         goto done;
 

--- a/lib/cn/hblock_builder.c
+++ b/lib/cn/hblock_builder.c
@@ -200,7 +200,7 @@ hbb_destroy(struct hblock_builder *bld)
 merr_t
 hbb_finish(
     struct hblock_builder *bld,
-    struct kvs_block      *blk,
+    uint64_t              *hblk_id_out,
     const struct vgmap    *vgmap,
     struct key_obj        *min_pfxp,
     struct key_obj        *max_pfxp,
@@ -340,7 +340,7 @@ hbb_finish(
     perfc_inc(bld->pc, PERFC_RA_CNCOMP_WREQS);
     perfc_add(bld->pc, PERFC_RA_CNCOMP_WBYTES, wlen);
 
-    blk->bk_blkid = blkid;
+    *hblk_id_out = blkid;
 
 out:
     if (err) {

--- a/lib/cn/hblock_builder.c
+++ b/lib/cn/hblock_builder.c
@@ -74,6 +74,10 @@ make_header(
     omf_set_hbh_vgmap_len_pg(hdr, vgmap_pgc);
     omf_set_hbh_hlog_off_pg(hdr, HBLOCK_HDR_PAGES + vgmap_pgc);
     omf_set_hbh_hlog_len_pg(hdr, HLOG_PGC);
+
+    /* Note: if ptree_pgc==0, then data_off_pg > 0 but data_len_pg == 0, which seems
+     * contradictory but it works.
+     */
     omf_set_hbh_ptree_data_off_pg(hdr, HBLOCK_HDR_PAGES + vgmap_pgc + HLOG_PGC);
     omf_set_hbh_ptree_data_len_pg(hdr, ptree_pgc);
 

--- a/lib/cn/hblock_builder.c
+++ b/lib/cn/hblock_builder.c
@@ -28,6 +28,7 @@
 #include "blk_list.h"
 #include "kvset.h"
 #include "cn_perfc.h"
+#include "vgmap.h"
 
 struct hblock_builder {
     struct mpool              *mpool;

--- a/lib/cn/hblock_builder.h
+++ b/lib/cn/hblock_builder.h
@@ -45,7 +45,7 @@ hbb_destroy(struct hblock_builder *bld);
 merr_t
 hbb_finish(
     struct hblock_builder *bld,
-    struct kvs_block      *blk,
+    uint64_t              *hblk_id_out,
     const struct vgmap    *vgmap,
     struct key_obj        *min_pfxp,
     struct key_obj        *max_pfxp,

--- a/lib/cn/hblock_reader.c
+++ b/lib/cn/hblock_reader.c
@@ -21,6 +21,7 @@
 #include "kvs_mblk_desc.h"
 #include "omf.h"
 #include "wbt_reader.h"
+#include "vgmap.h"
 
 static bool HSE_NONNULL(1)
 hblock_hdr_valid(const struct hblock_hdr_omf *omf)

--- a/lib/cn/hblock_reader.c
+++ b/lib/cn/hblock_reader.c
@@ -13,8 +13,6 @@
 #include <hse_util/compiler.h>
 #include <hse_util/event_counter.h>
 #include <hse/error/merr.h>
-#include <mpool/mpool_structs.h>
-#include <mpool/mpool.h>
 
 #include "kvset.h"
 #include "hblock_reader.h"
@@ -27,114 +25,54 @@ static bool HSE_NONNULL(1)
 hblock_hdr_valid(const struct hblock_hdr_omf *omf)
 {
     const uint32_t version = omf_hbh_version(omf);
-    const uint32_t magic = omf_hbh_magic(omf);
+    const uint32_t magic   = omf_hbh_magic(omf);
 
     return HSE_LIKELY(magic == HBLOCK_HDR_MAGIC && version == HBLOCK_HDR_VERSION);
 }
 
-static merr_t
-hbr_madvise_region(
-    struct kvs_mblk_desc *hblk_desc,
-    uint32_t pg,
-    const uint32_t pg_cnt,
-    const int advice)
+void
+hbr_madvise_kmd(struct kvs_mblk_desc *md, struct wbt_desc *wbd, int advice)
 {
-    merr_t err = 0;
-    const uint32_t pg_max = pg + pg_cnt;
+    merr_t err;
+    const uint32_t pg  = wbd->wbd_first_page + wbd->wbd_root + 1;
+    const uint32_t pgc = wbd->wbd_kmd_pgc;
 
-    while (pg < pg_max) {
-        const uint32_t chunk = min_t(uint32_t, pg_max - pg, HSE_RA_PAGES_MAX);
-
-        err = mpool_mcache_madvise(
-            hblk_desc->map, hblk_desc->map_idx, PAGE_SIZE * pg, PAGE_SIZE * chunk, advice);
-        if (ev(err))
-            return err;
-
-        pg += chunk;
+    if (pgc) {
+        err = mblk_madvise_pages(md, pg, pgc, advice);
+        ev(err);
     }
-
-    return err;
 }
 
 void
-hbr_madvise_kmd(struct kvs_mblk_desc *kblkdesc, struct wbt_desc *desc, int advice)
+hbr_madvise_wbt_leaf_nodes(struct kvs_mblk_desc *md, struct wbt_desc *wbd, int advice)
 {
     merr_t err;
-    u32    pg = desc->wbd_first_page + desc->wbd_root + 1;
-    u32    pg_cnt = desc->wbd_kmd_pgc;
+    const uint32_t pg  = wbd->wbd_first_page;
+    const uint32_t pgc = wbd->wbd_leaf_cnt;
 
-    err = hbr_madvise_region(kblkdesc, pg, pg_cnt, advice);
-
-    ev(err);
+    if (pgc) {
+        err = mblk_madvise_pages(md, pg, pgc, advice);
+        ev(err);
+    }
 }
 
 void
-hbr_madvise_wbt_leaf_nodes(
-    struct kvs_mblk_desc *const hblk_desc,
-    struct wbt_desc *const wbt_desc,
-    const int advice)
+hbr_madvise_wbt_int_nodes(struct kvs_mblk_desc *md, struct wbt_desc *wbd, int advice)
 {
     merr_t err;
-    const uint32_t pg = wbt_desc->wbd_first_page;
-    const uint32_t pg_cnt = wbt_desc->wbd_leaf_cnt;
+    const uint32_t pg  = wbd->wbd_first_page + wbd->wbd_leaf_cnt;
+    const uint32_t pgc = wbd->wbd_n_pages - wbd->wbd_leaf_cnt - wbd->wbd_kmd_pgc;
 
-    err = hbr_madvise_region(hblk_desc, pg, pg_cnt, advice);
-
-    ev(err);
-}
-
-void
-hbr_madvise_wbt_int_nodes(
-    struct kvs_mblk_desc *const hblk_desc,
-    struct wbt_desc *const wbt_desc,
-    const int advice)
-{
-    merr_t err;
-    const uint32_t pg = wbt_desc->wbd_first_page + wbt_desc->wbd_leaf_cnt;
-    const uint32_t pg_cnt =
-        (wbt_desc->wbd_n_pages - wbt_desc->wbd_leaf_cnt - wbt_desc->wbd_kmd_pgc);
-
-    err = hbr_madvise_region(hblk_desc, pg, pg_cnt, advice);
-
-    ev(err);
-}
-
-merr_t
-hbr_read_desc(
-    struct mpool *mpool,
-    struct mpool_mcache_map *map,
-    struct mblock_props *props,
-    uint64_t blkid,
-    struct kvs_mblk_desc *mblk_desc)
-{
-    void *base;
-
-    /* There is only one hblock within the mcache map. */
-    base = mpool_mcache_getbase(map, 0);
-    if (!base)
-        return merr(EINVAL);
-
-    mblk_desc->ds = mpool;
-    mblk_desc->mbid = blkid;
-    mblk_desc->map = map;
-    mblk_desc->map_idx = 0;
-    mblk_desc->map_base = base;
-    mblk_desc->mclass = props->mpr_mclass;
-
-    return 0;
+    if (pgc) {
+        err = mblk_madvise_pages(md, pg, pgc, advice);
+        ev(err);
+    }
 }
 
 merr_t
 hbr_read_metrics(struct kvs_mblk_desc *hblk_desc, struct hblk_metrics *metrics)
 {
-    merr_t err;
-    struct mblock_props props;
-
-    err = mpool_mblock_props_get(hblk_desc->ds, hblk_desc->mbid, &props);
-    if (err)
-        return err;
-
-    metrics->hm_size = props.mpr_write_len;
+    metrics->hm_size = hblk_desc->wlen_pages * PAGE_SIZE;
     metrics->hm_nptombs = omf_hbh_num_ptombs(hblk_desc->map_base);
 
     return 0;
@@ -143,19 +81,11 @@ hbr_read_metrics(struct kvs_mblk_desc *hblk_desc, struct hblk_metrics *metrics)
 merr_t
 hbr_read_ptree_region_desc(struct kvs_mblk_desc *mblk_desc, struct wbt_desc *wbt_desc)
 {
-    merr_t err;
-    void * pg;
-    off_t pg_idxs[1];
     struct hblock_hdr_omf *hb_hdr;
 
     memset(wbt_desc, 0, sizeof(*wbt_desc));
 
-    pg_idxs[0] = 0;
-    err = mpool_mcache_getpages(mblk_desc->map, 1, mblk_desc->map_idx, pg_idxs, &pg);
-    if (ev(err))
-        return err;
-
-    hb_hdr = pg;
+    hb_hdr = mblk_desc->map_base;
     if (!hblock_hdr_valid(hb_hdr))
         return merr(EPROTO);
 
@@ -168,17 +98,9 @@ hbr_read_ptree_region_desc(struct kvs_mblk_desc *mblk_desc, struct wbt_desc *wbt
 merr_t
 hbr_read_seqno_range(struct kvs_mblk_desc *mblk_desc, uint64_t *seqno_min, uint64_t *seqno_max)
 {
-    merr_t err;
-    off_t pg_idxs[1];
     struct hblock_hdr_omf *hb_hdr;
-    void *pg;
 
-    pg_idxs[0] = 0;
-    err = mpool_mcache_getpages(mblk_desc->map, 1, mblk_desc->map_idx, pg_idxs, &pg);
-    if (ev(err))
-        return err;
-
-    hb_hdr = pg;
+    hb_hdr = mblk_desc->map_base;
     if (!hblock_hdr_valid(hb_hdr))
         return merr(EPROTO);
 

--- a/lib/cn/hblock_reader.h
+++ b/lib/cn/hblock_reader.h
@@ -64,23 +64,6 @@ hbr_madvise_kmd(
     int advice) HSE_NONNULL(1, 2);
 
 /**
- * Get the mblock descriptor for the given mblock.
- *
- * @param mpool mpool containing the mblock
- * @param map mcache
- * @param props properties of the mblock
- * @param blkid mblock id referencing the mblock
- * @param[in,out] mblk_desc mblock descriptor
- */
-merr_t
-hbr_read_desc(
-    struct mpool *mpool,
-    struct mpool_mcache_map *map,
-    struct mblock_props *props,
-    uint64_t blkid,
-    struct kvs_mblk_desc *mblk_desc) HSE_NONNULL(1, 2, 3, 5);
-
-/**
  * Read various metrics about an hblock.
  *
  * @param hblk_desc hblock descriptor

--- a/lib/cn/kblock_builder.c
+++ b/lib/cn/kblock_builder.c
@@ -1095,7 +1095,7 @@ kbb_finish(struct kblock_builder *bld, struct blk_list *kblks)
 
     /* In the event we have no keys, return no kblocks to the caller. */
     if (bld->curr.num_keys == 0) {
-        assert(bld->finished_kblks.n_blks == 0);
+        assert(bld->finished_kblks.idc == 0);
 
         return 0;
     }

--- a/lib/cn/kblock_reader.h
+++ b/lib/cn/kblock_reader.h
@@ -36,21 +36,6 @@ struct kblock_desc {
 };
 
 /**
- * kbr_get_kblock_desc() - Get the mblock descriptor for the given
- *                     KBLOCK ID.
- * @kblock_id:      KBLOCK ID for KBLOCK to read
- * @kblock_desc:    (output) KVBLOCK_DESC for KBLOCK
- */
-merr_t
-kbr_get_kblock_desc(
-    struct mpool *           ds,
-    struct mpool_mcache_map *map,
-    struct mblock_props     *props,
-    u32                      map_idx,
-    u64                      kblock_id,
-    struct kvs_mblk_desc *   kblock_desc);
-
-/**
  * kbr_read_wbt_region_desc() - Read the WBT region descriptor for
  *                          the given KBLOCK ID.
  * @kblock_desc:    KVBLOCK_DESC for KBLOCK to read
@@ -68,16 +53,6 @@ kbr_read_wbt_region_desc(struct kvs_mblk_desc *kblock_desc, struct wbt_desc *wbt
  */
 merr_t
 kbr_read_blm_region_desc(struct kvs_mblk_desc *kblock_desc, struct bloom_desc *blm_desc);
-
-/**
- * kbr_read_blm_pages() - Get base address of bloom filter bitmap
- * @kblock_desc:    KVBLOCK_DESC for KBLOCK to read
- * @blm_desc:       bloom region descriptor
- */
-merr_t
-kbr_read_blm_pages(
-    struct kvs_mblk_desc *kblock_desc,
-    struct bloom_desc *   blm_desc);
 
 /**
  * kbr_read_metrics() - Read kblock header to obtain metrics.

--- a/lib/cn/kcompact.c
+++ b/lib/cn/kcompact.c
@@ -22,6 +22,7 @@
 #include "cn_tree.h"
 #include "cn_tree_internal.h"
 #include "cn_tree_compact.h"
+#include "vgmap.h"
 
 static int
 kv_item_compare(const void *a, const void *b)

--- a/lib/cn/kcompact.h
+++ b/lib/cn/kcompact.h
@@ -6,22 +6,14 @@
 #ifndef HSE_KVS_CN_COMPACT_H
 #define HSE_KVS_CN_COMPACT_H
 
+/* MTF_MOCK_DECL(kcompact) */
+
 #include <hse/error/merr.h>
 #include <hse_util/inttypes.h>
 
 struct cn_compaction_work;
 
-/* MTF_MOCK_DECL(kcompact) */
-
-/**
- * struct kvset_vblk_map - maps vblock refs for k-compaction
- * @vbm_blkv:   vector of vblock ids
- * @vbm_blkc:   number of entries in blkv
- * @vbm_map:    map of offsets from src vr_index to new vr_index in target
- * @vbm_mapc:   number of entries in map[]
- * @vbm_used:   total bytes of used vblock space
- * @vbm_waste:  total bytes of un-used vblock space
- * @vbm_tot:    total bytes of all values in vblock space
+/* Maps vblock refs for k-compaction
  *
  * This structure is used during k-compaction to map the vr_index
  * in kvs_vtuple_ref into the new target vr_index in the larger kvset.
@@ -48,17 +40,16 @@ struct cn_compaction_work;
  * used 20M,  waste 300M, ratio: 300 / 320 = .94
  */
 struct kvset_vblk_map {
-    struct kvs_block *vbm_blkv;
-    uint32_t         *vbm_map;
-    uint32_t          vbm_blkc;
-    uint32_t          vbm_mapc;
-    uint64_t          vbm_used;
-    uint64_t          vbm_waste;
-    uint64_t          vbm_tot;
+    uint64_t         *vbm_blkv;  // vector of vblock ids
+    uint32_t         *vbm_map;   // map of offsets from src vr_index to new vr_index in target
+    uint32_t          vbm_blkc;  // number of entries in blkv
+    uint32_t          vbm_mapc;  // number of entries in map[]
+    uint64_t          vbm_used;  // total bytes of used vblock space
+    uint64_t          vbm_waste; // total bytes of un-used vblock space
+    uint64_t          vbm_tot;   // total bytes of all values in vblock space
 };
 
-/**
- * cn_kcompact - Build kvsets as part of a k-compact operation
+/* Perform a k-compact operation
  */
 /* MTF_MOCK */
 merr_t

--- a/lib/cn/keep.c
+++ b/lib/cn/keep.c
@@ -20,7 +20,7 @@ kvset_keep_vblocks(
     int                     niv)
 {
     struct vgmap *vgm = NULL;
-    struct kvs_block *blks;
+    void *mem;
     uint32_t nv, nvg, vgidx;
     size_t sz;
     merr_t err = 0;
@@ -40,8 +40,8 @@ kvset_keep_vblocks(
 
     /* alloc both the vblks and the vbm; 1 free does both */
     sz = nv * sizeof(*vbm->vbm_blkv) + niv * sizeof(*vbm->vbm_map);
-    blks = calloc(1, sz);
-    if (!blks)
+    mem = calloc(1, sz);
+    if (!mem)
         return merr(ev(ENOMEM));
 
     if (nvg > 0) {
@@ -55,13 +55,13 @@ kvset_keep_vblocks(
     }
 
     if (err) {
-        free(blks);
+        free(mem);
         return err;
     }
 
-    vbm->vbm_blkv = blks;
+    vbm->vbm_blkv = mem;
     vbm->vbm_blkc = 0;
-    vbm->vbm_map = (u32 *)(blks + nv);
+    vbm->vbm_map = (u32 *)(vbm->vbm_blkv + nv);
     vbm->vbm_mapc = niv;
     vbm->vbm_used = 0;
     vbm->vbm_waste = 0;
@@ -92,7 +92,7 @@ kvset_keep_vblocks(
         vbm->vbm_map[i] = nv;
 
         for (uint32_t j = 0; j < cnt; ++j) {
-            blks[nv].bk_blkid = kvset_get_nth_vblock_id(kvset, j);
+            vbm->vbm_blkv[nv] = kvset_get_nth_vblock_id(kvset, j);
             vbm->vbm_tot += kvset_get_nth_vblock_len(kvset, j);
 
             if (j == vgmap_vbidx_out_end(kvset, kvg)) {

--- a/lib/cn/kvs_mblk_desc.c
+++ b/lib/cn/kvs_mblk_desc.c
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2022 Micron Technology, Inc.  All rights reserved.
+ */
+
+#define MTF_MOCK_IMPL_mblk_desc
+
+#include <sys/mman.h>
+
+#include <mpool/mpool_structs.h>
+#include <mpool/mpool.h>
+
+#include <hse/error/merr.h>
+
+#include <hse_util/assert.h>
+#include <hse_util/compiler.h>
+#include <hse_util/event_counter.h>
+#include <hse_util/page.h>
+
+#include "kvs_mblk_desc.h"
+
+merr_t
+mblk_mmap(struct mpool *mp, uint64_t mbid, struct kvs_mblk_desc *md)
+{
+    merr_t err;
+    struct mblock_props props;
+    const void *base;
+
+    err = mpool_mblock_props_get(mp, mbid, &props);
+    if (ev(err))
+        return err;
+
+    err = mpool_mblock_mmap(mp, mbid, &base);
+    if (ev(err))
+        return err;
+
+    assert(props.mpr_alloc_cap % PAGE_SIZE == 0);
+    assert(props.mpr_write_len % PAGE_SIZE == 0);
+
+    md->map_base = (void *)base;
+    md->alen_pages = props.mpr_alloc_cap / PAGE_SIZE;
+    md->wlen_pages = props.mpr_write_len / PAGE_SIZE;
+    md->mclass = props.mpr_mclass;
+    md->mbid = mbid;
+
+    /* Verify mappings to pages and smaller int types don't lose information.
+     */
+    assert(md->alen_pages * PAGE_SIZE == props.mpr_alloc_cap);
+    assert(md->wlen_pages * PAGE_SIZE == props.mpr_write_len);
+    assert(md->mclass == props.mpr_mclass);
+
+    return 0;
+}
+
+merr_t
+mblk_munmap(struct mpool *mp, struct kvs_mblk_desc *md)
+{
+    merr_t err = 0;
+
+    INVARIANT(mp);
+    INVARIANT(md);
+
+    if (md->map_base) {
+        assert(md->mbid);
+        err = mpool_mblock_munmap(mp, md->mbid);
+        if (!err)
+            md->map_base = NULL;
+    }
+
+    return err;
+}
+
+merr_t
+mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice)
+{
+    int rc;
+
+    if (len == 0)
+        return 0;
+
+    assert(off + len <= md->wlen_pages * PAGE_SIZE);
+    assert(md->map_base);
+
+    /* Cast away the const of map_base for madvise().
+     */
+    rc = madvise((void *)md->map_base + off, len, advice);
+    if (rc)
+        return merr(errno);
+
+    return 0;
+}
+
+merr_t
+mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg, size_t pg_cnt, int advice)
+{
+    if (pg_cnt == 0)
+        return 0;
+
+    return mblk_madvise(md, pg * PAGE_SIZE, pg_cnt * PAGE_SIZE, advice);
+}
+
+#if HSE_MOCKING
+#include "kvs_mblk_desc_ut_impl.i"
+#endif

--- a/lib/cn/kvs_mblk_desc.h
+++ b/lib/cn/kvs_mblk_desc.h
@@ -3,23 +3,67 @@
  * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
-#ifndef HSE_KVS_MBLK_DESC_H
-#define HSE_KVS_MBLK_DESC_H
+#ifndef HSE_MBLK_DESC_H
+#define HSE_MBLK_DESC_H
 
 #include <stdint.h>
 
+#include <hse/error/merr.h>
 #include <hse/types.h>
 
-struct mpool_mcache_map;
+/* MTF_MOCK_DECL(mblk_desc) */
+
 struct mpool;
 
+/* Mblock descriptor */
 struct kvs_mblk_desc {
-    void *                   map_base; /* base address of mcache map */
-    struct mpool_mcache_map *map;      /* mcache map */
-    uint32_t                 map_idx;  /* index of mblk in map */
-    enum hse_mclass          mclass;   /* media class */
-    struct mpool *           ds;       /* mpool dataset */
-    uint64_t                 mbid;    /* mblock id */
+    void *map_base;         // memory mapped address of mblock
+    uint64_t mbid;          // mblock id
+    uint16_t alen_pages;    // allocated length of mblock, in 4K pages
+    uint16_t wlen_pages;    // written length of mblock, in 4K pages
+    uint8_t  mclass;        // media class
 };
+
+/* Map an mblock and initialize an mblock descriptor.
+ */
+/* MTF_MOCK */
+merr_t
+mblk_mmap(struct mpool *mp, uint64_t mbid, struct kvs_mblk_desc *md_out);
+
+/* Unmap an mblock.
+ */
+/* MTF_MOCK */
+merr_t
+mblk_munmap(struct mpool *mp, struct kvs_mblk_desc *md);
+
+/* MTF_MOCK */
+merr_t
+mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice);
+
+/* MTF_MOCK */
+merr_t
+mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg, size_t pg_cnt, int advice);
+
+static inline enum hse_mclass
+mblk_mclass(const struct kvs_mblk_desc *d)
+{
+    return (enum hse_mclass)(d->mclass);
+}
+
+static inline uint64_t
+mblk_alen(const struct kvs_mblk_desc *d)
+{
+    return d->alen_pages * 4096UL;
+}
+
+static inline uint64_t
+mblk_wlen(const struct kvs_mblk_desc *d)
+{
+    return d->wlen_pages * 4096UL;
+}
+
+#ifdef HSE_MOCKING
+#include "kvs_mblk_desc_ut.h"
+#endif
 
 #endif

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -238,7 +238,7 @@ kvset_hblk_init(
     *vgmap_out = NULL;
     *use_vgmap = false;
 
-    err = hbr_read_desc(mpool, map, props, blk->kh_hblk.bk_blkid, hbd);
+    err = hbr_read_desc(mpool, map, props, props->mpr_objid, hbd);
     if (err)
         return err;
 
@@ -309,7 +309,7 @@ kvset_kblk_init(
     struct kblock_hdr_omf *hdr;
     merr_t                 err;
 
-    err = kbr_get_kblock_desc(ds, kmap, props, idx, p->kb_kblk.bk_blkid, kbd);
+    err = kbr_get_kblock_desc(ds, kmap, props, idx, props->mpr_objid, kbd);
     if (ev(err))
         return err;
 
@@ -369,60 +369,6 @@ kvset_kblk_init(
         kbr_madvise_bloom(kbd, &p->kb_blm_desc, MADV_WILLNEED);
 
     return 0;
-}
-
-/**
- * blkid_list_to_vec()
- *
- * malloc a vector for blkids, and populate it from a blk_list.  Caller
- * must free the vector when finished.
- */
-static u64 *
-blkid_list_to_vec(struct blk_list *blkl, size_t bufc, u64 *bufv)
-{
-    u64 *v = bufv;
-    int  i;
-
-    if (blkl->n_blks > bufc) {
-        v = malloc_array(blkl->n_blks, sizeof(u64));
-        if (ev(!v))
-            return NULL;
-    }
-
-    for (i = 0; i < blkl->n_blks; i++)
-        v[i] = blkl->blks[i].bk_blkid;
-
-    return v;
-}
-
-/* This is not a general purpose function!  The caller must ensure mapv is
- * large enough, and must also cleanup on failure.
- */
-static merr_t
-kvset_map_blklist(
-    struct mpool *            mp,
-    struct blk_list *         blks,
-    struct mpool_mcache_map **mapp)
-{
-    uint    idc;
-    u64    *idv;
-    u64     bufv[64];
-    merr_t  err;
-
-    idc = blks->n_blks;
-    if (!idc)
-        return 0;
-
-    idv = blkid_list_to_vec(blks, NELEM(bufv), bufv);
-    if (ev(!idv))
-        return merr(ENOMEM);
-
-    err = mpool_mcache_mmap(mp, idc, idv, mapp);
-
-    if (idv != bufv)
-        free(idv);
-
-    return err;
 }
 
 static merr_t
@@ -490,7 +436,7 @@ kvset_open2(
     struct kvs_cparams *cp;
 
     /* need hblock, kblocks and vblocks optional */
-    assert(km->km_hblk.bk_blkid);
+    assert(km->km_hblk_id);
     last_kb = n_kblks - 1;
 
     /* number of vbsets */
@@ -577,21 +523,20 @@ kvset_open2(
     assert(ks->ks_kvsetid != 0);
 
     /* map single hblock */
-    err = mpool_mcache_mmap(mp, 1, &km->km_hblk.bk_blkid, &ks->ks_hmap);
+    err = mpool_mcache_mmap(mp, 1, &km->km_hblk_id, &ks->ks_hmap);
     if (ev(err))
         goto err_exit;
 
     {
         struct mblock_props props;
 
-        err = mpool_mblock_props_get(mp, km->km_hblk.bk_blkid, &props);
+        err = mpool_mblock_props_get(mp, km->km_hblk_id, &props);
         if (ev(err))
             goto err_exit;
 
-        ks->ks_hblk.kh_hblk.bk_blkid = km->km_hblk.bk_blkid;
-
         err = kvset_hblk_init(mp, &props, ks->ks_hmap, &ks->ks_vgmap, &ks->ks_use_vgmap,
                               &ks->ks_hlog, &ks->ks_hblk);
+
         if (ev(err))
             goto err_exit;
 
@@ -606,7 +551,7 @@ kvset_open2(
     assert(ks->ks_seqno_min <= ks->ks_seqno_max);
 
     /* map kblocks */
-    err = kvset_map_blklist(mp, &km->km_kblk_list, &ks->ks_kmap);
+    err = mpool_mcache_mmap(mp, km->km_kblk_list.n_blks, km->km_kblk_list.blks, &ks->ks_kmap);
     if (ev(err))
         goto err_exit;
 
@@ -616,13 +561,11 @@ kvset_open2(
         struct kvset_kblk * kblk = ks->ks_kblks + i;
         struct mblock_props props;
 
-        u64 mbid = km->km_kblk_list.blks[i].bk_blkid;
+        u64 mbid = km->km_kblk_list.blks[i];
 
         err = mpool_mblock_props_get(mp, mbid, &props);
         if (ev(err))
             goto err_exit;
-
-        kblk->kb_kblk.bk_blkid = mbid;
 
         err = kvset_kblk_init(rp, mp, &props, ks->ks_kmap, i, kblk);
         if (ev(err))
@@ -832,38 +775,27 @@ merr_t
 kvset_open(struct cn_tree *tree, uint64_t kvsetid, struct kvset_meta *km, struct kvset **ks)
 {
     merr_t         err;
-    uint           n_vblks = km->km_vblk_list.n_blks;
+    uint32_t       idc = km->km_vblk_list.n_blks;
+    uint64_t      *idv = km->km_vblk_list.blks;
     struct mbset * vbset = 0;
     struct mbset **vbsetv = &vbset;
     uint           vbsetc = 0;
     uint           len = 0;
 
-    if (n_vblks) {
-        u64 bufv[64];
-        u64 *idv;
-
-        idv = blkid_list_to_vec(&km->km_vblk_list, NELEM(bufv), bufv);
-        if (ev(!idv))
-            return merr(ENOMEM);
-
-        err = mbset_create(cn_tree_get_mp(tree), n_vblks, idv, sizeof(struct vblock_desc),
+    if (idc) {
+        err = mbset_create(cn_tree_get_mp(tree), idc, idv, sizeof(struct vblock_desc),
                            vblock_udata_init, 0, &vbset);
-        if (idv != bufv)
-            free(idv);
-        if (ev(err))
-            return err;
-
         len = 1;
         vbsetc = 1;
     }
 
-    /* kvset_open2 takes its own mbset ref, must free ours
+    /* kvset_open2 takes its own mbset ref, must release ours
      * unconditionally after calling kvset_open2.
      */
     err = kvset_open2(tree, kvsetid, km, len, &vbsetc, &vbsetv, ks);
     ev(err);
 
-    if (n_vblks)
+    if (vbset)
         mbset_put_ref(vbset);
 
     return err;
@@ -949,7 +881,7 @@ kvset_purge_blklist_add(struct kvset *ks, struct blk_list *blks)
     ks->ks_deleted = DEL_LIST;
 
     for (uint32_t i = 0; i < blks->n_blks; i++) {
-        merr_t err = blk_list_append(&ks->ks_purge, blks->blks[i].bk_blkid);
+        merr_t err = blk_list_append(&ks->ks_purge, blks->blks[i]);
         if (err) {
             atomic_inc(&ks->ks_delete_error);
             return;
@@ -974,7 +906,7 @@ cleanup_kblocks(struct kvset *ks)
      * a serious error, and stopping immediately would do less harm.
      */
     for (i = 0; i < ks->ks_st.kst_kblks; i++) {
-        err = mpool_mblock_delete(ks->ks_mp, ks->ks_kblks[i].kb_kblk.bk_blkid);
+        err = mpool_mblock_delete(ks->ks_mp, ks->ks_kblks[i].kb_kblk_desc.mbid);
         if (err) {
             atomic_inc(&ks->ks_delete_error);
             return;
@@ -992,7 +924,7 @@ cleanup_hblock(struct kvset *ks)
     if (ks->ks_deleted == DEL_NONE || ks->ks_deleted == DEL_LIST)
         return;
 
-    err = mpool_mblock_delete(ks->ks_mp, ks->ks_hblk.kh_hblk.bk_blkid);
+    err = mpool_mblock_delete(ks->ks_mp, ks->ks_hblk.kh_hblk_desc.mbid);
     if (err) {
         atomic_inc(&ks->ks_delete_error);
         return;
@@ -1005,7 +937,7 @@ cleanup_purge_blklist(struct kvset *ks)
     assert(ks->ks_deleted == DEL_LIST);
 
     for (uint32_t i = 0; i < ks->ks_purge.n_blks; i++) {
-        merr_t err = mpool_mblock_delete(ks->ks_mp, ks->ks_purge.blks[i].bk_blkid);
+        merr_t err = mpool_mblock_delete(ks->ks_mp, ks->ks_purge.blks[i]);
         if (err) {
             atomic_inc(&ks->ks_delete_error);
             return;
@@ -1892,7 +1824,7 @@ kvset_set_workid(struct kvset *ks, u64 id)
 uint64_t
 kvset_get_hblock_id(struct kvset *ks)
 {
-    return ks->ks_hblk.kh_hblk.bk_blkid;
+    return ks->ks_hblk.kh_hblk_desc.mbid;
 }
 
 u32
@@ -1904,7 +1836,7 @@ kvset_get_num_kblocks(struct kvset *ks)
 u64
 kvset_get_nth_kblock_id(struct kvset *ks, u32 index)
 {
-    return (index < ks->ks_st.kst_kblks ? ks->ks_kblks[index].kb_kblk.bk_blkid : 0);
+    return (index < ks->ks_st.kst_kblks ? ks->ks_kblks[index].kb_kblk_desc.mbid : 0);
 }
 
 uint32_t
@@ -2363,12 +2295,12 @@ kblk_start_read(struct kvset_iterator *iter, struct kblk_reader *kr, enum read_t
             kblk = &iter->ks->ks_kblks[kr->kr_next_blk_idx];
 
             wbt = &kblk->kb_wbt_desc;
-            kr->kr_mbid = kblk->kb_kblk.bk_blkid;
+            kr->kr_mbid = kblk->kb_kblk_desc.mbid;
             break;
         }
         case READ_PT:
             wbt = &iter->ks->ks_hblk.kh_ptree_desc;
-            kr->kr_mbid = iter->ks->ks_hblk.kh_hblk.bk_blkid;
+            kr->kr_mbid = iter->ks->ks_hblk.kh_hblk_desc.mbid;
             break;
         }
 

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -59,6 +59,7 @@
 #include "mbset.h"
 #include "cn_tree.h"
 #include "cn_tree_internal.h"
+#include "vgmap.h"
 
 /*
  * kvset deferred deletes

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -837,7 +837,6 @@ kvset_open(struct cn_tree *tree, uint64_t kvsetid, struct kvset_meta *km, struct
     struct mbset **vbsetv = &vbset;
     uint           vbsetc = 0;
     uint           len = 0;
-    uint           flags = 0;
 
     if (n_vblks) {
         u64 bufv[64];
@@ -847,11 +846,8 @@ kvset_open(struct cn_tree *tree, uint64_t kvsetid, struct kvset_meta *km, struct
         if (ev(!idv))
             return merr(ENOMEM);
 
-        if (km->km_capped)
-            flags |= MBSET_FLAGS_CAPPED;
-
         err = mbset_create(cn_tree_get_mp(tree), n_vblks, idv, sizeof(struct vblock_desc),
-                           vblock_udata_init, flags, &vbset);
+                           vblock_udata_init, 0, &vbset);
         if (idv != bufv)
             free(idv);
         if (ev(err))

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -428,8 +428,8 @@ kvset_open2(
     size_t        alloc_len;
     struct kvset *ks;
     size_t        kcachesz;
-    const uint32_t n_kblks = km->km_kblk_list.n_blks;
-    const uint32_t n_vblks = km->km_vblk_list.n_blks;
+    const uint32_t n_kblks = km->km_kblk_list.idc;
+    const uint32_t n_vblks = km->km_vblk_list.idc;
     uint          vbsetc;
     uint32_t      last_kb;
 
@@ -551,7 +551,7 @@ kvset_open2(
     assert(ks->ks_seqno_min <= ks->ks_seqno_max);
 
     /* map kblocks */
-    err = mpool_mcache_mmap(mp, km->km_kblk_list.n_blks, km->km_kblk_list.blks, &ks->ks_kmap);
+    err = mpool_mcache_mmap(mp, km->km_kblk_list.idc, km->km_kblk_list.idv, &ks->ks_kmap);
     if (ev(err))
         goto err_exit;
 
@@ -561,7 +561,7 @@ kvset_open2(
         struct kvset_kblk * kblk = ks->ks_kblks + i;
         struct mblock_props props;
 
-        u64 mbid = km->km_kblk_list.blks[i];
+        u64 mbid = km->km_kblk_list.idv[i];
 
         err = mpool_mblock_props_get(mp, mbid, &props);
         if (ev(err))
@@ -775,8 +775,8 @@ merr_t
 kvset_open(struct cn_tree *tree, uint64_t kvsetid, struct kvset_meta *km, struct kvset **ks)
 {
     merr_t         err;
-    uint32_t       idc = km->km_vblk_list.n_blks;
-    uint64_t      *idv = km->km_vblk_list.blks;
+    uint32_t       idc = km->km_vblk_list.idc;
+    uint64_t      *idv = km->km_vblk_list.idv;
     struct mbset * vbset = 0;
     struct mbset **vbsetv = &vbset;
     uint           vbsetc = 0;
@@ -880,8 +880,8 @@ kvset_purge_blklist_add(struct kvset *ks, struct blk_list *blks)
 {
     ks->ks_deleted = DEL_LIST;
 
-    for (uint32_t i = 0; i < blks->n_blks; i++) {
-        merr_t err = blk_list_append(&ks->ks_purge, blks->blks[i]);
+    for (uint32_t i = 0; i < blks->idc; i++) {
+        merr_t err = blk_list_append(&ks->ks_purge, blks->idv[i]);
         if (err) {
             atomic_inc(&ks->ks_delete_error);
             return;
@@ -936,8 +936,8 @@ cleanup_purge_blklist(struct kvset *ks)
 {
     assert(ks->ks_deleted == DEL_LIST);
 
-    for (uint32_t i = 0; i < ks->ks_purge.n_blks; i++) {
-        merr_t err = mpool_mblock_delete(ks->ks_mp, ks->ks_purge.blks[i]);
+    for (uint32_t i = 0; i < ks->ks_purge.idc; i++) {
+        merr_t err = mpool_mblock_delete(ks->ks_mp, ks->ks_purge.idv[i]);
         if (err) {
             atomic_inc(&ks->ks_delete_error);
             return;

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -66,7 +66,7 @@ enum kvset_iter_flags {
  * This structure is passed between the MDC and kvset_open().
  */
 struct kvset_meta {
-    struct kvs_block km_hblk;
+    uint64_t        km_hblk_id;
     struct blk_list km_kblk_list;
     struct blk_list km_vblk_list;
     uint64_t        km_dgen_hi;

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -36,6 +36,7 @@ struct cn_kvdb;
 struct cn_tree;
 struct cn_merge_stats;
 struct kvset_stats;
+struct vgmap;
 
 struct kvset_list_entry {
     struct list_head le_link;
@@ -83,41 +84,6 @@ struct kvset_meta {
 enum {
     KVSET_MISS_KEY_TOO_SMALL = -1,
     KVSET_MISS_KEY_TOO_LARGE = -2,
-};
-
-/**
- * struct vgmap - vgroup map
- *
- * Vblock indexes are stored with keys in a kvset's kblocks and are used to identify
- * which vblock in the kvset's list of vblocks holds a key's value. A vgroup map is
- * associated with a kvset and is used to convert these indexes so they reference the
- * correct vblock. This conversion is only necessary with kvsets that have been
- * split because kvset split changes the vblock list but does not update the vblock
- * indexes stored in the kblocks.
- *
- * The last vblock index from each vgroup is stored in vbidx_out.
- *
- * In the case of a split kvset where the kblocks are not rewritten, a source vblock
- * index stored in its kblocks needs to be adjusted to obtain the correct output
- * vblock index. This index adjust value is stored in vbidx_adj.
- *
- * vbidx_src is memory-resident and it exists purely for efficient vbidx conversion.
- *
- * The nvgroups, vbidx_out and vbidx_adj for each kvset are persisted in its hblock.
- *
- * Each kvset must contain a vgroup map. A vgroup map is established during all the
- * different types of maintenance operations. However, queries and compaction
- * operations consult a kvset's vgmap only if that kvset is a result of a split
- * operation (flagged by setting a boolean in struct kvset).
- *
- * A vgroup map is also written for a kvset with zero vblocks with nvgroups as 0
- * and w/o any vblock index mappings.
- */
-struct vgmap {
-    uint32_t  nvgroups;  /* number of vgroups */
-    uint16_t *vbidx_out; /* array of output indexes (indexes the vblock list in a kvset) */
-    uint16_t *vbidx_adj; /* array of index adjust offsets */
-    uint16_t *vbidx_src; /* array of source indexes (vblock index recorded in the kblocks) */
 };
 
 merr_t

--- a/lib/cn/kvset_builder.c
+++ b/lib/cn/kvset_builder.c
@@ -325,10 +325,10 @@ kvset_builder_adopt_vblocks(
     uint64_t              vtotal,
     struct vgmap         *vgmap)
 {
-    assert(self->vblk_list.n_blks == 0);
+    assert(self->vblk_list.idc == 0);
 
-    self->vblk_list.blks = vblock_ids;
-    self->vblk_list.n_blks = num_vblocks;
+    self->vblk_list.idv = vblock_ids;
+    self->vblk_list.idc = num_vblocks;
     self->vblk_list.n_alloc = num_vblocks;
     self->vtotal = vtotal;
 
@@ -378,7 +378,7 @@ static merr_t
 kvset_builder_finish(struct kvset_builder *imp)
 {
     merr_t err;
-    bool adopted_vbs = (imp->vblk_list.n_blks > 0);
+    bool adopted_vbs = (imp->vblk_list.idc > 0);
 
     INVARIANT(imp->hbb);
     INVARIANT(imp->kbb);
@@ -397,10 +397,10 @@ kvset_builder_finish(struct kvset_builder *imp)
 
             assert(!imp->vgmap);
             /* In the event we have vblocks, there will always be one vgroup. */
-            if (imp->vblk_list.n_blks > 0) {
+            if (imp->vblk_list.idc > 0) {
                 imp->vgmap = vgmap_alloc(1);
                 if (imp->vgmap) {
-                    uint32_t vbidx_out = imp->vblk_list.n_blks - 1;
+                    uint32_t vbidx_out = imp->vblk_list.idc - 1;
                     /* vgmap_src is passed as NULL as the kblocks are rewritten during
                      * ingest/spill/kv-compact.
                      */
@@ -444,7 +444,7 @@ kvset_builder_finish(struct kvset_builder *imp)
     }
 
     err = hbb_finish(imp->hbb, &imp->hblk_id, imp->vgmap, NULL, NULL, imp->seqno_min, imp->seqno_max,
-                     imp->kblk_list.n_blks, imp->vblk_list.n_blks, hbb_get_nptombs(imp->hbb),
+                     imp->kblk_list.idc, imp->vblk_list.idc, hbb_get_nptombs(imp->hbb),
                      kbb_get_composite_hlog(imp->kbb), NULL, NULL, 0);
     if (err) {
         delete_mblocks(cn_get_dataset(imp->cn), &imp->kblk_list);
@@ -473,17 +473,17 @@ kvset_builder_get_mblocks(struct kvset_builder *self, struct kvset_mblocks *mblk
 
     /* transfer kblock ids to caller */
     list = &self->kblk_list;
-    mblks->kblks.blks = list->blks;
-    mblks->kblks.n_blks = list->n_blks;
-    list->blks = 0;
-    list->n_blks = 0;
+    mblks->kblks.idv = list->idv;
+    mblks->kblks.idc = list->idc;
+    list->idv = 0;
+    list->idc = 0;
 
     /* transfer vblock ids to caller */
     list = &self->vblk_list;
-    mblks->vblks.blks = list->blks;
-    mblks->vblks.n_blks = list->n_blks;
-    list->blks = 0;
-    list->n_blks = 0;
+    mblks->vblks.idv = list->idv;
+    mblks->vblks.idc = list->idc;
+    list->idv = 0;
+    list->idc = 0;
 
     mblks->bl_vtotal = self->vtotal;
     mblks->bl_vused = self->vused;

--- a/lib/cn/kvset_builder_internal.h
+++ b/lib/cn/kvset_builder_internal.h
@@ -39,7 +39,7 @@ struct kvset_builder {
     struct cn *cn;               // pointer to cn struct
 
     struct hblock_builder *hbb;  // hblock builder
-    struct kvs_block hblk;       // hblock id
+    uint64_t hblk_id;            // hblock id
 
     struct kblock_builder *kbb;  // kblock builder
     struct blk_list kblk_list;   // list of kblock ids

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -112,7 +112,6 @@ struct kvset {
     struct kvset_hblk ks_hblk;
 
     const u8 *                ks_klarge; /* large key cache */
-    struct mpool_mcache_map  *ks_kmap;
     struct mbset **           ks_vbsetv;
     uint                      ks_vbsetc;
 

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -47,7 +47,6 @@ struct kvset_hblk {
     uint64_t kh_seqno_max; /* max seqno */
 
     struct hblk_metrics kh_metrics;
-    struct kvs_block kh_hblk;
 };
 
 struct kvset_kblk {
@@ -66,7 +65,6 @@ struct kvset_kblk {
     struct bloom_desc kb_blm_desc;  /* Bloom descriptor */
 
     struct kblk_metrics kb_metrics; /* kblock metrics */
-    struct kvs_block    kb_kblk;    /* blkid and handle */
 };
 
 struct kvset {

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -110,7 +110,6 @@ struct kvset {
     size_t          ks_lcp;       /* longest common prefix */
 
     struct kvset_hblk ks_hblk;
-    struct mpool_mcache_map *ks_hmap; /* hblock mcache map */
 
     const u8 *                ks_klarge; /* large key cache */
     struct mpool_mcache_map  *ks_kmap;

--- a/lib/cn/kvset_split.c
+++ b/lib/cn/kvset_split.c
@@ -33,6 +33,7 @@
 #include "cn_tree.h"
 #include "cn_perfc.h"
 #include "cn_tree_internal.h"
+#include "vgmap.h"
 
 /**
  * struct kvset_split_work - work struct for kvset split

--- a/lib/cn/kvset_split.c
+++ b/lib/cn/kvset_split.c
@@ -241,8 +241,8 @@ kblock_split(
     err = kblock_copy_range(kbd, NULL, split_key, &kblks[LEFT], hlogs[LEFT], &vused[LEFT]);
     if (!err) {
         err = kblock_copy_range(kbd, split_key, NULL, &kblks[RIGHT], hlogs[RIGHT], &vused[RIGHT]);
-        if (!err && (kblks[LEFT].n_blks == 0 && kblks[RIGHT].n_blks == 0)) {
-            assert(kblks[LEFT].n_blks > 0 || kblks[RIGHT].n_blks > 0);
+        if (!err && (kblks[LEFT].idc == 0 && kblks[RIGHT].idc == 0)) {
+            assert(kblks[LEFT].idc > 0 || kblks[RIGHT].idc > 0);
             err = merr(EBUG);
         }
     }
@@ -344,13 +344,13 @@ kblocks_split(
         /* split kblock at split_idx */
         err = kblock_split(&kbd, split_kobj, kblks, hlogs, vused);
 
-        assert((kblks[LEFT].n_blks > 0 && kblks[RIGHT].n_blks > 0) || err);
+        assert((kblks[LEFT].idc > 0 && kblks[RIGHT].idc > 0) || err);
 
         /* Append kblks[LEFT] to the left kvset, kblks[RIGHT] to the right kvset, and both
          * kblks[LEFT] and kblks[RIGHT] to the commit list
          */
-        for (uint32_t i = 0; i < kblks[LEFT].n_blks && !err; i++) {
-            uint64_t blkid = kblks[LEFT].blks[i];
+        for (uint32_t i = 0; i < kblks[LEFT].idc && !err; i++) {
+            uint64_t blkid = kblks[LEFT].idv[i];
 
             err = blk_list_append(&blks_left->kblks, blkid);
             if (!err) {
@@ -361,8 +361,8 @@ kblocks_split(
 
         }
 
-        for (uint32_t i = 0; i < kblks[RIGHT].n_blks && !err; i++) {
-            uint64_t blkid = kblks[RIGHT].blks[i];
+        for (uint32_t i = 0; i < kblks[RIGHT].idc && !err; i++) {
+            uint64_t blkid = kblks[RIGHT].idv[i];
 
             err = blk_list_append(&blks_right->kblks, blkid);
             if (!err) {
@@ -468,8 +468,8 @@ vblocks_split(
     uint32_t vgidx_left = 0, vgidx_right = 0;
     char split_key[HSE_KVS_KEY_LEN_MAX];
     uint32_t split_klen, nvgroups = kvset_get_vgroups(ks), perfc_rwc = 0;
-    bool move_left = (blks_right->kblks.n_blks == 0);
-    bool move_right = (blks_left->kblks.n_blks == 0);
+    bool move_left = (blks_right->kblks.idc == 0);
+    bool move_right = (blks_left->kblks.idc == 0);
     uint64_t perfc_rwb = 0;
     merr_t err;
 
@@ -631,18 +631,18 @@ hblock_split(
     /* Add both the left and the right hblock to the commit list and add the source hblock
      * to the purge list.
      */
-    if (blks_left->kblks.n_blks > 0 || ptree) {
+    if (blks_left->kblks.idc > 0 || ptree) {
         err = hbb_finish(work[LEFT].hbb, &blks_left->hblk_id, work[LEFT].vgmap, &min_pfx, &max_pfx,
-                         min_seqno, max_seqno, blks_left->kblks.n_blks, blks_left->vblks.n_blks,
+                         min_seqno, max_seqno, blks_left->kblks.idc, blks_left->vblks.idc,
                          num_ptombs, hlog_data(work[LEFT].hlog),
                          ptree, &ks->ks_hblk.kh_ptree_desc, ptree_pgc);
         if (!err)
             err = blk_list_append(result->ks[LEFT].blks_commit, blks_left->hblk_id);
     }
 
-    if (!err && (blks_right->kblks.n_blks > 0 || ptree)) {
+    if (!err && (blks_right->kblks.idc > 0 || ptree)) {
         err = hbb_finish(work[RIGHT].hbb, &blks_right->hblk_id, work[RIGHT].vgmap, &min_pfx, &max_pfx,
-                         min_seqno, max_seqno, blks_right->kblks.n_blks, blks_right->vblks.n_blks,
+                         min_seqno, max_seqno, blks_right->kblks.idc, blks_right->vblks.idc,
                          num_ptombs, hlog_data(work[RIGHT].hlog),
                          ptree, &ks->ks_hblk.kh_ptree_desc, ptree_pgc);
         if (!err)

--- a/lib/cn/kvset_split.c
+++ b/lib/cn/kvset_split.c
@@ -428,7 +428,7 @@ get_vblk_split_index(
 
     for (v = start; v <= end; v++) {
         struct vblock_desc *vbd = kvset_get_nth_vblock_desc(ks, v);
-        const void *min_key = vbd->vbd_mblkdesc.map_base + vbd->vbd_min_koff;
+        const void *min_key = vbd->vbd_mblkdesc->map_base + vbd->vbd_min_koff;
 
         if (keycmp(split_key, split_klen, min_key, vbd->vbd_min_klen) < 0)
             break;
@@ -436,7 +436,7 @@ get_vblk_split_index(
 
     if (v > start) {
         struct vblock_desc *vbd = kvset_get_nth_vblock_desc(ks, v - 1);
-        const void *max_key = vbd->vbd_mblkdesc.map_base + vbd->vbd_max_koff;
+        const void *max_key = vbd->vbd_mblkdesc->map_base + vbd->vbd_max_koff;
 
         if (keycmp(split_key, split_klen, max_key, vbd->vbd_max_klen) < 0) {
             *overlap = true;

--- a/lib/cn/mbset.h
+++ b/lib/cn/mbset.h
@@ -16,8 +16,6 @@ struct mpool;
 struct mblock_props;
 struct mbset;
 
-#define MBSET_FLAGS_CAPPED (0x0001)
-
 /* MTF_MOCK_DECL(mbset) */
 
 typedef void

--- a/lib/cn/meson.build
+++ b/lib/cn/meson.build
@@ -20,6 +20,7 @@ cn_sources = files(
     'kvset.c',
     'kvset_builder.c',
     'kvset_split.c',
+    'kvs_mblk_desc.c',
     'mbset.c',
     'move.c',
     'node_split.c',

--- a/lib/cn/node_split.c
+++ b/lib/cn/node_split.c
@@ -587,13 +587,13 @@ cn_split(struct cn_compaction_work *w)
             uint idx = (k == LEFT ? i : i + w->cw_kvset_cnt);
 
             if (blks->hblk_id != 0) {
-                if (drop_ptomb_ks[k] && blks->kblks.n_blks > 0)
+                if (drop_ptomb_ks[k] && blks->kblks.idc > 0)
                     drop_ptomb_ks[k] = false;
 
-                assert(blks->kblks.n_blks > 0 || blks->vblks.n_blks == 0);
+                assert(blks->kblks.idc > 0 || blks->vblks.idc == 0);
 
                 if (HSE_UNLIKELY(drop_ptomb_ks[k])) {
-                    assert(result->ks[k].blks_commit->n_blks == 1);
+                    assert(result->ks[k].blks_commit->idc == 1);
 
                     /* Drop contiguous kvsets containing only ptombs, starting from the oldest.
                      */

--- a/lib/cn/node_split.c
+++ b/lib/cn/node_split.c
@@ -586,7 +586,7 @@ cn_split(struct cn_compaction_work *w)
             struct kvset_mblocks *blks = result->ks[k].blks;
             uint idx = (k == LEFT ? i : i + w->cw_kvset_cnt);
 
-            if (blks->hblk.bk_blkid != 0) {
+            if (blks->hblk_id != 0) {
                 if (drop_ptomb_ks[k] && blks->kblks.n_blks > 0)
                     drop_ptomb_ks[k] = false;
 
@@ -597,7 +597,7 @@ cn_split(struct cn_compaction_work *w)
 
                     /* Drop contiguous kvsets containing only ptombs, starting from the oldest.
                      */
-                    delete_mblock(w->cw_mp, &blks->hblk);
+                    delete_mblock(w->cw_mp, blks->hblk_id);
                     blk_list_free(result->ks[k].blks_commit);
                 } else {
                     w->cw_kvsetidv[idx] = cndb_kvsetid_mint(cndb);

--- a/lib/cn/spill.c
+++ b/lib/cn/spill.c
@@ -174,7 +174,7 @@ cn_subspill_get_kvset_meta(struct subspill *ss, struct kvset_meta *km)
     km->km_vused = ss->ss_mblks.bl_vused;
     km->km_vgarb = ss->ss_mblks.bl_vtotal - km->km_vused;
 
-    km->km_hblk = ss->ss_mblks.hblk;
+    km->km_hblk_id = ss->ss_mblks.hblk_id;
     km->km_kblk_list = ss->ss_mblks.kblks;
     km->km_vblk_list = ss->ss_mblks.vblks;
 

--- a/lib/cn/vblock_builder.c
+++ b/lib/cn/vblock_builder.c
@@ -383,8 +383,8 @@ vbb_add_entry(
     assert(bld->wbuf_off < bld->wbuf_len);
 
     *vboffout = bld->vblk_off;
-    *vbidxout = bld->vblk_list.n_blks - 1;
-    *vbidout = bld->vblk_list.blks[*vbidxout];
+    *vbidxout = bld->vblk_list.idc - 1;
+    *vbidout = bld->vblk_list.idv[*vbidxout];
 
     bld->vblk_off += vlen;
     bld->vsize += vlen;

--- a/lib/cn/vblock_builder.c
+++ b/lib/cn/vblock_builder.c
@@ -384,7 +384,7 @@ vbb_add_entry(
 
     *vboffout = bld->vblk_off;
     *vbidxout = bld->vblk_list.n_blks - 1;
-    *vbidout = bld->vblk_list.blks[*vbidxout].bk_blkid;
+    *vbidout = bld->vblk_list.blks[*vbidxout];
 
     bld->vblk_off += vlen;
     bld->vsize += vlen;

--- a/lib/cn/vblock_reader.h
+++ b/lib/cn/vblock_reader.h
@@ -52,9 +52,9 @@ struct vbr_madvise_work {
  * from media and the relevant information is stored in a @vblock_desc struct.
  */
 struct vblock_desc {
-    struct kvs_mblk_desc vbd_mblkdesc; /* underlying block descriptor */
-    uint32_t             vbd_off;      /* byte offset of vblock data */
-    uint32_t             vbd_len;      /* byte length of vblock data */
+    const struct kvs_mblk_desc *vbd_mblkdesc; /* underlying block descriptor */
+    uint32_t             vbd_off;      /* byte offset of vblock data (always 0!) */
+    uint32_t             vbd_len;      /* byte length of vblock data (not including footer) */
     uint32_t             vbd_min_koff; /* min key offset */
     uint32_t             vbd_max_koff; /* max key offset */
     uint16_t             vbd_min_klen; /* min key length */
@@ -70,23 +70,14 @@ struct vblock_desc {
  */
 merr_t
 vbr_desc_read(
-    struct mpool *           ds,
-    struct mpool_mcache_map *map,
-    uint                     maxidx,
-    uint *                   vgroupsp,
-    u64 *                    argv,
-    struct mblock_props *    props,
-    struct vblock_desc *     vblock_desc);
+    const struct kvs_mblk_desc *mblk,
+    struct vblock_desc *vblk_desc);
 
 merr_t
-vbr_desc_update(
-    struct mpool *           ds,
-    struct mpool_mcache_map *map,
-    uint                     maxidx,
-    uint *                   vgroupsp,
-    u64 *                    argv,
-    struct mblock_props *    props,
-    struct vblock_desc *     vblock_desc);
+vbr_desc_update_vgidx(
+    struct vblock_desc *vblock_desc,
+    uint               *vgroupc,
+    u64                *vgroupv);
 
 /**
  * vbr_madvise_async() - initiate async vblock readahead

--- a/lib/cn/vgmap.h
+++ b/lib/cn/vgmap.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
+ */
+
+#ifndef HSE_CN_VGMAP_H
+#define HSE_CN_VGMAP_H
+
+#include <stdint.h>
+
+/**
+ * struct vgmap - vgroup map
+ *
+ * Vblock indexes are stored with keys in a kvset's kblocks and are used to identify
+ * which vblock in the kvset's list of vblocks holds a key's value. A vgroup map is
+ * associated with a kvset and is used to convert these indexes so they reference the
+ * correct vblock. This conversion is only necessary with kvsets that have been
+ * split because kvset split changes the vblock list but does not update the vblock
+ * indexes stored in the kblocks.
+ *
+ * The last vblock index from each vgroup is stored in vbidx_out.
+ *
+ * In the case of a split kvset where the kblocks are not rewritten, a source vblock
+ * index stored in its kblocks needs to be adjusted to obtain the correct output
+ * vblock index. This index adjust value is stored in vbidx_adj.
+ *
+ * vbidx_src is memory-resident and it exists purely for efficient vbidx conversion.
+ *
+ * The nvgroups, vbidx_out and vbidx_adj for each kvset are persisted in its hblock.
+ *
+ * Each kvset must contain a vgroup map. A vgroup map is established during all the
+ * different types of maintenance operations. However, queries and compaction
+ * operations consult a kvset's vgmap only if that kvset is a result of a split
+ * operation (flagged by setting a boolean in struct kvset).
+ *
+ * A vgroup map is also written for a kvset with zero vblocks with nvgroups as 0
+ * and w/o any vblock index mappings.
+ */
+struct vgmap {
+    uint32_t  nvgroups;  /* number of vgroups */
+    uint16_t *vbidx_out; /* array of output indexes (indexes the vblock list in a kvset) */
+    uint16_t *vbidx_adj; /* array of index adjust offsets */
+    uint16_t *vbidx_src; /* array of source indexes (vblock index recorded in the kblocks) */
+};
+
+#endif

--- a/lib/cndb/cndb.c
+++ b/lib/cndb/cndb.c
@@ -1424,7 +1424,7 @@ cndb_cn_instantiate(struct cndb *cndb, uint64_t cnid, void *ctx, cn_init_callbac
             .km_vgarb = kvset->ck_vgarb,
             .km_capped = cn->cp.kvs_ext01,
             .km_nodeid = kvset->ck_nodeid,
-            .km_hblk.bk_blkid = kvset->ck_hblkid,
+            .km_hblk_id = kvset->ck_hblkid,
             .km_restored = true,
         };
 

--- a/lib/include/hse_ikvdb/blk_list.h
+++ b/lib/include/hse_ikvdb/blk_list.h
@@ -9,9 +9,9 @@
 #include <inttypes.h>
 
 struct blk_list {
-    uint64_t *blks;
+    uint64_t *idv;
+    uint32_t idc;
     uint32_t n_alloc;
-    uint32_t n_blks;
 };
 
 struct kvset_mblocks {

--- a/lib/include/hse_ikvdb/blk_list.h
+++ b/lib/include/hse_ikvdb/blk_list.h
@@ -8,23 +8,14 @@
 
 #include <inttypes.h>
 
-/**
- * struct kvs_block - information about a mblock in a blk_list
- * @bk_blkid:  mblock id
- * @bk_handle: mblock handle
- */
-struct kvs_block {
-    uint64_t bk_blkid;
-};
-
 struct blk_list {
-    struct kvs_block *blks;
+    uint64_t *blks;
     uint32_t n_alloc;
     uint32_t n_blks;
 };
 
 struct kvset_mblocks {
-    struct kvs_block hblk;
+    uint64_t hblk_id;
     struct blk_list kblks;
     struct blk_list vblks;
     uint64_t bl_vtotal;

--- a/lib/include/hse_ikvdb/kvset_builder.h
+++ b/lib/include/hse_ikvdb/kvset_builder.h
@@ -105,7 +105,7 @@ void
 kvset_builder_adopt_vblocks(
     struct kvset_builder *self,
     size_t                num_vblocks,
-    struct kvs_block     *vblocks,
+    uint64_t             *vblock_ids,
     uint64_t              vtotal,
     struct vgmap         *vgmap);
 

--- a/lib/mpool/include/mpool/mpool.h
+++ b/lib/mpool/include/mpool/mpool.h
@@ -458,6 +458,13 @@ mpool_mblock_read(struct mpool *mp, uint64_t mbid, const struct iovec *iov, int 
 merr_t
 mpool_mblock_clone(struct mpool *mp, uint64_t mbid, off_t off, size_t len, uint64_t *mbid_out);
 
+merr_t
+mpool_mblock_mmap(struct mpool *mp, uint64_t mbid, const void **addr_out);
+
+merr_t
+mpool_mblock_munmap(struct mpool *mp, uint64_t mbid);
+
+
 /******************************** MCACHE APIs ************************************/
 
 /**

--- a/lib/mpool/src/mblock.c
+++ b/lib/mpool/src/mblock.c
@@ -144,3 +144,45 @@ mpool_mblock_clone(struct mpool *mp, uint64_t mbid, off_t off, size_t len, uint6
 
     return mblock_fset_clone(mclass_fset(mc), mbid, off, len, mbid_out);
 }
+
+merr_t
+mpool_mblock_mmap(struct mpool *mp, uint64_t mbid, const void **addr_out)
+{
+    struct media_class *mc;
+    uint32_t wlen;
+    merr_t err;
+    char *addr;
+
+    if (!mp || !mbid || !addr_out)
+        return merr(EINVAL);
+
+    mc = mpool_mclass_handle(mp, mcid_to_mclass(mclassid(mbid)));
+    if (!mc)
+        return merr(ENOENT);
+
+    err = mblock_fset_map_getbase(mclass_fset(mc), mbid, &addr, &wlen);
+    if (err)
+        return err;
+
+    *addr_out = (const void *)addr;
+
+    return err;
+}
+
+merr_t
+mpool_mblock_munmap(struct mpool *mp, uint64_t mbid)
+{
+    struct media_class *mc;
+    merr_t err;
+
+    if (!mp || !mbid)
+        return merr(EINVAL);
+
+    mc = mpool_mclass_handle(mp, mcid_to_mclass(mclassid(mbid)));
+    if (!mc)
+        return merr(ENOENT);
+
+    err = mblock_fset_unmap(mclass_fset(mc), mbid);
+
+    return err;
+}

--- a/tests/mocks/meson.build
+++ b/tests/mocks/meson.build
@@ -18,6 +18,7 @@ mocked_headers = [
     meson.project_source_root() / 'lib/cn/kblock_builder.h',
     meson.project_source_root() / 'lib/cn/kcompact.h',
     meson.project_source_root() / 'lib/cn/kvset.h',
+    meson.project_source_root() / 'lib/cn/kvs_mblk_desc.h',
     meson.project_source_root() / 'lib/cn/mbset.h',
     meson.project_source_root() / 'lib/cn/route.h',
     meson.project_source_root() / 'lib/cn/spill.h',

--- a/tests/mocks/repository/lib/mock_kvset.c
+++ b/tests/mocks/repository/lib/mock_kvset.c
@@ -145,13 +145,13 @@ mock_make_kvi(struct kv_iterator **kvi, int src, struct kvs_rparams *rp, struct 
     km.km_dgen_hi = nkv->dgen;
     km.km_dgen_lo = nkv->dgen;
 
-    km.km_kblk_list.n_blks = 1;
+    km.km_kblk_list.idc = 1;
     km.km_kblk_list.n_alloc = 1;
-    km.km_kblk_list.blks = &kid;
+    km.km_kblk_list.idv = &kid;
 
-    km.km_vblk_list.n_blks = 1;
+    km.km_vblk_list.idc = 1;
     km.km_vblk_list.n_alloc = 1;
-    km.km_vblk_list.blks = &vid;
+    km.km_vblk_list.idv = &vid;
 
     err = _make_common(kvi, src, (struct mpool *)ds, rp, &km);
     if (err)
@@ -190,13 +190,13 @@ mock_make_vblocks(struct kv_iterator **kvi, struct kvs_rparams *rp, int nv)
     km.km_dgen_lo = 1;
     km.km_vused = nv * 1000;
 
-    km.km_kblk_list.n_blks = 1;
+    km.km_kblk_list.idc = 1;
     km.km_kblk_list.n_alloc = 1;
-    km.km_kblk_list.blks = &kid;
+    km.km_kblk_list.idv = &kid;
 
-    km.km_vblk_list.n_blks = nv;
+    km.km_vblk_list.idc = nv;
     km.km_vblk_list.n_alloc = nv;
-    km.km_vblk_list.blks = vblk_ids;
+    km.km_vblk_list.idv = vblk_ids;
 
     err = _make_common(kvi, 0, (struct mpool *)kvdata, rp, &km);
     if (err)
@@ -219,7 +219,7 @@ _kvset_open(struct cn_tree *tree, uint64_t kvsetid, struct kvset_meta *km, struc
     int                i = 0, j;
 
     /* +1 for the singular hblock */
-    alloc_sz = sizeof(*mk) + (sizeof(u64) * (1 + km->km_kblk_list.n_blks + km->km_vblk_list.n_blks));
+    alloc_sz = sizeof(*mk) + (sizeof(u64) * (1 + km->km_kblk_list.idc + km->km_vblk_list.idc));
     alloc_sz = ALIGN(alloc_sz, PAGE_SIZE);
 
     mk = mmap(NULL, alloc_sz, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
@@ -241,8 +241,8 @@ _kvset_open(struct cn_tree *tree, uint64_t kvsetid, struct kvset_meta *km, struc
     mk->stats.kst_kvsets = 1;
 
     mk->stats.kst_hblks = 1;
-    mk->stats.kst_kblks = km->km_kblk_list.n_blks;
-    mk->stats.kst_vblks = km->km_vblk_list.n_blks;
+    mk->stats.kst_kblks = km->km_kblk_list.idc;
+    mk->stats.kst_vblks = km->km_vblk_list.idc;
 
     mk->stats.kst_halen = 32 * 1024 * 1024;
     mk->stats.kst_hwlen = 30 * 1024 * 1024;
@@ -263,11 +263,11 @@ _kvset_open(struct cn_tree *tree, uint64_t kvsetid, struct kvset_meta *km, struc
     mk->ref = 1; /* as in reality, kvsets are minted ref 1 */
 
     mk->ids[i++] = km->km_hblk_id;
-    for (i = 1; i < km->km_kblk_list.n_blks; i++)
-        mk->ids[i] = km->km_kblk_list.blks[i];
+    for (i = 1; i < km->km_kblk_list.idc; i++)
+        mk->ids[i] = km->km_kblk_list.idv[i];
 
-    for (j = 0; j < km->km_vblk_list.n_blks; j++, i++)
-        mk->ids[i] = km->km_vblk_list.blks[j];
+    for (j = 0; j < km->km_vblk_list.idc; j++, i++)
+        mk->ids[i] = km->km_vblk_list.idv[j];
 
     *handle = (struct kvset *)mk;
 

--- a/tests/unit/cn/blk_list_test.c
+++ b/tests/unit/cn/blk_list_test.c
@@ -72,14 +72,14 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_blk_list_append, pre, post)
         err = blk_list_append(&b, blkid++);
         ASSERT_EQ(err, 0);
     }
-    ASSERT_EQ(b.n_blks, add);
+    ASSERT_EQ(b.idc, add);
     for (i = 0; i < add; i++)
-        ASSERT_EQ(b.blks[i], blkid_start + i);
+        ASSERT_EQ(b.idv[i], blkid_start + i);
 
     /* A common pattern is to reset blk count to reuse a blk_list
      * without having to re-allocate the array of mblock IDs.
      */
-    b.n_blks = 0;
+    b.idc = 0;
 
     add = 2 * BLK_LIST_PRE_ALLOC + 10;
     blkid_start = blkid;
@@ -87,9 +87,9 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_blk_list_append, pre, post)
         err = blk_list_append(&b, blkid++);
         ASSERT_EQ(err, 0);
     }
-    ASSERT_EQ(b.n_blks, add);
+    ASSERT_EQ(b.idc, add);
     for (i = 0; i < add; i++)
-        ASSERT_EQ(b.blks[i], blkid_start + i);
+        ASSERT_EQ(b.idv[i], blkid_start + i);
 
     blk_list_free(&b);
 
@@ -133,7 +133,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_commit_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = commit_mblock(ds, b.blks[0]);
+    err = commit_mblock(ds, b.idv[0]);
     ASSERT_EQ(err, 0);
     blk_list_free(&b);
 
@@ -143,7 +143,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_commit_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = commit_mblock(ds, b.blks[0]);
+    err = commit_mblock(ds, b.idv[0]);
     ASSERT_NE(err, 0);
     blk_list_free(&b);
     mapi_inject(api, 0);
@@ -159,7 +159,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = delete_mblock(ds, b.blks[0]);
+    err = delete_mblock(ds, b.idv[0]);
     ASSERT_EQ(err, 0);
     blk_list_free(&b);
 
@@ -169,7 +169,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = delete_mblock(ds, b.blks[0]);
+    err = delete_mblock(ds, b.idv[0]);
     ASSERT_NE(err, 0);
     blk_list_free(&b);
     mapi_inject(api, 0);
@@ -178,7 +178,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = delete_mblock(ds, b.blks[0]);
+    err = delete_mblock(ds, b.idv[0]);
     ASSERT_EQ(err, 0);
     blk_list_free(&b);
 }

--- a/tests/unit/cn/blk_list_test.c
+++ b/tests/unit/cn/blk_list_test.c
@@ -74,7 +74,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_blk_list_append, pre, post)
     }
     ASSERT_EQ(b.n_blks, add);
     for (i = 0; i < add; i++)
-        ASSERT_EQ(b.blks[i].bk_blkid, blkid_start + i);
+        ASSERT_EQ(b.blks[i], blkid_start + i);
 
     /* A common pattern is to reset blk count to reuse a blk_list
      * without having to re-allocate the array of mblock IDs.
@@ -89,7 +89,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_blk_list_append, pre, post)
     }
     ASSERT_EQ(b.n_blks, add);
     for (i = 0; i < add; i++)
-        ASSERT_EQ(b.blks[i].bk_blkid, blkid_start + i);
+        ASSERT_EQ(b.blks[i], blkid_start + i);
 
     blk_list_free(&b);
 
@@ -133,7 +133,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_commit_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = commit_mblock(ds, &b.blks[0]);
+    err = commit_mblock(ds, b.blks[0]);
     ASSERT_EQ(err, 0);
     blk_list_free(&b);
 
@@ -143,7 +143,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_commit_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = commit_mblock(ds, &b.blks[0]);
+    err = commit_mblock(ds, b.blks[0]);
     ASSERT_NE(err, 0);
     blk_list_free(&b);
     mapi_inject(api, 0);
@@ -159,7 +159,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = delete_mblock(ds, &b.blks[0]);
+    err = delete_mblock(ds, b.blks[0]);
     ASSERT_EQ(err, 0);
     blk_list_free(&b);
 
@@ -169,7 +169,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = delete_mblock(ds, &b.blks[0]);
+    err = delete_mblock(ds, b.blks[0]);
     ASSERT_NE(err, 0);
     blk_list_free(&b);
     mapi_inject(api, 0);
@@ -178,7 +178,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = delete_mblock(ds, &b.blks[0]);
+    err = delete_mblock(ds, b.blks[0]);
     ASSERT_EQ(err, 0);
     blk_list_free(&b);
 }
@@ -189,8 +189,6 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblocks, pre, post)
     merr_t          err;
     struct blk_list b;
     u32             api;
-
-    delete_mblocks(ds, 0);
 
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);

--- a/tests/unit/cn/cn_ingest_test.c
+++ b/tests/unit/cn/cn_ingest_test.c
@@ -164,7 +164,7 @@ init_mblks(struct kvset_mblocks *p, uint nsets, uint *nk, uint *nv)
     memset(p, 0, nsets * sizeof(*p));
 
     for (i = 0; i < nsets; ++i) {
-        p[i].hblk.bk_blkid = mblk_id++;
+        p[i].hblk_id = mblk_id++;
 
         blk_list_init(&p[i].kblks);
         for (j = 0; j < *nk; j++)

--- a/tests/unit/cn/csched_sp3_test.c
+++ b/tests/unit/cn/csched_sp3_test.c
@@ -61,16 +61,16 @@ init_kvset_meta(u64 dgen)
     memset(&km_kblocks, 0, sizeof(km_kblocks));
     memset(&km_vblocks, 0, sizeof(km_vblocks));
 
-    km.km_kblk_list.n_blks = NELEM(km_kblocks);
-    km.km_vblk_list.n_blks = NELEM(km_vblocks);
+    km.km_kblk_list.idc = NELEM(km_kblocks);
+    km.km_vblk_list.idc = NELEM(km_vblocks);
 
-    km.km_kblk_list.blks = km_kblocks;
-    km.km_vblk_list.blks = km_vblocks;
+    km.km_kblk_list.idv = km_kblocks;
+    km.km_vblk_list.idv = km_vblocks;
 
-    for (i = 0; i < km.km_kblk_list.n_blks; i++)
+    for (i = 0; i < km.km_kblk_list.idc; i++)
         km_kblocks[i] = mbid++;
 
-    for (i = 0; i < km.km_vblk_list.n_blks; i++)
+    for (i = 0; i < km.km_vblk_list.idc; i++)
         km_vblocks[i] = mbid++;
 
     km.km_vused = 1000;

--- a/tests/unit/cn/csched_sp3_test.c
+++ b/tests/unit/cn/csched_sp3_test.c
@@ -48,8 +48,8 @@ struct cndb *        cndb;
  *   - Uses counter for mblock ids.
  */
 struct kvset_meta km;
-struct kvs_block  km_kblocks[4];
-struct kvs_block  km_vblocks[4];
+uint64_t          km_kblocks[4];
+uint64_t          km_vblocks[4];
 u64               mbid = 123456;
 
 static struct kvset_meta *
@@ -68,10 +68,10 @@ init_kvset_meta(u64 dgen)
     km.km_vblk_list.blks = km_vblocks;
 
     for (i = 0; i < km.km_kblk_list.n_blks; i++)
-        km_kblocks[i].bk_blkid = mbid++;
+        km_kblocks[i] = mbid++;
 
     for (i = 0; i < km.km_vblk_list.n_blks; i++)
-        km_vblocks[i].bk_blkid = mbid++;
+        km_vblocks[i] = mbid++;
 
     km.km_vused = 1000;
     km.km_dgen_hi = dgen;

--- a/tests/unit/cn/hblock_builder_test.c
+++ b/tests/unit/cn/hblock_builder_test.c
@@ -143,7 +143,7 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, add_ptomb_success, test_pre, test_
     struct mpool *mpool = (void *)-1;
     struct cn *cn = (void *)-1;
     struct iovec iov[1];
-    struct kvs_block blk;
+    uint64_t mbid;
     const void *pfx, *pfx_min, *pfx_max;
     size_t pfx_min_len = 0, pfx_max_len = 0;
 
@@ -158,10 +158,10 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, add_ptomb_success, test_pre, test_
     err = hbb_create(&bld, cn, NULL);
     ASSERT_EQ(0, merr_errno(err));
 
-    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 0, hlog, NULL, NULL, 0);
+    err = hbb_finish(bld, &mbid, vgmap, NULL, NULL, 0, 1, 1, 3, 0, hlog, NULL, NULL, 0);
     ASSERT_EQ(0, merr_errno(err));
 
-    err = mpool_mblock_read(mpool, blk.bk_blkid, iov, NELEM(iov), 0);
+    err = mpool_mblock_read(mpool, mbid, iov, NELEM(iov), 0);
     ASSERT_EQ(0, merr_errno(err));
     ASSERT_EQ(0, omf_hbh_min_seqno(hdr));
     ASSERT_EQ(1, omf_hbh_max_seqno(hdr));
@@ -179,10 +179,10 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, add_ptomb_success, test_pre, test_
     err = add_ptomb(bld, HSE_KVS_PFX_LEN_MAX, 9, &pfx);
     ASSERT_EQ(0, merr_errno(err));
 
-    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 1, hlog, NULL, NULL, 0);
+    err = hbb_finish(bld, &mbid, vgmap, NULL, NULL, 0, 1, 1, 3, 1, hlog, NULL, NULL, 0);
     ASSERT_EQ(0, merr_errno(err));
 
-    err = mpool_mblock_read(mpool, blk.bk_blkid, iov, NELEM(iov), 0);
+    err = mpool_mblock_read(mpool, mbid, iov, NELEM(iov), 0);
     ASSERT_EQ(0, merr_errno(err));
     ASSERT_EQ(0, omf_hbh_min_seqno(hdr));
     ASSERT_EQ(1, omf_hbh_max_seqno(hdr));
@@ -231,10 +231,10 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, add_ptomb_success, test_pre, test_
         }
     }
 
-    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 190, hlog, NULL, NULL, 0);
+    err = hbb_finish(bld, &mbid, vgmap, NULL, NULL, 0, 1, 1, 3, 190, hlog, NULL, NULL, 0);
     ASSERT_EQ(0, merr_errno(err));
 
-    err = mpool_mblock_read(mpool, blk.bk_blkid, iov, NELEM(iov), 0);
+    err = mpool_mblock_read(mpool, mbid, iov, NELEM(iov), 0);
     ASSERT_EQ(0, merr_errno(err));
     ASSERT_EQ(0, omf_hbh_min_seqno(hdr));
     ASSERT_EQ(1, omf_hbh_max_seqno(hdr));
@@ -256,12 +256,12 @@ MTF_DEFINE_UTEST_PREPOST(hblock_builder_test, finish_null_hlog, test_pre, test_p
     merr_t err;
     struct hblock_builder *bld;
     struct cn *cn = (void *)-1;
-    struct kvs_block blk;
+    uint64_t mbid;
 
     err = hbb_create(&bld, cn, NULL);
     ASSERT_EQ(0, merr_errno(err));
 
-    err = hbb_finish(bld, &blk, vgmap, NULL, NULL, 0, 1, 1, 3, 0, NULL, NULL, NULL, 0);
+    err = hbb_finish(bld, &mbid, vgmap, NULL, NULL, 0, 1, 1, 3, 0, NULL, NULL, NULL, 0);
     ASSERT_EQ(EINVAL, merr_errno(err));
 
     hbb_destroy(bld);

--- a/tests/unit/cn/hblock_reader_test.c
+++ b/tests/unit/cn/hblock_reader_test.c
@@ -13,6 +13,8 @@
 #include <cn/kvs_mblk_desc.h>
 #include <cn/omf.h>
 #include <cn/wbt_reader.h>
+#include <cn/vgmap.h>
+#include <cn/kvset.h>
 
 #include <hse_util/hlog.h>
 #include <hse/error/merr.h>

--- a/tests/unit/cn/kblock_reader_test.c
+++ b/tests/unit/cn/kblock_reader_test.c
@@ -11,8 +11,6 @@
 #include <hse_util/bloom_filter.h>
 #include <hse_util/page.h>
 
-#include <hse_ikvdb/kvs_rparams.h>
-
 #include <cn/omf.h>
 #include <cn/kblock_reader.h>
 #include <cn/bloom_reader.h>
@@ -20,439 +18,318 @@
 #include <cn/wbt_reader.h>
 #include <cn/cn_metrics.h>
 
-#include <mocks/mock_mpool.h>
+/* 1 header page + 4 wbtree pages + 3 bloom pages */
+#define FAKE_WBTREE_DOFF_PG  1
+#define FAKE_WBTREE_DLEN_PG  4
 
-int
-test_collection_setup(struct mtf_test_info *info)
+#define FAKE_BLOOM_DOFF_PG   5
+#define FAKE_BLOOM_DLEN_PG   3
+
+#define FAKE_KBLOCK_SIZE ((1 + 4 + 3) * PAGE_SIZE)
+
+size_t madvise_advice;
+size_t madvise_off;
+size_t madvise_len;
+uint8_t kblock[FAKE_KBLOCK_SIZE];
+struct kvs_mblk_desc mblk;
+
+#define NUM_KEYS         1178
+#define NUM_TOMBSTONES    100
+#define TOT_KEY_BYTES    (NUM_KEYS * 20)
+#define TOT_VAL_BYTES    (NUM_KEYS * 100)
+#define TOT_KVLEN        (NUM_KEYS * 200)
+#define TOT_VUSED_BYTES  ((NUM_KEYS * 100) - 100)
+#define TOT_VGARB_BYTES   0
+
+#define HOFF_ALIGN  8
+#define WBT_HOFF ((sizeof(struct kblock_hdr_omf) + HOFF_ALIGN) & ~(HOFF_ALIGN - 1))
+#define BLM_HOFF (WBT_HOFF + ((sizeof(struct wbt_hdr_omf) + HOFF_ALIGN) & ~(HOFF_ALIGN - 1)))
+
+const struct kblk_metrics met = {
+    .num_keys = NUM_KEYS,
+    .num_tombstones = NUM_TOMBSTONES,
+    .tot_key_bytes = TOT_KEY_BYTES,
+    .tot_val_bytes = TOT_VAL_BYTES,
+    .tot_kvlen = TOT_KVLEN,
+    .tot_vused_bytes = TOT_VUSED_BYTES,
+    .tot_wbt_pages = FAKE_WBTREE_DLEN_PG,
+    .tot_blm_pages = FAKE_BLOOM_DLEN_PG,
+};
+
+const struct kblock_hdr_omf kbhro = {
+    .kbh_magic = KBLOCK_HDR_MAGIC,
+    .kbh_version = KBLOCK_HDR_VERSION,
+
+    .kbh_hlog_doff_pg = 0,
+    .kbh_hlog_dlen_pg = 0,
+
+    .kbh_entries = NUM_KEYS,
+    .kbh_tombs = NUM_TOMBSTONES,
+    .kbh_key_bytes = TOT_KEY_BYTES,
+    .kbh_val_bytes = TOT_VAL_BYTES,
+    .kbh_kvlen = TOT_KVLEN,
+    .kbh_vused_bytes = TOT_VUSED_BYTES,
+    .kbh_vgarb_bytes = TOT_VGARB_BYTES,
+
+    .kbh_min_koff = PAGE_SIZE - 100,
+    .kbh_max_koff = PAGE_SIZE - 50,
+    .kbh_min_klen = 20,
+    .kbh_max_klen = 21,
+
+    .kbh_wbt_hoff = WBT_HOFF,
+    .kbh_wbt_hlen = sizeof(struct wbt_hdr_omf),
+    .kbh_wbt_doff_pg = FAKE_WBTREE_DOFF_PG,
+    .kbh_wbt_dlen_pg = FAKE_WBTREE_DLEN_PG,
+
+    .kbh_blm_hoff = BLM_HOFF,
+    .kbh_blm_hlen = sizeof(struct bloom_hdr_omf),
+    .kbh_blm_doff_pg = FAKE_BLOOM_DOFF_PG,
+    .kbh_blm_dlen_pg = FAKE_BLOOM_DLEN_PG,
+};
+
+void
+init_kblock(struct kblock_hdr_omf *kbh)
 {
+    struct wbt_hdr_omf *wbt = (void *)kbh + WBT_HOFF;
+    struct bloom_hdr_omf *bh = (void *)kbh + BLM_HOFF;
+
+    omf_set_kbh_magic(kbh, kbhro.kbh_magic);
+    omf_set_kbh_version(kbh, kbhro.kbh_version);
+
+    omf_set_kbh_hlog_doff_pg(kbh, kbhro.kbh_hlog_doff_pg);
+    omf_set_kbh_hlog_dlen_pg(kbh, kbhro.kbh_hlog_dlen_pg);
+
+    omf_set_kbh_entries(kbh, kbhro.kbh_entries);
+    omf_set_kbh_tombs(kbh, kbhro.kbh_tombs);
+    omf_set_kbh_key_bytes(kbh, kbhro.kbh_key_bytes);
+    omf_set_kbh_val_bytes(kbh, kbhro.kbh_val_bytes);
+    omf_set_kbh_kvlen(kbh, kbhro.kbh_kvlen);
+    omf_set_kbh_vused_bytes(kbh, kbhro.kbh_vused_bytes);
+    omf_set_kbh_vgarb_bytes(kbh, kbhro.kbh_vgarb_bytes);
+
+    omf_set_kbh_min_koff(kbh, kbhro.kbh_min_koff - 100);
+    omf_set_kbh_min_klen(kbh, kbhro.kbh_min_klen);
+    omf_set_kbh_max_koff(kbh, kbhro.kbh_max_koff - 50);
+    omf_set_kbh_max_klen(kbh, kbhro.kbh_max_klen);
+
+    /* NOTE: fake wbtree is supposed to be at pages 3..12 */
+    omf_set_kbh_wbt_hoff(kbh, kbhro.kbh_wbt_hoff);
+    omf_set_kbh_wbt_hlen(kbh, kbhro.kbh_wbt_hlen);
+    omf_set_kbh_wbt_doff_pg(kbh, kbhro.kbh_wbt_doff_pg);
+    omf_set_kbh_wbt_dlen_pg(kbh, kbhro.kbh_wbt_dlen_pg);
+
+    /* NOTE: fake bloom filter at pages 1..2 */
+    omf_set_kbh_blm_hoff(kbh, kbhro.kbh_blm_hoff);
+    omf_set_kbh_blm_hlen(kbh, kbhro.kbh_blm_hlen);
+    omf_set_kbh_blm_doff_pg(kbh, kbhro.kbh_blm_doff_pg);
+    omf_set_kbh_blm_dlen_pg(kbh, kbhro.kbh_blm_dlen_pg);
+
+    /* wbtree header */
+    omf_set_wbt_magic(wbt, WBT_TREE_MAGIC);
+    omf_set_wbt_version(wbt, WBT_TREE_VERSION);
+    omf_set_wbt_root(wbt, 2);
+    omf_set_wbt_leaf(wbt, 1);
+    omf_set_wbt_leaf_cnt(wbt, 1);
+    omf_set_wbt_kmd_pgc(wbt, 1);
+
+    /* bloom header */
+    omf_set_bh_magic(bh, BLOOM_OMF_MAGIC);
+    omf_set_bh_version(bh, BLOOM_OMF_VERSION);
+    omf_set_bh_bitmapsz(bh, 128);
+    omf_set_bh_modulus(bh, 11);
+    omf_set_bh_bktshift(bh, 8);
+    omf_set_bh_rotl(bh, 8);
+    omf_set_bh_n_hashes(bh, 4);
+}
+
+merr_t
+mock_mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice)
+{
+    madvise_off = off;
+    madvise_len = len;
+    madvise_advice = advice;
     return 0;
 }
 
-int
-test_collection_teardown(struct mtf_test_info *info)
+merr_t
+mock_mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg_off, size_t pg_cnt, int advice)
 {
-    mock_mpool_unset();
+    madvise_off = pg_off * PAGE_SIZE;
+    madvise_len = pg_cnt * PAGE_SIZE;
+    madvise_advice = advice;
     return 0;
 }
 
 int
 pre(struct mtf_test_info *info)
 {
-    mock_mpool_set();
-    return 0;
-}
+    memset(kblock, 0, sizeof(kblock));
+    memset(&mblk, 0, sizeof(mblk));
 
-struct kb_hdr {
-    struct kblock_hdr_omf *kb_hdr;
-    struct wbt_hdr_omf *   wbt_hdr;
-    struct bloom_hdr_omf * blm_hdr;
-    u8                     data[4096];
-};
+    mblk.map_base = kblock;
 
-/* 1 header page + 2 bloom pages +10 wbtree pages */
-#define FAKE_KBLOCK_SIZE ((1 + 2 + 10) * PAGE_SIZE)
+    mblk.alen_pages = FAKE_KBLOCK_SIZE / PAGE_SIZE;
+    mblk.wlen_pages = FAKE_KBLOCK_SIZE / PAGE_SIZE;
+    mblk.mbid = 123;
+    mblk.mclass = 1;
 
-/* an empty buffer for writing to mblocks */
-const char fake_kblock_buf[FAKE_KBLOCK_SIZE];
+    init_kblock(mblk.map_base);
 
-void
-init_kb_hdr(struct kb_hdr *kb)
-{
-    u32 align = 8;
-    u32 wbt_off = (sizeof(struct kblock_hdr_omf) + align) & ~(align - 1);
-    u32 blm_off = wbt_off + ((sizeof(struct wbt_hdr_omf) + align) & ~(align - 1));
+    madvise_off = 12345;
+    madvise_len = 12345;
+    madvise_advice = 12345;
 
-    memset(kb->data, 0, 4096);
-    kb->kb_hdr = (struct kblock_hdr_omf *)(kb->data);
-    kb->wbt_hdr = (struct wbt_hdr_omf *)(kb->data + wbt_off);
-    kb->blm_hdr = (struct bloom_hdr_omf *)(kb->data + blm_off);
-
-    omf_set_kbh_magic(kb->kb_hdr, KBLOCK_HDR_MAGIC);
-    omf_set_kbh_version(kb->kb_hdr, KBLOCK_HDR_VERSION);
-    omf_set_kbh_entries(kb->kb_hdr, 1173);
-    omf_set_kbh_tombs(kb->kb_hdr, 87);
-    omf_set_kbh_key_bytes(kb->kb_hdr, 13789);
-    omf_set_kbh_val_bytes(kb->kb_hdr, 83787);
-    omf_set_kbh_wbt_hoff(kb->kb_hdr, wbt_off);
-
-    /* NOTE: fake bloom filter at pages 1..2 */
-    omf_set_kbh_blm_hlen(kb->kb_hdr, sizeof(struct bloom_hdr_omf));
-    omf_set_kbh_blm_doff_pg(kb->kb_hdr, 1);
-    omf_set_kbh_blm_dlen_pg(kb->kb_hdr, 2);
-
-    /* NOTE: fake wbtree is supposed to be at pages 3..12 */
-    omf_set_kbh_wbt_hlen(kb->kb_hdr, sizeof(struct wbt_hdr_omf));
-    omf_set_kbh_wbt_doff_pg(kb->kb_hdr, 3);
-    omf_set_kbh_wbt_dlen_pg(kb->kb_hdr, 10);
-    omf_set_kbh_blm_hoff(kb->kb_hdr, blm_off);
-
-    omf_set_wbt_magic(kb->wbt_hdr, WBT_TREE_MAGIC);
-    omf_set_wbt_version(kb->wbt_hdr, WBT_TREE_VERSION);
-    omf_set_wbt_root(kb->wbt_hdr, 0);
-    omf_set_wbt_leaf(kb->wbt_hdr, 0);
-    omf_set_wbt_leaf_cnt(kb->wbt_hdr, 0);
-
-    omf_set_bh_magic(kb->blm_hdr, BLOOM_OMF_MAGIC);
-    omf_set_bh_version(kb->blm_hdr, BLOOM_OMF_VERSION);
-
-    omf_set_bh_modulus(kb->blm_hdr, 11730);
-    omf_set_bh_bktshift(kb->blm_hdr, BF_BKTSHIFT);
-    omf_set_bh_rotl(kb->blm_hdr, BF_ROTL);
-    omf_set_bh_n_hashes(kb->blm_hdr, 7);
-    omf_set_bh_bitmapsz(kb->blm_hdr, ALIGN((omf_bh_modulus(kb->blm_hdr) / CHAR_BIT), PAGE_SIZE));
-}
-
-merr_t
-write_kb_hdr(struct kb_hdr *kb, struct kvs_mblk_desc *blkdesc)
-{
-    return mpm_mblock_write(blkdesc->mbid, kb->data, 0, PAGE_SIZE);
-}
-
-int
-check_read_hdrs(
-    struct kb_hdr *       kb,
-    struct kvs_mblk_desc *blkdesc,
-    int                   wbt_errno,
-    int                   blm_errno)
-{
-    merr_t            err;
-    struct wbt_desc   wb_desc;
-    struct bloom_desc blm_desc;
-
-    write_kb_hdr(kb, blkdesc);
-
-    err = kbr_read_wbt_region_desc(blkdesc, &wb_desc);
-    VERIFY_EQ_RET(merr_errno(err), wbt_errno, 1);
-
-    err = kbr_read_blm_region_desc(blkdesc, &blm_desc);
-    VERIFY_EQ_RET(merr_errno(err), blm_errno, 1);
+    MOCK_SET_FN(mblk_desc, mblk_madvise, mock_mblk_madvise);
+    MOCK_SET_FN(mblk_desc, mblk_madvise_pages, mock_mblk_madvise_pages);
 
     return 0;
 }
 
-MTF_BEGIN_UTEST_COLLECTION_PREPOST(
-    kblock_reader_test,
-    test_collection_setup,
-    test_collection_teardown);
+MTF_BEGIN_UTEST_COLLECTION(kblock_reader);
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_kbr_get_kblock_desc, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_read_wbt_region_desc, pre)
 {
-    merr_t                   err;
-    struct mpool *           ds = (void *)-1;
-    struct mpool_mcache_map *map = (struct mpool_mcache_map *)0x123;
-    u32                      map_idx = 3;
-    u64                      kbid = 0xffff;
-    struct kvs_mblk_desc     desc;
-    struct mblock_props      props = { 0 };
+    merr_t err;
+    struct wbt_desc wbt;
 
-    /* force success w/o having an actual mblock */
-    mapi_inject_ptr(mapi_idx_mpool_mcache_getbase, (void *)1);
-    err = kbr_get_kblock_desc(ds, map, &props, map_idx, kbid, &desc);
-    ASSERT_EQ(err, 0);
-
-    /* force fail */
-    mapi_inject_ptr(mapi_idx_mpool_mcache_getbase, 0);
-    err = kbr_get_kblock_desc(ds, map, &props, map_idx, kbid, &desc);
-    ASSERT_NE(err, 0);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
+    ASSERT_EQ(0, err);
+    ASSERT_EQ(wbt.wbd_first_page, kbhro.kbh_wbt_doff_pg);
+    ASSERT_EQ(wbt.wbd_n_pages, kbhro.kbh_wbt_dlen_pg);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, basic_wbt_blm_test, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_read_blm_region_desc, pre)
 {
-    merr_t               err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct wbt_desc      wb_desc;
-    struct bloom_desc    blm_desc;
-    struct kb_hdr        kb;
-    struct kblk_metrics  metrics;
-    struct kvs_mblk_desc blkdesc;
-    u64                  blkid;
+    merr_t err;
+    struct bloom_desc blm;
 
-    memset(&blkdesc, 0, sizeof(blkdesc));
-
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
+    err = kbr_read_blm_region_desc(&mblk, &blm);
     ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
-
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
-    ASSERT_EQ(0, err);
-
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
-
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
-
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(0, err);
-    ASSERT_EQ(omf_kbh_wbt_doff_pg(kb.kb_hdr), wb_desc.wbd_first_page);
-    ASSERT_EQ(omf_kbh_wbt_dlen_pg(kb.kb_hdr), wb_desc.wbd_n_pages);
-
-    err = kbr_read_blm_region_desc(&blkdesc, &blm_desc);
-    ASSERT_EQ(0, err);
-    ASSERT_EQ(omf_kbh_blm_doff_pg(kb.kb_hdr), blm_desc.bd_first_page);
-    ASSERT_EQ(omf_kbh_blm_dlen_pg(kb.kb_hdr), blm_desc.bd_n_pages);
-
-    /* BLOOM_LOOKUP_MCACHE will return base address of the bloom
-     * blocks in the mcache map.
-     */
-    blm_desc.bd_bitmap = NULL;
-    err = kbr_read_blm_pages(&blkdesc, &blm_desc);
-    ASSERT_EQ(0, err);
-    ASSERT_NE(NULL, blm_desc.bd_bitmap);
-
-    mapi_inject_once(mapi_idx_mpool_mcache_getpages, 1, EBUG);
-    blm_desc.bd_bitmap = NULL;
-    err = kbr_read_blm_pages(&blkdesc, &blm_desc);
-    ASSERT_NE(0, err);
-    ASSERT_EQ(NULL, blm_desc.bd_bitmap);
-
-    err = kbr_read_metrics(&blkdesc, &metrics);
-
-    ASSERT_EQ(0, err);
-    ASSERT_EQ(omf_kbh_entries(kb.kb_hdr), metrics.num_keys);
-    ASSERT_EQ(omf_kbh_tombs(kb.kb_hdr), metrics.num_tombstones);
-    ASSERT_EQ(omf_kbh_key_bytes(kb.kb_hdr), metrics.tot_key_bytes);
-    ASSERT_EQ(omf_kbh_val_bytes(kb.kb_hdr), metrics.tot_val_bytes);
-
-    mpool_mcache_munmap(blkdesc.map);
+    ASSERT_EQ(blm.bd_first_page, kbhro.kbh_blm_doff_pg);
+    ASSERT_EQ(blm.bd_n_pages, kbhro.kbh_blm_dlen_pg);
+    ASSERT_EQ(blm.bd_bitmap, mblk.map_base + PAGE_SIZE * blm.bd_first_page);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_kbr_madvise_bloom, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_read_metrics, pre)
 {
-    merr_t               err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct kb_hdr        kb;
-    struct kvs_mblk_desc blkdesc;
-    struct bloom_desc    blm_desc;
-    u64                  blkid;
+    merr_t err;
+    struct kblk_metrics met;
 
-    memset(&blkdesc, 0, sizeof(blkdesc));
-
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
+    err = kbr_read_metrics(&mblk, &met);
     ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
+    ASSERT_EQ(met.num_keys, kbhro.kbh_entries);
+    ASSERT_EQ(met.num_tombstones, kbhro.kbh_tombs);
+    ASSERT_EQ(met.tot_key_bytes, kbhro.kbh_key_bytes);
+    ASSERT_EQ(met.tot_val_bytes, kbhro.kbh_val_bytes);
+    ASSERT_EQ(met.tot_kvlen, kbhro.kbh_kvlen);
+    ASSERT_EQ(met.tot_vused_bytes, kbhro.kbh_vused_bytes);
+    ASSERT_EQ(met.tot_wbt_pages, kbhro.kbh_wbt_dlen_pg);
+    ASSERT_EQ(met.tot_blm_pages, kbhro.kbh_blm_dlen_pg);
 
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
-    ASSERT_EQ(0, err);
-
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
-
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
-
-    err = kbr_read_blm_region_desc(&blkdesc, &blm_desc);
-    ASSERT_EQ(err, 0);
-
-    /* once w/ forced error */
-    mapi_inject_once(mapi_idx_mpool_mcache_madvise, 1, EINVAL);
-    kbr_madvise_bloom(&blkdesc, &blm_desc, MADV_WILLNEED);
-
-    /* once w/o error */
-    kbr_madvise_bloom(&blkdesc, &blm_desc, MADV_WILLNEED);
-
-    blm_desc.bd_n_pages = 0;
-    kbr_madvise_bloom(&blkdesc, &blm_desc, MADV_WILLNEED);
-
-    mpool_mcache_munmap(blkdesc.map);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_kbr_madvise_wbt_leaf_nodes, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_read_invalid_version, pre)
 {
-    merr_t               err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct kb_hdr        kb = {};
-    struct kvs_mblk_desc blkdesc = {};
-    struct wbt_desc      wb_desc = {};
-    u64                  blkid = 0;
+    merr_t err;
+    struct wbt_desc wbt;
+    struct kblk_metrics met;
+    struct bloom_desc blm;
+    struct kblock_hdr_omf *kbh = mblk.map_base;
 
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
-    ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
+    omf_set_kbh_version(kbh, kbhro.kbh_version + 1);
 
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
-    ASSERT_EQ(0, err);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
+    ASSERT_EQ(EINVAL, merr_errno(err));
 
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
+    err = kbr_read_blm_region_desc(&mblk, &blm);
+    ASSERT_EQ(EINVAL, merr_errno(err));
 
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
-
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(err, 0);
-
-    /* once w/ forced error */
-    mapi_inject_once(mapi_idx_mpool_mcache_madvise, 1, EINVAL);
-    kbr_madvise_wbt_leaf_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    /* once w/o error */
-    kbr_madvise_wbt_leaf_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    wb_desc.wbd_leaf_cnt = 0;
-    kbr_madvise_wbt_leaf_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    mpool_mcache_munmap(blkdesc.map);
+    err = kbr_read_metrics(&mblk, &met);
+    ASSERT_EQ(EINVAL, merr_errno(err));
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_kbr_madvise_wbt_int_nodes, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_madvise_kmd, pre)
 {
-    merr_t               err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct kb_hdr        kb = {};
-    struct kvs_mblk_desc blkdesc = {};
-    struct wbt_desc      wb_desc = {};
-    u64                  blkid = 0;
+    merr_t err;
+    int adv;
+    uint32_t pg_off, pg_cnt;
+    struct wbt_desc wbt;
 
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
-    ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
-
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
     ASSERT_EQ(0, err);
 
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
+    adv = __LINE__;
+    pg_off = wbt.wbd_first_page + wbt.wbd_root + 1;
+    pg_cnt = wbt.wbd_kmd_pgc;
 
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
+    kbr_madvise_kmd(&mblk, &wbt, adv);
 
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(err, 0);
-
-    /* once w/ forced error */
-    mapi_inject_once(mapi_idx_mpool_mcache_madvise, 1, EINVAL);
-    kbr_madvise_wbt_int_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    /* once w/o error */
-    kbr_madvise_wbt_int_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    wb_desc.wbd_n_pages = 0;
-    wb_desc.wbd_leaf_cnt = 0;
-    kbr_madvise_wbt_int_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    mpool_mcache_munmap(blkdesc.map);
+    ASSERT_EQ(madvise_advice, adv);
+    ASSERT_EQ(madvise_off, PAGE_SIZE * pg_off);
+    ASSERT_EQ(madvise_len, PAGE_SIZE * pg_cnt);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_corrupt_header, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_madvise_wbt_leaf_nodes, pre)
 {
-    merr_t               err;
-    struct kvs_mblk_desc blkdesc;
-    struct kb_hdr        kb;
-    struct mpool *       mp_ds = (void *)-1;
-    u64                  blkid;
+    merr_t err;
+    int adv;
+    uint32_t pg_off, pg_cnt;
+    struct wbt_desc wbt;
 
-    memset(&blkdesc, 0, sizeof(blkdesc));
-
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
-    ASSERT_EQ(err, 0);
-    blkdesc.mbid = blkid;
-
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
     ASSERT_EQ(0, err);
 
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(err, 0);
+    adv = __LINE__;
+    pg_off = wbt.wbd_first_page;
+    pg_cnt = wbt.wbd_leaf_cnt;
 
-    /* verify we can read w/o corruption */
-    init_kb_hdr(&kb);
-    err = check_read_hdrs(&kb, &blkdesc, 0, 0);
-    ASSERT_EQ(err, 0);
+    kbr_madvise_wbt_leaf_nodes(&mblk, &wbt, adv);
 
-    /* corrupt kblock hdr magic */
-    init_kb_hdr(&kb);
-    omf_set_kbh_magic(kb.kb_hdr, omf_kbh_magic(kb.kb_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, EINVAL, EINVAL);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt kblock hdr version */
-    init_kb_hdr(&kb);
-    omf_set_kbh_version(kb.kb_hdr, omf_kbh_version(kb.kb_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, EINVAL, EINVAL);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt wbt hdr magic */
-    init_kb_hdr(&kb);
-    omf_set_wbt_magic(kb.wbt_hdr, omf_wbt_magic(kb.wbt_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, EINVAL, 0);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt wbt hdr version */
-    init_kb_hdr(&kb);
-    omf_set_wbt_version(kb.wbt_hdr, omf_wbt_version(kb.wbt_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, EINVAL, 0);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt blm hdr magic */
-    init_kb_hdr(&kb);
-    omf_set_bh_magic(kb.blm_hdr, omf_bh_magic(kb.blm_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, 0, EINVAL);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt blm hdr version */
-    /* check should succeed, but with blooms disabled */
-    init_kb_hdr(&kb);
-    omf_set_bh_version(kb.blm_hdr, omf_bh_version(kb.blm_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, 0, 0);
-    ASSERT_EQ(err, 0);
-
-    mpool_mcache_munmap(blkdesc.map);
+    ASSERT_EQ(madvise_advice, adv);
+    ASSERT_EQ(madvise_off, PAGE_SIZE * pg_off);
+    ASSERT_EQ(madvise_len, PAGE_SIZE * pg_cnt);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, basic_kblock_error_test, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_madvise_wbt_int_nodes, pre)
 {
-    merr_t               err, force_err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct kb_hdr        kb;
-    struct wbt_desc      wb_desc;
-    struct bloom_desc    blm_desc;
-    struct kvs_mblk_desc blkdesc;
-    u64                  blkid;
+    merr_t err;
+    int adv;
+    uint32_t pg_off, pg_cnt;
+    struct wbt_desc wbt;
 
-    memset(&blkdesc, 0, sizeof(blkdesc));
-
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
-    ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
-
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
     ASSERT_EQ(0, err);
 
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
+    adv = __LINE__;
+    pg_off = wbt.wbd_first_page + wbt.wbd_leaf_cnt;
+    pg_cnt = wbt.wbd_n_pages - wbt.wbd_leaf_cnt - wbt.wbd_kmd_pgc;
 
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
+    kbr_madvise_wbt_int_nodes(&mblk, &wbt, adv);
 
-    force_err = __LINE__;
-    mapi_inject_ptr(mapi_idx_mpool_mcache_getpages, (void *)force_err);
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(force_err, err);
-    mapi_inject_unset(mapi_idx_mpool_mcache_getpages);
-
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(0, err);
-
-    force_err = __LINE__;
-    mapi_inject_ptr(mapi_idx_mpool_mcache_getpages, (void *)force_err);
-    err = kbr_read_blm_region_desc(&blkdesc, &blm_desc);
-    ASSERT_EQ(force_err, err);
-    mapi_inject_unset(mapi_idx_mpool_mcache_getpages);
-
-    err = kbr_read_blm_region_desc(&blkdesc, &blm_desc);
-    ASSERT_EQ(0, err);
-
-    /* kbr_read_blm_pages() should return base address of the bloom blocks in the mcache map.
-     */
-    blm_desc.bd_bitmap = NULL;
-    err = kbr_read_blm_pages(&blkdesc, &blm_desc);
-    ASSERT_EQ(0, err);
-    ASSERT_NE(NULL, blm_desc.bd_bitmap);
+    ASSERT_EQ(madvise_advice, adv);
+    ASSERT_EQ(madvise_off, PAGE_SIZE * pg_off);
+    ASSERT_EQ(madvise_len, PAGE_SIZE * pg_cnt);
 }
 
-MTF_END_UTEST_COLLECTION(kblock_reader_test)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_madvise_bloom, pre)
+{
+    merr_t err;
+    int adv;
+    uint32_t pg_off, pg_cnt;
+    struct bloom_desc blm;
+
+    err = kbr_read_blm_region_desc(&mblk, &blm);
+    ASSERT_EQ(0, err);
+
+    adv = __LINE__;
+    pg_off = blm.bd_first_page;
+    pg_cnt = blm.bd_n_pages;
+
+    kbr_madvise_bloom(&mblk, &blm, adv);
+
+    ASSERT_EQ(madvise_advice, adv);
+    ASSERT_EQ(madvise_off, PAGE_SIZE * pg_off);
+    ASSERT_EQ(madvise_len, PAGE_SIZE * pg_cnt);
+}
+
+MTF_END_UTEST_COLLECTION(kblock_reader)

--- a/tests/unit/cn/kcompact_test.c
+++ b/tests/unit/cn/kcompact_test.c
@@ -307,7 +307,7 @@ MTF_DEFINE_UTEST_PRE(kcompact_test, four_into_one, pre)
     ASSERT_EQ(w.cw_stats.ms_keys_out, 10);
     ASSERT_EQ(w.cw_stats.ms_val_bytes_out, 10 * sizeof(int));
 
-    free(output.vblks.blks);
+    free(output.vblks.idv);
     for (i = 0; i < NITER; ++i) {
         struct mock_kv_iterator *iter = container_of(itv[i], typeof(*iter), kvi);
 
@@ -380,7 +380,7 @@ MTF_DEFINE_UTEST_PRE(kcompact_test, all_gone, pre)
     ASSERT_EQ(w.cw_stats.ms_keys_out, 10);
     ASSERT_EQ(w.cw_stats.ms_val_bytes_out, 0);
 
-    free(output.vblks.blks);
+    free(output.vblks.idv);
     for (i = 0; i < 5; ++i) {
         struct mock_kv_iterator *iter = container_of(itv[i], typeof(*iter), kvi);
 
@@ -452,7 +452,7 @@ MTF_DEFINE_UTEST_PREPOST(kcompact_test, all_gone_mixed, mixed_pre, mixed_post)
     ASSERT_EQ(w.cw_stats.ms_keys_out, 10);
     ASSERT_EQ(w.cw_stats.ms_val_bytes_out, 0);
 
-    free(output.vblks.blks);
+    free(output.vblks.idv);
     for (i = 0; i < 5; ++i) {
         struct mock_kv_iterator *iter = container_of(itv[i], typeof(*iter), kvi);
 
@@ -515,7 +515,7 @@ MTF_DEFINE_UTEST_PREPOST(kcompact_test, four_into_one_mixed, mixed_pre, mixed_po
     ASSERT_EQ(w.cw_stats.ms_keys_in, 200 * NITER);
     ASSERT_EQ(w.cw_stats.ms_keys_out, 200);
 
-    free(output.vblks.blks);
+    free(output.vblks.idv);
     for (i = 0; i < NITER; ++i) {
         struct mock_kv_iterator *iter = container_of(itv[i], typeof(*iter), kvi);
 
@@ -585,7 +585,7 @@ run_kcompact(struct mtf_test_info *lcl_ti, int expect)
     else
         ASSERT_EQ_RET(err, expect, 1);
 
-    free(output.vblks.blks);
+    free(output.vblks.idv);
     for (i = 0; i < 5; ++i) {
         struct mock_kv_iterator *iter = container_of(itv[i], typeof(*iter), kvi);
 

--- a/tests/unit/cn/kcompact_test.c
+++ b/tests/unit/cn/kcompact_test.c
@@ -17,6 +17,7 @@
 #include <cn/kcompact.h>
 #include <cn/kvset.h>
 #include <cn/cn_metrics.h>
+#include <cn/vgmap.h>
 
 #include <mocks/mock_kvset.h>
 #include <mocks/mock_kvset_builder.h>

--- a/tests/unit/cn/merge_test.c
+++ b/tests/unit/cn/merge_test.c
@@ -34,6 +34,7 @@
 #include <cn/kvset.h>
 #include <cn/route.h>
 #include <cn/omf.h>
+#include <cn/vgmap.h>
 
 #include <dirent.h>
 

--- a/tests/unit/cn/merge_test.c
+++ b/tests/unit/cn/merge_test.c
@@ -1016,7 +1016,7 @@ run_testcase(struct mtf_test_info *lcl_ti, int mode, const char *info)
         vbmap.vbm_blkv = mapi_safe_malloc(sizeof(*vbmap.vbm_blkv) * iterc);
 
         for (i = 0; i < iterc; i++) {
-            vbmap.vbm_blkv[i].bk_blkid = 1000 + i;
+            vbmap.vbm_blkv[i] = 1000 + i;
             map[i] = 0;
         }
         vbmap.vbm_map = map;

--- a/tests/unit/cn/vblock_builder_test.c
+++ b/tests/unit/cn/vblock_builder_test.c
@@ -185,7 +185,7 @@ MTF_DEFINE_UTEST_PRE(test, t_vbb_finish_empty1, test_setup)
 
     err = vbb_finish(vbb, &blks, &max_kobj);
     ASSERT_EQ(err, 0);
-    ASSERT_EQ(blks.n_blks, 0);
+    ASSERT_EQ(blks.idc, 0);
     blk_list_free(&blks);
 
     vbb_destroy(vbb);
@@ -233,9 +233,9 @@ MTF_DEFINE_UTEST_PRE(test, t_vbb_finish_exact, test_setup)
 
     err = vbb_finish(vbb, &blks, &max_kobj);
     ASSERT_EQ(err, 0);
-    ASSERT_GE(blks.n_blks, 1);
+    ASSERT_GE(blks.idc, 1);
 
-    verify_vblock_footer(lcl_ti, blks.blks[0], HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
+    verify_vblock_footer(lcl_ti, blks.idv[0], HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
 
     blk_list_free(&blks);
     vbb_destroy(vbb);
@@ -304,7 +304,7 @@ MTF_DEFINE_UTEST_PRE(test, t_vbb_add_entry_exact, test_setup)
 
     err = vbb_finish(vbb, &blks, &max_kobj);
     ASSERT_EQ(err, 0);
-    ASSERT_GE(blks.n_blks, 1);
+    ASSERT_GE(blks.idc, 1);
 
     blk_list_free(&blks);
     vbb_destroy(vbb);
@@ -325,10 +325,10 @@ MTF_DEFINE_UTEST_PRE(test, t_vbb_add_entry_exact, test_setup)
 
     err = vbb_finish(vbb, &blks, &max_kobj);
     ASSERT_EQ(err, 0);
-    ASSERT_EQ(blks.n_blks, 2); /* verify 1 vblock */
+    ASSERT_EQ(blks.idc, 2); /* verify 1 vblock */
 
-    verify_vblock_footer(lcl_ti, blks.blks[0], HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
-    verify_vblock_footer(lcl_ti, blks.blks[1], PAGE_SIZE);
+    verify_vblock_footer(lcl_ti, blks.idv[0], HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
+    verify_vblock_footer(lcl_ti, blks.idv[1], PAGE_SIZE);
 
     blk_list_free(&blks);
     vbb_destroy(vbb);
@@ -577,10 +577,10 @@ run_test_case(struct mtf_test_info *lcl_ti, enum test_case tc, size_t n_vblocks)
 
             err = vbb_finish(vbb, &blks, &max_kobj);
             ASSERT_EQ_RET(0, err, 1);
-            ASSERT_EQ_RET(blks.n_blks, n_vblocks, 1);
+            ASSERT_EQ_RET(blks.idc, n_vblocks, 1);
             for (i = 0; i < n_vblocks; i++) {
-                ASSERT_EQ_RET(blks.blks[i], MPM_MBLOCK_ID_BASE + i, 1);
-                verify_vblock_footer(lcl_ti, blks.blks[i],
+                ASSERT_EQ_RET(blks.idv[i], MPM_MBLOCK_ID_BASE + i, 1);
+                verify_vblock_footer(lcl_ti, blks.idv[i],
                                      HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
             }
 

--- a/tests/unit/cn/vblock_builder_test.c
+++ b/tests/unit/cn/vblock_builder_test.c
@@ -235,7 +235,7 @@ MTF_DEFINE_UTEST_PRE(test, t_vbb_finish_exact, test_setup)
     ASSERT_EQ(err, 0);
     ASSERT_GE(blks.n_blks, 1);
 
-    verify_vblock_footer(lcl_ti, blks.blks->bk_blkid, HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
+    verify_vblock_footer(lcl_ti, blks.blks[0], HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
 
     blk_list_free(&blks);
     vbb_destroy(vbb);
@@ -327,8 +327,8 @@ MTF_DEFINE_UTEST_PRE(test, t_vbb_add_entry_exact, test_setup)
     ASSERT_EQ(err, 0);
     ASSERT_EQ(blks.n_blks, 2); /* verify 1 vblock */
 
-    verify_vblock_footer(lcl_ti, blks.blks[0].bk_blkid, HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
-    verify_vblock_footer(lcl_ti, blks.blks[1].bk_blkid, PAGE_SIZE);
+    verify_vblock_footer(lcl_ti, blks.blks[0], HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
+    verify_vblock_footer(lcl_ti, blks.blks[1], PAGE_SIZE);
 
     blk_list_free(&blks);
     vbb_destroy(vbb);
@@ -579,8 +579,8 @@ run_test_case(struct mtf_test_info *lcl_ti, enum test_case tc, size_t n_vblocks)
             ASSERT_EQ_RET(0, err, 1);
             ASSERT_EQ_RET(blks.n_blks, n_vblocks, 1);
             for (i = 0; i < n_vblocks; i++) {
-                ASSERT_EQ_RET(blks.blks[i].bk_blkid, MPM_MBLOCK_ID_BASE + i, 1);
-                verify_vblock_footer(lcl_ti, blks.blks[i].bk_blkid,
+                ASSERT_EQ_RET(blks.blks[i], MPM_MBLOCK_ID_BASE + i, 1);
+                verify_vblock_footer(lcl_ti, blks.blks[i],
                                      HSE_KVS_VALUE_LEN_MAX - VBLOCK_FOOTER_LEN);
             }
 

--- a/tools/cndump/kvset_dump.c
+++ b/tools/cndump/kvset_dump.c
@@ -419,7 +419,7 @@ wbt_dump_impl(struct dump_mblock *mblk, const struct wbt_hdr_omf *wbt)
     uint wbt_doff = omf_kbh_wbt_doff_pg(kbh);
     const uint8_t *kmd = p + pgoff(wbt_doff + omf_wbt_root(wbt) + 1);
 
-    printf("  wbthdr: magic 0x%08x  ver %d  root %d  leaf1 %d  nleaf %d kmdpgc %d\n",
+    printf("  wbthdr: magic 0x%08x  ver %d  root %d  leaf %d  leaf_cnt %d kmd_pgc %d\n",
         omf_wbt_magic(wbt), omf_wbt_version(wbt), omf_wbt_root(wbt),
         omf_wbt_leaf(wbt), omf_wbt_leaf_cnt(wbt), omf_wbt_kmd_pgc(wbt));
 
@@ -537,8 +537,6 @@ bloom_dump(struct dump_mblock *mblk)
     printf("  bloom bucket size:   %5lu (%lu bits)\n", bktsz, bitsperbkt);
     printf("  bloom empty buckets: %5u\n", cntempty);
     printf("  bloom full buckets:  %5u\n", cntfull);
-    printf("  bloom dist    min:  %6.3lf (%u / %zu)\n",
-        (double)cntv[0] / bitsperbkt, cntv[0], bitsperbkt);
 
     printf("  bloom dist    min:  %6.3lf (%u / %zu)\n",
         (double)cntv[0] / bitsperbkt, cntv[0], bitsperbkt);
@@ -585,6 +583,7 @@ hblock_dump(struct dump_mblock *mblk)
 {
     const void *p = mblk->data;
     const struct hblock_hdr_omf *hbh = p;
+    uint pg, pgc;
 
     printf("\nhblock: ");
 
@@ -595,9 +594,17 @@ hblock_dump(struct dump_mblock *mblk)
         omf_hbh_min_seqno(hbh), omf_hbh_min_seqno(hbh),
         omf_hbh_num_ptombs(hbh), omf_hbh_num_kblocks(hbh), omf_hbh_num_vblocks(hbh));
 
-    printf("  vgmap page off/len %u %u, hlog page off/len %u %u\n",
-        omf_hbh_vgmap_off_pg(hbh), omf_hbh_vgmap_len_pg(hbh),
-        omf_hbh_hlog_off_pg(hbh), omf_hbh_hlog_len_pg(hbh));
+    pg  = omf_hbh_vgmap_off_pg(hbh);
+    pgc = omf_hbh_vgmap_len_pg(hbh);
+    printf("  vgmap pages [%u..%u], pgc %u\n", pg, pg + pgc - 1, pgc);
+
+    pg  = omf_hbh_hlog_off_pg(hbh);
+    pgc = omf_hbh_hlog_len_pg(hbh);
+    printf("  hlog  pages [%u..%u], pgc %u\n", pg, pg + pgc - 1, pgc);
+
+    pg  = omf_hbh_ptree_data_off_pg(hbh);
+    pgc = omf_hbh_ptree_data_len_pg(hbh);
+    printf("  ptree pages [%u..%u], pgc %u\n", pg, pg + pgc - 1, pgc);
 
     printf("  max_ptomb byte off/len %u %u, min_ptomb off/len %u %u\n",
         omf_hbh_max_pfx_off(hbh),


### PR DESCRIPTION
This PR contains lot of changes:
- Created mmap and mummap methods for struct kvs_mblk_desc
- Mofied hblock, kblock and vblock readers to use new mmap method
- Similar changes to mbsets
- Significant unit test changes
 