### PR TITLE
Add way to detect an internally aborted transaction

### DIFF
--- a/include/hse/types.h
+++ b/include/hse/types.h
@@ -55,6 +55,7 @@ typedef uint64_t hse_err_t;
 /** @brief Error context values */
 enum hse_err_ctx {
     HSE_ERR_CTX_NONE, /**< No context */
+    HSE_ERR_CTX_TXN_EXPIRED, /**< Transaction timed out */
 };
 
 /** @brief Smallest error context value */

--- a/lib/error/lib/merr.c
+++ b/lib/error/lib/merr.c
@@ -155,7 +155,8 @@ merr_strinfo(
 
         if (ret < 0) {
             /* Try to just return what we already have. */
-            buf[sz] = '\000';
+            if (buf_sz > 0)
+                buf[sz - 1] = '\000';
             goto out;
         }
 

--- a/lib/kvdb/kvdb_ctxn_internal.h
+++ b/lib/kvdb/kvdb_ctxn_internal.h
@@ -64,6 +64,7 @@ struct kvdb_ctxn_impl {
     struct list_head        ctxn_free_link;
     struct list_head        ctxn_abort_link;
     u64                     ctxn_begin_ts;
+    bool                    ctxn_expired;
 };
 
 /* clang-format on */

--- a/lib/util/include/hse_util/err_ctx.h
+++ b/lib/util/include/hse_util/err_ctx.h
@@ -6,7 +6,9 @@
 #ifndef HSE_UTIL_ERR_CTX_H
 #define HSE_UTIL_ERR_CTX_H
 
+#include <hse_util/compiler.h>
+
 const char *
-err_ctx_strerror(int ctx);
+err_ctx_strerror(int ctx) HSE_RETURNS_NONNULL;
 
 #endif

--- a/lib/util/src/err_ctx.c
+++ b/lib/util/src/err_ctx.c
@@ -11,6 +11,8 @@ err_ctx_strerror(const int ctx)
     switch ((enum hse_err_ctx)ctx) {
     case HSE_ERR_CTX_NONE:
         return "No context";
+    case HSE_ERR_CTX_TXN_EXPIRED:
+        return "Transaction expired";
     }
 
     return "Undefined";

--- a/tests/functional/api/transaction_api_test.c
+++ b/tests/functional/api/transaction_api_test.c
@@ -1,12 +1,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <errno.h>
+#include <unistd.h>
 
 #include <hse/hse.h>
+#include <hse_util/base.h>
 #include <hse/test/fixtures/kvdb.h>
+#include <hse/test/fixtures/kvs.h>
 
 #include <mtf/framework.h>
 
@@ -16,9 +19,20 @@ struct hse_kvs  *kvs_handle = NULL;
 int
 test_collection_setup(struct mtf_test_info *lcl_ti)
 {
+    /* 5 second timeout with a 5 second delay. 5 seconds should be enough to
+     * hopefully get through all the tests, while allowing the 'expired' test
+     * to properly fail.
+     */
+    static const char *kvdb_rparamv[] = { "txn_timeout=5000", "txn_wkth_delay=5000" };
+    static const char *kvs_rparamv[] = { "transactions.enabled=true" };
+
     hse_err_t err;
 
-    err = fxt_kvdb_setup(mtf_kvdb_home, 0, NULL, 0, NULL, &kvdb_handle);
+    err = fxt_kvdb_setup(mtf_kvdb_home, NELEM(kvdb_rparamv), kvdb_rparamv, 0, NULL, &kvdb_handle);
+    if (err)
+        return hse_err_to_errno(err);
+
+    err = fxt_kvs_setup(kvdb_handle, "kvs", NELEM(kvs_rparamv), kvs_rparamv, 0, NULL, &kvs_handle);
 
     return hse_err_to_errno(err);
 }
@@ -191,6 +205,50 @@ MTF_DEFINE_UTEST(transaction_api_test, abort_without_begin)
     ASSERT_EQ(ECANCELED, hse_err_to_errno(err));
 
     hse_kvdb_txn_free(kvdb_handle, txn);
+}
+
+MTF_DEFINE_UTEST(transaction_api_test, expired)
+{
+    hse_err_t err;
+    struct hse_kvdb_txn *txn;
+    enum hse_kvdb_txn_state state;
+
+    txn = hse_kvdb_txn_alloc(kvdb_handle);
+    ASSERT_NE(NULL, txn);
+
+    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    ASSERT_EQ(0, hse_err_to_errno(err));
+
+    while (true) {
+        bool found;
+        size_t val_len;
+        struct hse_kvs_cursor *cursor;
+        char val_buf[HSE_KVS_VALUE_LEN_MAX];
+
+        state = hse_kvdb_txn_state_get(kvdb_handle, txn);
+        if (state != HSE_KVDB_TXN_ABORTED) {
+            sleep(5);
+            continue;
+        }
+
+        err = hse_kvs_cursor_create(kvs_handle, 0, txn, NULL, 0, &cursor);
+        ASSERT_EQ(EPROTO, hse_err_to_errno(err));
+        ASSERT_EQ(HSE_ERR_CTX_TXN_EXPIRED, hse_err_to_ctx(err));
+
+        err = hse_kvs_put(kvs_handle, 0, txn, "test", 4, "test", 4);
+        ASSERT_EQ(ECANCELED, hse_err_to_errno(err));
+        ASSERT_EQ(HSE_ERR_CTX_TXN_EXPIRED, hse_err_to_ctx(err));
+
+        err = hse_kvs_get(kvs_handle, 0, txn, "test", 4, &found, val_buf, sizeof(val_buf), &val_len);
+        ASSERT_EQ(ECANCELED, hse_err_to_errno(err));
+        ASSERT_EQ(HSE_ERR_CTX_TXN_EXPIRED, hse_err_to_ctx(err));
+
+        err = hse_kvs_delete(kvs_handle, 0, txn, "test", 4);
+        ASSERT_EQ(ECANCELED, hse_err_to_errno(err));
+        ASSERT_EQ(HSE_ERR_CTX_TXN_EXPIRED, hse_err_to_ctx(err));
+
+        break;
+    }
 }
 
 MTF_END_UTEST_COLLECTION(transaction_api_test)


### PR DESCRIPTION
HSE will abort transactions internally if they live longer than the configured timeout period. Previously there was no way to detect this behavior from the application side of things.

Signed-off-by: Tristan Partin <tpartin@micron.com>
