### PR TITLE
Replace KVDB's use of mcache map with new mblock descriptor

### DIFF
--- a/lib/c0/c0snr_set.c
+++ b/lib/c0/c0snr_set.c
@@ -383,10 +383,8 @@ c0snr_droprefv(int refc, uintptr_t **refv)
             *bkt->tailp = csl->act_cache;
             csl->act_cache = bkt->head;
             spin_unlock(&csl->act_lock);
-            ev(1);
         }
     }
-    ev(1);
 }
 
 bool

--- a/lib/cn/cn_tree_cursor.c
+++ b/lib/cn/cn_tree_cursor.c
@@ -246,7 +246,7 @@ cn_tree_cursor_create(struct cn_cursor *cur)
         }
     }
 
-    cur->cncur_flags = kvset_iter_flag_mcache;
+    cur->cncur_flags = kvset_iter_flag_mmap;
     if (cur->cncur_reverse)
         cur->cncur_flags |= kvset_iter_flag_reverse;
 

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -1654,30 +1654,29 @@ sp3_submit(struct sp3 *sp, struct cn_compaction_work *w, uint qnum)
     w->cw_io_workq = NULL;
 
     switch (csched_rp_kvset_iter(sp->rp)) {
-        case csched_rp_kvset_iter_sync:
-            /* synchronous mblock read */
-            break;
+    case csched_rp_kvset_iter_sync:
+        /* synchronous mblock read */
+        break;
 
-        case csched_rp_kvset_iter_mcache:
-            /* mache maps */
-            w->cw_iter_flags |= kvset_iter_flag_mcache;
-            break;
+    case csched_rp_kvset_iter_mmap:
+        w->cw_iter_flags |= kvset_iter_flag_mmap;
+        break;
 
-        case csched_rp_kvset_iter_async:
-        default:
-            /* async mblock read */
-            w->cw_io_workq = cn_get_io_wq(w->cw_tree->cn);
-            break;
+    case csched_rp_kvset_iter_async:
+    default:
+        /* async mblock read */
+        w->cw_io_workq = cn_get_io_wq(w->cw_tree->cn);
+        break;
     }
 
-    /* Force compaction reads to use mcache if the value blocks for this node reside on
+    /* Force compaction reads to use memory maps if the value blocks for this node reside on
      * the pmem media class. This is not accurate if the mclass policy is changed during
      * subsequent kvs opens, which results in a mix of media classes for the k/vblocks
      * in this node. However, this is not a correctness issue and will recover on its own
      * after a series of compaction operations.
      */
     if (cn_tree_node_mclass(tn, HSE_MPOLICY_DTYPE_VALUE) == HSE_MCLASS_PMEM) {
-        w->cw_iter_flags |= kvset_iter_flag_mcache;
+        w->cw_iter_flags |= kvset_iter_flag_mmap;
         w->cw_io_workq = NULL;
     }
 

--- a/lib/cn/hblock_builder.c
+++ b/lib/cn/hblock_builder.c
@@ -74,6 +74,10 @@ make_header(
     omf_set_hbh_vgmap_len_pg(hdr, vgmap_pgc);
     omf_set_hbh_hlog_off_pg(hdr, HBLOCK_HDR_PAGES + vgmap_pgc);
     omf_set_hbh_hlog_len_pg(hdr, HLOG_PGC);
+
+    /* Note: if ptree_pgc == 0, then data_off_pg > 0 but data_len_pg == 0, which seems
+     * contradictory but it works.
+     */
     omf_set_hbh_ptree_data_off_pg(hdr, HBLOCK_HDR_PAGES + vgmap_pgc + HLOG_PGC);
     omf_set_hbh_ptree_data_len_pg(hdr, ptree_pgc);
 

--- a/lib/cn/hblock_reader.c
+++ b/lib/cn/hblock_reader.c
@@ -13,8 +13,6 @@
 #include <hse_util/compiler.h>
 #include <hse_util/event_counter.h>
 #include <hse/error/merr.h>
-#include <mpool/mpool_structs.h>
-#include <mpool/mpool.h>
 
 #include "kvset.h"
 #include "hblock_reader.h"
@@ -27,114 +25,54 @@ static bool HSE_NONNULL(1)
 hblock_hdr_valid(const struct hblock_hdr_omf *omf)
 {
     const uint32_t version = omf_hbh_version(omf);
-    const uint32_t magic = omf_hbh_magic(omf);
+    const uint32_t magic   = omf_hbh_magic(omf);
 
     return HSE_LIKELY(magic == HBLOCK_HDR_MAGIC && version == HBLOCK_HDR_VERSION);
 }
 
-static merr_t
-hbr_madvise_region(
-    struct kvs_mblk_desc *hblk_desc,
-    uint32_t pg,
-    const uint32_t pg_cnt,
-    const int advice)
+void
+hbr_madvise_kmd(struct kvs_mblk_desc *md, struct wbt_desc *wbd, int advice)
 {
-    merr_t err = 0;
-    const uint32_t pg_max = pg + pg_cnt;
+    merr_t err;
+    const uint32_t pg  = wbd->wbd_first_page + wbd->wbd_root + 1;
+    const uint32_t pgc = wbd->wbd_kmd_pgc;
 
-    while (pg < pg_max) {
-        const uint32_t chunk = min_t(uint32_t, pg_max - pg, HSE_RA_PAGES_MAX);
-
-        err = mpool_mcache_madvise(
-            hblk_desc->map, hblk_desc->map_idx, PAGE_SIZE * pg, PAGE_SIZE * chunk, advice);
-        if (ev(err))
-            return err;
-
-        pg += chunk;
+    if (pgc) {
+        err = mblk_madvise_pages(md, pg, pgc, advice);
+        ev(err);
     }
-
-    return err;
 }
 
 void
-hbr_madvise_kmd(struct kvs_mblk_desc *kblkdesc, struct wbt_desc *desc, int advice)
+hbr_madvise_wbt_leaf_nodes(struct kvs_mblk_desc *md, struct wbt_desc *wbd, int advice)
 {
     merr_t err;
-    u32    pg = desc->wbd_first_page + desc->wbd_root + 1;
-    u32    pg_cnt = desc->wbd_kmd_pgc;
+    const uint32_t pg  = wbd->wbd_first_page;
+    const uint32_t pgc = wbd->wbd_leaf_cnt;
 
-    err = hbr_madvise_region(kblkdesc, pg, pg_cnt, advice);
-
-    ev(err);
+    if (pgc) {
+        err = mblk_madvise_pages(md, pg, pgc, advice);
+        ev(err);
+    }
 }
 
 void
-hbr_madvise_wbt_leaf_nodes(
-    struct kvs_mblk_desc *const hblk_desc,
-    struct wbt_desc *const wbt_desc,
-    const int advice)
+hbr_madvise_wbt_int_nodes(struct kvs_mblk_desc *md, struct wbt_desc *wbd, int advice)
 {
     merr_t err;
-    const uint32_t pg = wbt_desc->wbd_first_page;
-    const uint32_t pg_cnt = wbt_desc->wbd_leaf_cnt;
+    const uint32_t pg  = wbd->wbd_first_page + wbd->wbd_leaf_cnt;
+    const uint32_t pgc = wbd->wbd_n_pages - wbd->wbd_leaf_cnt - wbd->wbd_kmd_pgc;
 
-    err = hbr_madvise_region(hblk_desc, pg, pg_cnt, advice);
-
-    ev(err);
-}
-
-void
-hbr_madvise_wbt_int_nodes(
-    struct kvs_mblk_desc *const hblk_desc,
-    struct wbt_desc *const wbt_desc,
-    const int advice)
-{
-    merr_t err;
-    const uint32_t pg = wbt_desc->wbd_first_page + wbt_desc->wbd_leaf_cnt;
-    const uint32_t pg_cnt =
-        (wbt_desc->wbd_n_pages - wbt_desc->wbd_leaf_cnt - wbt_desc->wbd_kmd_pgc);
-
-    err = hbr_madvise_region(hblk_desc, pg, pg_cnt, advice);
-
-    ev(err);
-}
-
-merr_t
-hbr_read_desc(
-    struct mpool *mpool,
-    struct mpool_mcache_map *map,
-    struct mblock_props *props,
-    uint64_t blkid,
-    struct kvs_mblk_desc *mblk_desc)
-{
-    void *base;
-
-    /* There is only one hblock within the mcache map. */
-    base = mpool_mcache_getbase(map, 0);
-    if (!base)
-        return merr(EINVAL);
-
-    mblk_desc->ds = mpool;
-    mblk_desc->mbid = blkid;
-    mblk_desc->map = map;
-    mblk_desc->map_idx = 0;
-    mblk_desc->map_base = base;
-    mblk_desc->mclass = props->mpr_mclass;
-
-    return 0;
+    if (pgc) {
+        err = mblk_madvise_pages(md, pg, pgc, advice);
+        ev(err);
+    }
 }
 
 merr_t
 hbr_read_metrics(struct kvs_mblk_desc *hblk_desc, struct hblk_metrics *metrics)
 {
-    merr_t err;
-    struct mblock_props props;
-
-    err = mpool_mblock_props_get(hblk_desc->ds, hblk_desc->mbid, &props);
-    if (err)
-        return err;
-
-    metrics->hm_size = props.mpr_write_len;
+    metrics->hm_size = hblk_desc->wlen_pages * PAGE_SIZE;
     metrics->hm_nptombs = omf_hbh_num_ptombs(hblk_desc->map_base);
 
     return 0;
@@ -143,19 +81,11 @@ hbr_read_metrics(struct kvs_mblk_desc *hblk_desc, struct hblk_metrics *metrics)
 merr_t
 hbr_read_ptree_region_desc(struct kvs_mblk_desc *mblk_desc, struct wbt_desc *wbt_desc)
 {
-    merr_t err;
-    void * pg;
-    off_t pg_idxs[1];
     struct hblock_hdr_omf *hb_hdr;
 
     memset(wbt_desc, 0, sizeof(*wbt_desc));
 
-    pg_idxs[0] = 0;
-    err = mpool_mcache_getpages(mblk_desc->map, 1, mblk_desc->map_idx, pg_idxs, &pg);
-    if (ev(err))
-        return err;
-
-    hb_hdr = pg;
+    hb_hdr = mblk_desc->map_base;
     if (!hblock_hdr_valid(hb_hdr))
         return merr(EPROTO);
 
@@ -168,17 +98,9 @@ hbr_read_ptree_region_desc(struct kvs_mblk_desc *mblk_desc, struct wbt_desc *wbt
 merr_t
 hbr_read_seqno_range(struct kvs_mblk_desc *mblk_desc, uint64_t *seqno_min, uint64_t *seqno_max)
 {
-    merr_t err;
-    off_t pg_idxs[1];
     struct hblock_hdr_omf *hb_hdr;
-    void *pg;
 
-    pg_idxs[0] = 0;
-    err = mpool_mcache_getpages(mblk_desc->map, 1, mblk_desc->map_idx, pg_idxs, &pg);
-    if (ev(err))
-        return err;
-
-    hb_hdr = pg;
+    hb_hdr = mblk_desc->map_base;
     if (!hblock_hdr_valid(hb_hdr))
         return merr(EPROTO);
 
@@ -202,7 +124,7 @@ hbr_read_vgroup_cnt(const struct kvs_mblk_desc *hbd, uint32_t *nvgroups)
 {
     struct vgroup_map_omf *vgm_omf;
 
-    if (ev(omf_hbh_vgmap_len_pg(hbd->map_base) == 0)) {
+    if (omf_hbh_vgmap_len_pg(hbd->map_base) == 0) {
         *nvgroups = 0;
         return 0; /* no vgmap present */
     }

--- a/lib/cn/hblock_reader.h
+++ b/lib/cn/hblock_reader.h
@@ -14,9 +14,6 @@
 #include <hse/error/merr.h>
 
 struct kvs_mblk_desc;
-struct mblock_props;
-struct mpool;
-struct mpool_mcache_map;
 struct wbt_desc;
 struct vgmap;
 
@@ -62,23 +59,6 @@ hbr_madvise_kmd(
     struct kvs_mblk_desc *hblk_desc,
     struct wbt_desc *wbt_desc,
     int advice) HSE_NONNULL(1, 2);
-
-/**
- * Get the mblock descriptor for the given mblock.
- *
- * @param mpool mpool containing the mblock
- * @param map mcache
- * @param props properties of the mblock
- * @param blkid mblock id referencing the mblock
- * @param[in,out] mblk_desc mblock descriptor
- */
-merr_t
-hbr_read_desc(
-    struct mpool *mpool,
-    struct mpool_mcache_map *map,
-    struct mblock_props *props,
-    uint64_t blkid,
-    struct kvs_mblk_desc *mblk_desc) HSE_NONNULL(1, 2, 3, 5);
 
 /**
  * Read various metrics about an hblock.

--- a/lib/cn/kblock_reader.h
+++ b/lib/cn/kblock_reader.h
@@ -9,14 +9,10 @@
 #include <hse_util/inttypes.h>
 #include <hse_ikvdb/tuple.h>
 
-struct mpool;
 struct cn;
-struct mpool_mcache_map;
-struct mblock_props;
 struct bloom_desc;
 struct wbt_desc;
 struct kvs_mblk_desc;
-struct kvs_rparams;
 
 struct kblk_metrics {
     u32 num_keys;
@@ -36,21 +32,6 @@ struct kblock_desc {
 };
 
 /**
- * kbr_get_kblock_desc() - Get the mblock descriptor for the given
- *                     KBLOCK ID.
- * @kblock_id:      KBLOCK ID for KBLOCK to read
- * @kblock_desc:    (output) KVBLOCK_DESC for KBLOCK
- */
-merr_t
-kbr_get_kblock_desc(
-    struct mpool *           ds,
-    struct mpool_mcache_map *map,
-    struct mblock_props     *props,
-    u32                      map_idx,
-    u64                      kblock_id,
-    struct kvs_mblk_desc *   kblock_desc);
-
-/**
  * kbr_read_wbt_region_desc() - Read the WBT region descriptor for
  *                          the given KBLOCK ID.
  * @kblock_desc:    KVBLOCK_DESC for KBLOCK to read
@@ -68,16 +49,6 @@ kbr_read_wbt_region_desc(struct kvs_mblk_desc *kblock_desc, struct wbt_desc *wbt
  */
 merr_t
 kbr_read_blm_region_desc(struct kvs_mblk_desc *kblock_desc, struct bloom_desc *blm_desc);
-
-/**
- * kbr_read_blm_pages() - Get base address of bloom filter bitmap
- * @kblock_desc:    KVBLOCK_DESC for KBLOCK to read
- * @blm_desc:       bloom region descriptor
- */
-merr_t
-kbr_read_blm_pages(
-    struct kvs_mblk_desc *kblock_desc,
-    struct bloom_desc *   blm_desc);
 
 /**
  * kbr_read_metrics() - Read kblock header to obtain metrics.

--- a/lib/cn/kvs_mblk_desc.c
+++ b/lib/cn/kvs_mblk_desc.c
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2022 Micron Technology, Inc.  All rights reserved.
+ */
+
+#define MTF_MOCK_IMPL_mblk_desc
+
+#include <sys/mman.h>
+
+#include <mpool/mpool_structs.h>
+#include <mpool/mpool.h>
+
+#include <hse/error/merr.h>
+
+#include <hse_util/assert.h>
+#include <hse_util/compiler.h>
+#include <hse_util/event_counter.h>
+#include <hse_util/page.h>
+
+#include "kvs_mblk_desc.h"
+
+merr_t
+mblk_mmap(struct mpool *mp, uint64_t mbid, struct kvs_mblk_desc *md)
+{
+    merr_t err;
+    struct mblock_props props;
+    const void *base;
+
+    err = mpool_mblock_props_get(mp, mbid, &props);
+    if (ev(err))
+        return err;
+
+    err = mpool_mblock_mmap(mp, mbid, &base);
+    if (ev(err))
+        return err;
+
+    assert(props.mpr_alloc_cap % PAGE_SIZE == 0);
+    assert(props.mpr_write_len % PAGE_SIZE == 0);
+
+    md->map_base = (void *)base;
+    md->alen_pages = props.mpr_alloc_cap / PAGE_SIZE;
+    md->wlen_pages = props.mpr_write_len / PAGE_SIZE;
+    md->mclass = props.mpr_mclass;
+    md->mbid = mbid;
+
+    /* Verify mappings to pages and smaller int types don't lose information.
+     */
+    assert(md->alen_pages * PAGE_SIZE == props.mpr_alloc_cap);
+    assert(md->wlen_pages * PAGE_SIZE == props.mpr_write_len);
+    assert(md->mclass == props.mpr_mclass);
+
+    return 0;
+}
+
+merr_t
+mblk_munmap(struct mpool *mp, struct kvs_mblk_desc *md)
+{
+    merr_t err = 0;
+
+    INVARIANT(mp);
+    INVARIANT(md);
+
+    if (md->map_base) {
+        assert(md->mbid);
+        err = mpool_mblock_munmap(mp, md->mbid);
+        if (!err)
+            md->map_base = NULL;
+    }
+
+    return err;
+}
+
+merr_t
+mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice)
+{
+    int rc;
+
+    if (len == 0)
+        return 0;
+
+    assert(off + len <= md->wlen_pages * PAGE_SIZE);
+    assert(md->map_base);
+
+    /* Cast away the const of map_base for madvise().
+     */
+    rc = madvise((void *)md->map_base + off, len, advice);
+    if (rc)
+        return merr(errno);
+
+    return 0;
+}
+
+merr_t
+mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg, size_t pg_cnt, int advice)
+{
+    if (pg_cnt == 0)
+        return 0;
+
+    return mblk_madvise(md, pg * PAGE_SIZE, pg_cnt * PAGE_SIZE, advice);
+}
+
+#if HSE_MOCKING
+#include "kvs_mblk_desc_ut_impl.i"
+#endif

--- a/lib/cn/kvs_mblk_desc.h
+++ b/lib/cn/kvs_mblk_desc.h
@@ -3,23 +3,75 @@
  * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
-#ifndef HSE_KVS_MBLK_DESC_H
-#define HSE_KVS_MBLK_DESC_H
+#ifndef HSE_MBLK_DESC_H
+#define HSE_MBLK_DESC_H
 
-#include <stdint.h>
+#include <inttypes.h>
+#include <assert.h>
+
+#include <hse/error/merr.h>
+
+#include <hse_util/page.h>
 
 #include <hse/types.h>
 
-struct mpool_mcache_map;
+
+/* MTF_MOCK_DECL(mblk_desc) */
+
 struct mpool;
 
+/* Mblock descriptor */
 struct kvs_mblk_desc {
-    void *                   map_base; /* base address of mcache map */
-    struct mpool_mcache_map *map;      /* mcache map */
-    uint32_t                 map_idx;  /* index of mblk in map */
-    enum hse_mclass          mclass;   /* media class */
-    struct mpool *           ds;       /* mpool dataset */
-    uint64_t                 mbid;    /* mblock id */
+    void *map_base;         // memory mapped address of mblock
+    uint64_t mbid;          // mblock id
+    uint16_t alen_pages;    // allocated length of mblock, in 4K pages
+    uint16_t wlen_pages;    // written length of mblock, in 4K pages
+    uint8_t  mclass;        // media class
 };
+
+static_assert(HSE_MCLASS_MAX <= UINT8_MAX,
+    "struct kvs_mblk_desc member mclass too small to hold enum hse_mclass");
+
+/* Map an mblock and initialize an mblock descriptor.
+ */
+/* MTF_MOCK */
+merr_t
+mblk_mmap(struct mpool *mp, uint64_t mbid, struct kvs_mblk_desc *md_out);
+
+/* Unmap an mblock.
+ */
+/* MTF_MOCK */
+merr_t
+mblk_munmap(struct mpool *mp, struct kvs_mblk_desc *md);
+
+/* MTF_MOCK */
+merr_t
+mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice);
+
+/* MTF_MOCK */
+merr_t
+mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg, size_t pg_cnt, int advice);
+
+static inline enum hse_mclass
+mblk_mclass(const struct kvs_mblk_desc *d)
+{
+    return d->mclass;
+}
+
+static inline uint64_t
+mblk_alen(const struct kvs_mblk_desc *d)
+{
+    return d->alen_pages * PAGE_SIZE;
+}
+
+static inline uint64_t
+mblk_wlen(const struct kvs_mblk_desc *d)
+{
+    return d->wlen_pages * PAGE_SIZE;
+}
+
+#ifdef HSE_MOCKING
+#include "kvs_mblk_desc_ut.h"
+#endif
 
 #endif

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -44,7 +44,7 @@ struct kvset_list_entry {
 };
 
 enum kvset_iter_flags {
-    kvset_iter_flag_mcache = (1u << 0),
+    kvset_iter_flag_mmap = (1u << 0),
     kvset_iter_flag_reverse = (1u << 1),
     kvset_iter_flag_fullscan = (1u << 2),
 };
@@ -132,10 +132,10 @@ merr_t
 kvset_open(struct cn_tree *tree, u64 tag, struct kvset_meta *meta, struct kvset **kvset);
 
 /**
- * Preload/discard hblock mcache map pages
+ * Preload/discard hblock memory mapped pages
  *
  * This function is used to either preload or discard pages from @p kvset
- * kvset's mcache mapped hblock, depending upon @p madvice:
+ * kvset's memory mapped hblock, depending upon @p madvice:
  *
  * @p MADV_WILLNEED: Initiate readahead preloading of all the pages
  * @p MADV_DONTNEED: Mark all the pages as currently unneeded
@@ -151,12 +151,12 @@ void
 kvset_madvise_hblk(struct kvset *kvset, int advice, bool leaves);
 
 /**
- * kvset_madvise_kblks() - preload/discard kblock mcache map pages
+ * kvset_madvise_kblks() - preload/discard kblock memory mapped pages
  * @kvset:    kvset pointer
  * @advice:   readahead mode for madvise()
  *
  * This function is used to either preload or discard pages from all
- * the given kvset's mcache mapped kblocks, depending upon %madvice:
+ * the given kvset's memory mapped kblocks, depending upon %madvice:
  *
  *  %MADV_WILLNEED:  Initiate readahead preloading of all the pages
  *  %MADV_DONTNEED:  Mark all the pages as currently unneeded
@@ -168,12 +168,12 @@ void
 kvset_madvise_kblks(struct kvset *kvset, int advice, bool blooms, bool leaves);
 
 /**
- * kvset_madvise_vblks() - preload/discard vblock mcache map pages
+ * kvset_madvise_vblks() - preload/discard vblock memory mapped pages
  * @kvset:    kvset pointer
  * @advice:   readahead mode for madvise()
  *
  * This function is used to either preload or dicsard pages from all
- * the given kvset's mcache mapped vblocks, depending upon %madvice:
+ * the given kvset's memory mapped vblocks, depending upon %madvice:
  *
  *  %MADV_WILLNEED:  Initiate readahead preloading of all the pages
  *  %MADV_DONTNEED:  Mark all the pages as currently unneeded
@@ -188,16 +188,13 @@ void
 kvset_madvise_capped(struct kvset *kvset, int advice);
 
 /**
- * kvset_madvise_vmaps() - Change kvset vblock mcache map memory use mode
+ * kvset_madvise_vmaps() - Change kvset vblock memory mapped pages use mode
  * @kvset:    kvset pointer
  * @advice:   readahead mode for madvise()
  *
- * This function is used to change the mcache map readahead mode for all
- * mcache maps in the given kvset's vblocks, where %adivce may be one
+ * This function is used to change the memory map readahead mode for all
+ * memory maps in the given kvset's vblocks, where %adivce may be one
  * of the following:  %MADV_RANDOM, %MADV_DONTNEED
- *
- * Note that the default mode for mcache maps is %MADV_RANDOM, which
- * effectively disables readahead.
  *
  * See madvise(2) for more informaation.
  */
@@ -419,12 +416,12 @@ kvset_get_dgen_lo(const struct kvset *kvset);
  *
  * Flags:
  *   - %kvset_iter_flag_reverse: Iterate over keys in reverse.  Can only
- *     be used with mcache map based iteration.
- *   - %kvset_iter_flag_mcache: If set, use mcache maps to access
+ *     be used with memory map based iteration.
+ *   - %kvset_iter_flag_mmap: If set, use memory maps to access
  *     mblock data.  If not set, access data with mblock read.
  *
  * Notes:
- *   - @io_workq is ignored when iterating with mcache maps.
+ *   - @io_workq is ignored when iterating with memory maps.
  *   - With read-based compaction, if @io_workq is NULL, then mblock reads are
  *     issued synchronously using a single buffer.  If @io_workq is provided,
  *     then double buffering is used to overlap reads with iteration work.

--- a/lib/cn/kvset_internal.h
+++ b/lib/cn/kvset_internal.h
@@ -113,10 +113,8 @@ struct kvset {
     size_t          ks_lcp;       /* longest common prefix */
 
     struct kvset_hblk ks_hblk;
-    struct mpool_mcache_map *ks_hmap; /* hblock mcache map */
 
     const u8 *                ks_klarge; /* large key cache */
-    struct mpool_mcache_map  *ks_kmap;
     struct mbset **           ks_vbsetv;
     uint                      ks_vbsetc;
 

--- a/lib/cn/kvset_split.c
+++ b/lib/cn/kvset_split.c
@@ -428,7 +428,7 @@ get_vblk_split_index(
 
     for (v = start; v <= end; v++) {
         struct vblock_desc *vbd = kvset_get_nth_vblock_desc(ks, v);
-        const void *min_key = vbd->vbd_mblkdesc.map_base + vbd->vbd_min_koff;
+        const void *min_key = vbd->vbd_mblkdesc->map_base + vbd->vbd_min_koff;
 
         if (keycmp(split_key, split_klen, min_key, vbd->vbd_min_klen) < 0)
             break;
@@ -436,7 +436,7 @@ get_vblk_split_index(
 
     if (v > start) {
         struct vblock_desc *vbd = kvset_get_nth_vblock_desc(ks, v - 1);
-        const void *max_key = vbd->vbd_mblkdesc.map_base + vbd->vbd_max_koff;
+        const void *max_key = vbd->vbd_mblkdesc->map_base + vbd->vbd_max_koff;
 
         if (keycmp(split_key, split_klen, max_key, vbd->vbd_max_klen) < 0) {
             *overlap = true;

--- a/lib/cn/mbset.c
+++ b/lib/cn/mbset.c
@@ -1,16 +1,19 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
+
+#define MTF_MOCK_IMPL_mbset
 
 #include <hse_util/alloc.h>
 #include <hse_util/slab.h>
 #include <hse_util/minmax.h>
 #include <hse_util/event_counter.h>
 
-#define MTF_MOCK_IMPL_mbset
+#include <hse/logging/logging.h>
 
 #include "mbset.h"
+#include "kvs_mblk_desc.h"
 
 /*
  * An "mbset" is a reference counted set of mblocks with associated object
@@ -23,7 +26,6 @@
  * Currently (early 2018), each kvset has an "mbset' containing:
  *   - vblocks
  *   - one handle for each vblock (for use with mpool_mblock_read)
- *   - an mcache map handle
  *   - a vblock descriptor for each vblock (this is the "user data")
  *
  * Mbsets can be shared by multiple kvsets after k-compaction operations as
@@ -34,7 +36,7 @@
  *   4. Cursor update operation takes a ref on kvset S1.
  *   5. k-compaction completes, creating kvset S3.
  *   6. Recall k-compaction passes vblocks from input to output.  Instead of
- *      re-creating mcache maps, it is more efficient to share the mbset.  As
+ *      re-creating memory maps, it is more efficient to share the mbset.  As
  *      such, kvset S3 takes a ref on mbset M1 and M2, and then drops refs on
  *      S1 and S2.
  *   7. S2 is destroyed, but S1 lingers because the cursor is using it.
@@ -61,65 +63,6 @@
  */
 
 /**
- * mbset_mblk_getprops() - get mblock properties for each mblock in the mbset
- *
- * Used by mbset constructor.
- */
-static merr_t
-mbset_mblk_getprops(struct mbset *self, mbset_udata_init_fn *cb)
-{
-    merr_t err = 0;
-    u64 *  argv;
-    uint   argc;
-    uint   i;
-
-    /* Create some scratch space for the callback.  Currrently only used
-     * by vblock_udata_init() to compute the number of vgroups.
-     */
-    argc = 0;
-    argv = malloc(sizeof(*argv) * (self->mbs_idc + 1));
-    if (ev(!argv))
-        return merr(ENOMEM);
-
-    self->mbs_alen = 0;
-    self->mbs_wlen = 0;
-
-    for (i = 0; i < self->mbs_idc; i++) {
-
-        struct mblock_props props;
-
-        err = mpool_mblock_props_get(self->mbs_mp, self->mbs_idv[i], &props);
-        if (ev(err))
-            break;
-
-        if (cb) {
-            err = cb(self, i, &argc, argv, &props, mbset_get_udata(self, i));
-            if (ev(err))
-                break;
-        }
-
-        self->mbs_alen += props.mpr_alloc_cap;
-        self->mbs_wlen += props.mpr_write_len;
-    }
-
-    free(argv);
-
-    return err;
-}
-
-void
-mbset_apply(struct mbset *self, mbset_udata_init_fn *cb, uint *argcp, u64 *argv)
-{
-    uint i;
-
-    if (!self || !cb)
-        return;
-
-    for (i = 0; i < self->mbs_idc; i++)
-        cb(self, i, argcp, argv, NULL, mbset_get_udata(self, i));
-}
-
-/**
  * mbset_mblk_del() - delete mblocks
  *
  * Used by mbset destructor if mblocks have been marked for deletion.
@@ -132,39 +75,78 @@ mbset_apply(struct mbset *self, mbset_udata_init_fn *cb, uint *argcp, u64 *argv)
 static merr_t
 mbset_mblk_del(struct mbset *self)
 {
-    merr_t err;
-    uint   i;
+    merr_t err_report = 0, err;
+    uint64_t mbid_report = 0, mbid;
+    uint count = 0;
 
-    for (i = 0; i < self->mbs_idc; i++) {
-        if (self->mbs_idv[i]) {
-            err = mpool_mblock_delete(self->mbs_mp, self->mbs_idv[i]);
-            if (ev(err))
-                return err;
+    for (uint i = 0; i < self->mbs_mblkc; i++) {
+        mbid = self->mbs_mblkv[i].mbid;
+        if (mbid) {
+            err = mpool_mblock_delete(self->mbs_mp, mbid);
+            if (err) {
+                count++;
+                if (!err_report) {
+                    err_report = err;
+                    mbid_report = mbid;
+                }
+            }
         }
     }
+
+    if (err_report)
+        log_errx("%u of %u mblocks could not be deleted, mbid 0x%lx",
+            err_report, count, self->mbs_mblkc, mbid_report);
+
+    return err_report;
+}
+
+static merr_t
+mbset_mmap(struct mbset *self, uint idc, uint64_t *idv)
+{
+    uint64_t alen_pages = 0;
+    uint64_t wlen_pages = 0;
+    merr_t err;
+
+    self->mbs_mblkc = idc;
+
+    for (uint i = 0; i < idc; i++) {
+        err = mblk_mmap(self->mbs_mp, idv[i], &self->mbs_mblkv[i]);
+        if (err)
+            return err;
+        alen_pages += self->mbs_mblkv[i].alen_pages;
+        wlen_pages += self->mbs_mblkv[i].wlen_pages;
+    }
+
+    self->mbs_alen = alen_pages * PAGE_SIZE;
+    self->mbs_wlen = wlen_pages * PAGE_SIZE;
+
     return 0;
 }
 
-/**
- * mbset_map() - create mcache maps
- *
- * Used by mbset constructor.
- */
-static merr_t
-mbset_map(struct mbset *self, uint flags)
-{
-    return mpool_mcache_mmap(self->mbs_mp, self->mbs_idc, self->mbs_idv, &self->mbs_map);
-}
-
-/**
- * mbset_unmap() - destroy mcache maps
- *
- * Used by mbset destructor.
- */
 static void
-mbset_unmap(struct mbset *self)
+mbset_munmap(struct mbset *self)
 {
-    mpool_mcache_munmap(self->mbs_map);
+    merr_t err_report = 0, err;
+    uint64_t mbid_report = 0, mbid;
+    uint count = 0;
+
+    for (uint i = 0; i < self->mbs_mblkc; i++) {
+        mbid = self->mbs_mblkv[i].mbid;
+        if (mbid) {
+            err = mblk_munmap(self->mbs_mp, &self->mbs_mblkv[i]);
+            if (err) {
+                count++;
+                if (!err_report) {
+                    err_report = err;
+                    mbid_report = mbid;
+                }
+            }
+        }
+    }
+
+    if (err_report)
+        log_errx("%u of %u mblocks could not be unmapped, mbid 0x%lx",
+            err_report, count, self->mbs_mblkc, mbid_report);
 }
 
 /**
@@ -174,51 +156,48 @@ merr_t
 mbset_create(
     struct mpool *      mp,
     uint                idc,
-    u64 *               idv,
+    uint64_t *          idv,
     size_t              udata_sz,
-    mbset_udata_init_fn udata_init_fn,
-    uint                flags,
+    mbset_udata_init_fn udata_init,
     struct mbset **     handle)
 {
     struct mbset *self;
     size_t        alloc_len;
     merr_t        err;
 
-    if (!mp || !handle || !idv || !idc)
-        return merr(ev(EINVAL));
+    if (ev(!mp || !handle || !idv || !idc))
+        return merr(EINVAL);
 
     /* one allocation for:
      * - the mbset struct
-     * - array of mblock ids
-     * - array of udata structs
+     * - array of kvs_mblk_desc
+     * - array of udata elements
      */
-    alloc_len = sizeof(*self) + (sizeof(*self->mbs_idv) * idc) + (udata_sz * idc);
+    alloc_len  = sizeof(*self);
+    alloc_len += idc * sizeof(*self->mbs_mblkv);
+    alloc_len += idc * udata_sz;
 
     self = calloc(1, alloc_len);
-    if (!self)
-        return merr(ev(ENOMEM));
+    if (ev(!self))
+        return merr(ENOMEM);
 
-    self->mbs_idv = (void *)(self + 1);
-    self->mbs_udata = (void *)(self->mbs_idv + idc);
+    self->mbs_mblkv = (void *)(self + 1);
+    self->mbs_udata = (void *)(self->mbs_mblkv + idc);
 
-    assert(((void *)self) + alloc_len == (void *)(self->mbs_udata + idc * udata_sz));
-
-    memcpy(self->mbs_idv, idv, sizeof(*idv) * idc);
-
-    self->mbs_idc = idc;
+    self->mbs_mblkc = idc;
     self->mbs_mp = mp;
     self->mbs_del = false;
     self->mbs_udata_sz = udata_sz;
 
-    err = mbset_map(self, flags);
-    if (ev(err))
+    err = mbset_mmap(self, idc, idv);
+    if (err)
         goto fail;
 
-    /* Must have mapped mblocks prior to this b/c the udata
-     * callback uses the maps */
-    err = mbset_mblk_getprops(self, udata_init_fn);
-    if (ev(err))
-        goto fail;
+    for (uint i = 0; i < idc; i++) {
+        err = udata_init(&self->mbs_mblkv[i], mbset_get_udata(self, i));
+        if (ev(err))
+            goto fail;
+    }
 
     atomic_set(&self->mbs_ref, 1);
     *handle = self;
@@ -226,7 +205,8 @@ mbset_create(
     return 0;
 
 fail:
-    mbset_unmap(self);
+
+    mbset_munmap(self);
     free(self);
 
     return err;
@@ -240,13 +220,13 @@ mbset_destroy(struct mbset *self, bool *delete_errors)
 {
     merr_t err = 0;
 
-    if (ev(!self))
+    if (!self)
         return;
 
-    mbset_unmap(self);
+    mbset_munmap(self);
+
     if (self->mbs_del) {
         err = mbset_mblk_del(self);
-        ev(err);
         *delete_errors = !!err;
     } else {
         *delete_errors = false;
@@ -305,15 +285,6 @@ void
 mbset_set_delete_flag(struct mbset *self)
 {
     self->mbs_del = true;
-}
-
-void
-mbset_madvise(struct mbset *self, int advice)
-{
-    merr_t err;
-
-    err = mpool_mcache_madvise(self->mbs_map, 0, 0, SIZE_MAX, advice);
-    ev(err);
 }
 
 #if HSE_MOCKING

--- a/lib/cn/meson.build
+++ b/lib/cn/meson.build
@@ -20,6 +20,7 @@ cn_sources = files(
     'kvset.c',
     'kvset_builder.c',
     'kvset_split.c',
+    'kvs_mblk_desc.c',
     'mbset.c',
     'move.c',
     'node_split.c',

--- a/lib/cn/vblock_reader.c
+++ b/lib/cn/vblock_reader.c
@@ -19,48 +19,36 @@
 
 #include "omf.h"
 #include "vblock_reader.h"
+#include "kvs_mblk_desc.h"
 
 merr_t
 vbr_desc_read(
-    struct mpool *           ds,
-    struct mpool_mcache_map *map,
-    uint                     idx,
-    uint *                   vgroupsp,
-    u64 *                    argv,
-    struct mblock_props *    props,
-    struct vblock_desc *     vblk_desc)
+    const struct kvs_mblk_desc *mblk,
+    struct vblock_desc *vblk_desc)
 {
     struct vblock_footer_omf *footer;
-    bool     supported;
-    void    *base;
-    u64      vgroup;
-    uint32_t vers;
+    uint32_t wlen;
 
-    base = mpool_mcache_getbase(map, idx);
-    if (ev(!base))
-        return merr(EINVAL);
+    wlen = mblk->wlen_pages * PAGE_SIZE;
+    footer = mblk->map_base + wlen - VBLOCK_FOOTER_LEN;
 
-    footer = base + props->mpr_write_len - VBLOCK_FOOTER_LEN;
-    vgroup = omf_vbf_vgroup(footer);
-    vers = omf_vbf_version(footer);
+    if (ev(omf_vbf_magic(footer) != VBLOCK_FOOTER_MAGIC))
+        return merr(EPROTO);
 
-    supported = (omf_vbf_magic(footer) == VBLOCK_FOOTER_MAGIC && vers == VBLOCK_FOOTER_VERSION);
-    if (ev(!supported))
+    if (ev(omf_vbf_version(footer) != VBLOCK_FOOTER_VERSION))
         return merr(EPROTO);
 
     memset(vblk_desc, 0, sizeof(*vblk_desc));
-    vblk_desc->vbd_mblkdesc.map_base = base;
-    vblk_desc->vbd_mblkdesc.mbid = props->mpr_objid;
-    vblk_desc->vbd_mblkdesc.map = map;
-    vblk_desc->vbd_mblkdesc.map_idx = idx;
-    vblk_desc->vbd_mblkdesc.mclass = props->mpr_mclass;
+
+    vblk_desc->vbd_mblkdesc = mblk;
     vblk_desc->vbd_off = 0;
-    vblk_desc->vbd_len = props->mpr_write_len - VBLOCK_FOOTER_LEN;
-    vblk_desc->vbd_vgroup = vgroup;
+    vblk_desc->vbd_len = wlen - VBLOCK_FOOTER_LEN;
+    vblk_desc->vbd_vgroup = omf_vbf_vgroup(footer);
     vblk_desc->vbd_min_koff = vblk_desc->vbd_len + VBLOCK_FOOTER_LEN - (2 * HSE_KVS_KEY_LEN_MAX);
     vblk_desc->vbd_min_klen = omf_vbf_min_klen(footer);
     vblk_desc->vbd_max_koff = vblk_desc->vbd_min_koff + HSE_KVS_KEY_LEN_MAX;
     vblk_desc->vbd_max_klen = omf_vbf_max_klen(footer);
+
     atomic_set(&vblk_desc->vbd_vgidx, 1);
     atomic_set(&vblk_desc->vbd_refcnt, 0);
 
@@ -68,14 +56,10 @@ vbr_desc_read(
 }
 
 merr_t
-vbr_desc_update(
-    struct mpool *           ds,
-    struct mpool_mcache_map *map,
-    uint                     idx,
-    uint *                   vgroupsp,
-    u64 *                    argv,
-    struct mblock_props *    props,
-    struct vblock_desc *     vblk_desc)
+vbr_desc_update_vgidx(
+    struct vblock_desc *vblk_desc,
+    uint               *vgroupc,
+    u64                *vgroupv)
 {
     u64  vgroup = vblk_desc->vbd_vgroup;
     uint i;
@@ -84,12 +68,12 @@ vbr_desc_update(
      * sequence starting from 1.  The resulting packed indices are
      * used by vbr_readahead() to minimize history table collisions.
      */
-    for (i = 0; i < *vgroupsp && argv[i] != vgroup; ++i)
+    for (i = 0; i < *vgroupc && vgroupv[i] != vgroup; ++i)
         ; /* do nothing */
 
-    if (i >= *vgroupsp) {
-        argv[i] = vgroup;
-        *vgroupsp = i + 1;
+    if (i >= *vgroupc) {
+        vgroupv[i] = vgroup;
+        *vgroupc = i + 1;
     }
 
     atomic_set(&vblk_desc->vbd_vgidx, i + 1);
@@ -121,7 +105,7 @@ vbr_readahead(
     /* The first and last buckets of each vblock group are likely to be hot
      * but we currently have no way to identify them.  As a compromise,
      * we allow the first and last buckets of each vblock to be preloaded
-     * organically via mcache.
+     * organically via the memory map.
      */
     bkt = voff / ra_len;
     vgidx = atomic_read(&vbd->vbd_vgidx);
@@ -237,35 +221,14 @@ vbr_madvise_async(
 void
 vbr_madvise(struct vblock_desc *vbd, uint off, uint len, int advice)
 {
-    u32    pg, pg_cnt, pg_len, pg_max;
-    merr_t err;
-
-    pg = (vbd->vbd_off + off) / PAGE_SIZE;
-    pg_cnt = len / PAGE_SIZE;
-    pg_len = 0;
-
-    if (ev(pg_cnt < 2))
-        return;
-
-    for (pg_max = pg + pg_cnt; pg < pg_max; pg += pg_len) {
-        pg_len = min_t(u32, pg_max - pg, HSE_RA_PAGES_MAX);
-
-        err = mpool_mcache_madvise(
-            vbd->vbd_mblkdesc.map,
-            vbd->vbd_mblkdesc.map_idx,
-            PAGE_SIZE * pg,
-            PAGE_SIZE * pg_len,
-            advice);
-        if (ev(err))
-            break;
-    }
+    mblk_madvise(vbd->vbd_mblkdesc, off, len, advice);
 }
 
 /* off, len version */
 void *
 vbr_value(struct vblock_desc *vbd, uint vboff, uint vlen)
 {
-    assert(vbd->vbd_mblkdesc.map_base);
+    assert(vbd->vbd_mblkdesc->map_base);
     assert(vboff + vlen <= vbd->vbd_len);
-    return vbd->vbd_mblkdesc.map_base + vbd->vbd_off + vboff;
+    return vbd->vbd_mblkdesc->map_base + vbd->vbd_off + vboff;
 }

--- a/lib/cn/vblock_reader.h
+++ b/lib/cn/vblock_reader.h
@@ -20,10 +20,6 @@
 #define VBR_REVERSE     (0x0001u)
 #define VBR_FULLSCAN    (0x0002u)
 
-struct mpool;
-struct mpool_mcache_map;
-struct mblock_props;
-
 /**
  * struct ra_hist - readahead history cache record
  * vgidx:   vblock group index
@@ -52,9 +48,9 @@ struct vbr_madvise_work {
  * from media and the relevant information is stored in a @vblock_desc struct.
  */
 struct vblock_desc {
-    struct kvs_mblk_desc vbd_mblkdesc; /* underlying block descriptor */
-    uint32_t             vbd_off;      /* byte offset of vblock data */
-    uint32_t             vbd_len;      /* byte length of vblock data */
+    const struct kvs_mblk_desc *vbd_mblkdesc; /* underlying block descriptor */
+    uint32_t             vbd_off;      /* byte offset of vblock data (always 0!) */
+    uint32_t             vbd_len;      /* byte length of vblock data (not including footer) */
     uint32_t             vbd_min_koff; /* min key offset */
     uint32_t             vbd_max_koff; /* max key offset */
     uint16_t             vbd_min_klen; /* min key length */
@@ -70,23 +66,14 @@ struct vblock_desc {
  */
 merr_t
 vbr_desc_read(
-    struct mpool *           ds,
-    struct mpool_mcache_map *map,
-    uint                     maxidx,
-    uint *                   vgroupsp,
-    u64 *                    argv,
-    struct mblock_props *    props,
-    struct vblock_desc *     vblock_desc);
+    const struct kvs_mblk_desc *mblk,
+    struct vblock_desc *vblk_desc);
 
 merr_t
-vbr_desc_update(
-    struct mpool *           ds,
-    struct mpool_mcache_map *map,
-    uint                     maxidx,
-    uint *                   vgroupsp,
-    u64 *                    argv,
-    struct mblock_props *    props,
-    struct vblock_desc *     vblock_desc);
+vbr_desc_update_vgidx(
+    struct vblock_desc *vblock_desc,
+    uint               *vgroupc,
+    u64                *vgroupv);
 
 /**
  * vbr_madvise_async() - initiate async vblock readahead

--- a/lib/include/hse_ikvdb/csched_rp.h
+++ b/lib/include/hse_ikvdb/csched_rp.h
@@ -11,7 +11,7 @@
 
 #define csched_rp_kvset_iter_async 0
 #define csched_rp_kvset_iter_sync 1
-#define csched_rp_kvset_iter_mcache 2
+#define csched_rp_kvset_iter_mmap 2
 
 /* Compaction stats */
 #define csched_rp_dbg_comp(_rp)       ((uint)((_rp)->csched_debug_mask & 0x000f))

--- a/lib/kvdb/kvdb_rparams.c
+++ b/lib/kvdb/kvdb_rparams.c
@@ -756,7 +756,7 @@ static const struct param_spec pspecs[] = {
         .ps_bounds = {
             .as_uscalar = {
                 .ps_min = csched_rp_kvset_iter_async,
-                .ps_max = csched_rp_kvset_iter_mcache,
+                .ps_max = csched_rp_kvset_iter_mmap,
             },
         },
     },

--- a/lib/kvs/kvs_rparams.c
+++ b/lib/kvs/kvs_rparams.c
@@ -236,7 +236,7 @@ static const struct param_spec pspecs[] = {
     },
     {
         .ps_name = "cn_compact_vra",
-        .ps_description = "compaction vblk read-ahead via mcache",
+        .ps_description = "compaction vblk memory map read-ahead",
         .ps_flags = PARAM_FLAG_EXPERIMENTAL,
         .ps_type = PARAM_TYPE_U64,
         .ps_offset = offsetof(struct kvs_rparams, cn_compact_vra),
@@ -320,7 +320,7 @@ static const struct param_spec pspecs[] = {
     },
     {
         .ps_name = "cn_cursor_vra",
-        .ps_description = "compaction vblk read-ahead via mcache",
+        .ps_description = "cursor vblk memory map read-ahead",
         .ps_flags = PARAM_FLAG_EXPERIMENTAL,
         .ps_type = PARAM_TYPE_U64,
         .ps_offset = offsetof(struct kvs_rparams, cn_cursor_vra),
@@ -492,7 +492,7 @@ static const struct param_spec pspecs[] = {
     },
     {
         .ps_name = "cn_bloom_preload",
-        .ps_description = "preload mcache bloom filters",
+        .ps_description = "preload memory mapped bloom filters",
         .ps_flags = PARAM_FLAG_EXPERIMENTAL,
         .ps_type = PARAM_TYPE_BOOL,
         .ps_offset = offsetof(struct kvs_rparams, cn_bloom_preload),

--- a/lib/mpool/include/mpool/mcache.h
+++ b/lib/mpool/include/mpool/mcache.h
@@ -1,0 +1,135 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2022 Micron Technology, Inc.  All rights reserved.
+ */
+
+#ifndef MPOOL_MCACHE_H
+#define MPOOL_MCACHE_H
+
+#include <stdint.h>
+
+#include <sys/types.h>
+
+#include <hse/error/merr.h>
+
+
+struct mpool_mcache_map; /* opaque mcache map handle */
+struct mpool;
+
+/******************************** MCACHE APIs ************************************/
+
+/**
+ * mpool_mcache_madvise() - Give advice about use of memory
+ *
+ * @map:    mcache map handle
+ * @mbidx:  logical mblock number in mcache map
+ * @offset: offset into the mblock specified by mbidx
+ * @length: see madvise(2)
+ * @advice: see madvise(2)
+ *
+ * Like madvise(2), but for mcache maps.
+ *
+ * Note that one can address the entire map (including holes) by
+ * specifying zero for %mbidx, zero for %offset, and %SIZE_MAX for
+ * %length.  In general, %SIZE_MAX may always be specified for %length,
+ * in which case it addresses the map from the given mbidx based offset
+ * to the end of the map.
+ */
+/* MTF_MOCK */
+merr_t
+mpool_mcache_madvise(
+    struct mpool_mcache_map *map,
+    uint32_t                 mbidx,
+    off_t                    offset,
+    size_t                   length,
+    int                      advice);
+
+/**
+ * mpool_mcache_getbase() - Get the base address of a memory-mapped mblock in an mcache map
+ *
+ * @map:   mcache map handle
+ * @mbidx: mcache map mblock index
+ *
+ * If the pages of an mcache map are contiguous in memory (as is the case in
+ * user-space), return the the base address of the mapped mblock.  If the
+ * pages are not contiguous, return NULL.
+ */
+/* MTF_MOCK */
+void *
+mpool_mcache_getbase(struct mpool_mcache_map *map, const uint32_t mbidx);
+
+/**
+ * mpool_mcache_getpages() - Get a vector of pages from a single mblock
+ *
+ * @map:     mcache map handle
+ * @pagec:   page count (len of @pagev array)
+ * @mbidx:   mcache map mblock index
+ * @offsetv: vector of page offsets into objects/mblocks
+ * @pagev:   vector of pointers to pages (output)
+ *
+ * mbidx is an index into the mbidv[] vector that was given to mpool_mcache_create().
+ *
+ * Return: %0 on success, merr_t on failure
+ */
+/* MTF_MOCK */
+merr_t
+mpool_mcache_getpages(
+    struct mpool_mcache_map *map,
+    const uint32_t           pagec,
+    const uint32_t           mbidx,
+    const off_t              offsetv[],
+    void *                   pagev[]);
+
+/**
+ * mpool_mcache_mmap() - Create an mcache map
+ *
+ * @mp:    handle for the mpool
+ * @mbidc: mblock ID count
+ * @mbidv: vector of mblock IDs
+ * @mapp:  pointer to (opaque) mpool_mcache_map ptr
+ *
+ * Create an mcache map for the list of given mblock IDs and returns a handle to it via *mapp.
+ */
+/* MTF_MOCK */
+merr_t
+mpool_mcache_mmap(struct mpool *mp, size_t mbidc, uint64_t *mbidv, struct mpool_mcache_map **mapp);
+
+/**
+ * mpool_mcache_munmap() - munmap an mcache mmap
+ *
+ * @map:
+ */
+/* MTF_MOCK */
+void
+mpool_mcache_munmap(struct mpool_mcache_map *map);
+
+/**
+ * mpool_mcache_purge() - Purge map (NOT SUPPORTED)
+ *
+ * @map: mcache map handle
+ * @mp:  mp mpool
+ */
+/* MTF_MOCK */
+merr_t
+mpool_mcache_purge(struct mpool_mcache_map *map, const struct mpool *mp);
+
+/**
+ * mpool_mcache_mincore() - Get VSS and RSS for the mcache map (NOT SUPPORTED)
+ *
+ * @map:  mcache map handle
+ * @mp:   mpool handle
+ * @rssp: ptr to count of resident pages in the map
+ * @vssp: ptr to count of virtual pages in the map
+ *
+ * Get the virtual and resident set sizes (in pages count)
+ * for the given mcache map.
+ */
+/* MTF_MOCK */
+merr_t
+mpool_mcache_mincore(
+    struct mpool_mcache_map *map,
+    const struct mpool *     mp,
+    size_t *                 rssp,
+    size_t *                 vssp);
+
+#endif /* MPOOL_MCACHE_H */

--- a/lib/mpool/include/mpool/mpool.h
+++ b/lib/mpool/include/mpool/mpool.h
@@ -15,7 +15,6 @@
 
 struct mpool;            /* opaque mpool handle */
 struct mpool_mdc;        /* opaque MDC (metadata container) handle */
-struct mpool_mcache_map; /* opaque mcache map handle */
 struct mpool_file;       /* opaque mpool file handle */
 struct iovec;
 
@@ -463,123 +462,6 @@ mpool_mblock_mmap(struct mpool *mp, uint64_t mbid, const void **addr_out);
 
 merr_t
 mpool_mblock_munmap(struct mpool *mp, uint64_t mbid);
-
-
-/******************************** MCACHE APIs ************************************/
-
-/**
- * mpool_mcache_madvise() - Give advice about use of memory
- *
- * @map:    mcache map handle
- * @mbidx:  logical mblock number in mcache map
- * @offset: offset into the mblock specified by mbidx
- * @length: see madvise(2)
- * @advice: see madvise(2)
- *
- * Like madvise(2), but for mcache maps.
- *
- * Note that one can address the entire map (including holes) by
- * specifying zero for %mbidx, zero for %offset, and %SIZE_MAX for
- * %length.  In general, %SIZE_MAX may always be specified for %length,
- * in which case it addresses the map from the given mbidx based offset
- * to the end of the map.
- */
-/* MTF_MOCK */
-merr_t
-mpool_mcache_madvise(
-    struct mpool_mcache_map *map,
-    uint32_t                 mbidx,
-    off_t                    offset,
-    size_t                   length,
-    int                      advice);
-
-/**
- * mpool_mcache_getbase() - Get the base address of a memory-mapped mblock in an mcache map
- *
- * @map:   mcache map handle
- * @mbidx: mcache map mblock index
- *
- * If the pages of an mcache map are contiguous in memory (as is the case in
- * user-space), return the the base address of the mapped mblock.  If the
- * pages are not contiguous, return NULL.
- */
-/* MTF_MOCK */
-void *
-mpool_mcache_getbase(struct mpool_mcache_map *map, const uint32_t mbidx);
-
-/**
- * mpool_mcache_getpages() - Get a vector of pages from a single mblock
- *
- * @map:     mcache map handle
- * @pagec:   page count (len of @pagev array)
- * @mbidx:   mcache map mblock index
- * @offsetv: vector of page offsets into objects/mblocks
- * @pagev:   vector of pointers to pages (output)
- *
- * mbidx is an index into the mbidv[] vector that was given to mpool_mcache_create().
- *
- * Return: %0 on success, merr_t on failure
- */
-/* MTF_MOCK */
-merr_t
-mpool_mcache_getpages(
-    struct mpool_mcache_map *map,
-    const uint32_t           pagec,
-    const uint32_t           mbidx,
-    const off_t              offsetv[],
-    void *                   pagev[]);
-
-/**
- * mpool_mcache_mmap() - Create an mcache map
- *
- * @mp:    handle for the mpool
- * @mbidc: mblock ID count
- * @mbidv: vector of mblock IDs
- * @mapp:  pointer to (opaque) mpool_mcache_map ptr
- *
- * Create an mcache map for the list of given mblock IDs and returns a handle to it via *mapp.
- */
-/* MTF_MOCK */
-merr_t
-mpool_mcache_mmap(struct mpool *mp, size_t mbidc, uint64_t *mbidv, struct mpool_mcache_map **mapp);
-
-/**
- * mpool_mcache_munmap() - munmap an mcache mmap
- *
- * @map:
- */
-/* MTF_MOCK */
-void
-mpool_mcache_munmap(struct mpool_mcache_map *map);
-
-/**
- * mpool_mcache_purge() - Purge map (NOT SUPPORTED)
- *
- * @map: mcache map handle
- * @mp:  mp mpool
- */
-/* MTF_MOCK */
-merr_t
-mpool_mcache_purge(struct mpool_mcache_map *map, const struct mpool *mp);
-
-/**
- * mpool_mcache_mincore() - Get VSS and RSS for the mcache map (NOT SUPPORTED)
- *
- * @map:  mcache map handle
- * @mp:   mpool handle
- * @rssp: ptr to count of resident pages in the map
- * @vssp: ptr to count of virtual pages in the map
- *
- * Get the virtual and resident set sizes (in pages count)
- * for the given mcache map.
- */
-/* MTF_MOCK */
-merr_t
-mpool_mcache_mincore(
-    struct mpool_mcache_map *map,
-    const struct mpool *     mp,
-    size_t *                 rssp,
-    size_t *                 vssp);
 
 /**
  * An mpool_file is a simple wrapper around mpool to manage files in a specified

--- a/lib/mpool/src/mblock_file.h
+++ b/lib/mpool/src/mblock_file.h
@@ -7,7 +7,9 @@
 #define MPOOL_MBLOCK_FILE_H
 
 #include <rbtree.h>
+
 #include <hse/error/merr.h>
+#include <hse_util/compiler.h>
 
 #include "mclass.h"
 

--- a/lib/mpool/src/mdc_file.c
+++ b/lib/mpool/src/mdc_file.c
@@ -629,7 +629,7 @@ mdc_file_read(struct mdc_file *mfp, void *data, size_t len, bool verify, size_t 
     if (rdlen)
         *rdlen = rh.size;
 
-    if (ev(rh.size > len))
+    if (rh.size > len)
         return merr(EOVERFLOW);
 
     rhlen = omf_mdc_rechdr_len(mfp->lh.vers);

--- a/lib/util/include/hse_util/arch.h
+++ b/lib/util/include/hse_util/arch.h
@@ -11,10 +11,6 @@
 
 /* clang-format off */
 
-/* Max readahead pages offered by mcache.
- */
-#define HSE_RA_PAGES_MAX        ((128 * 1024) / PAGE_SIZE)
-
 #if (LEVEL1_DCACHE_LINESIZE > 64)
 #define HSE_L1D_LINESIZE        (LEVEL1_DCACHE_LINESIZE)
 #else

--- a/lib/util/include/hse_util/bloom_filter.h
+++ b/lib/util/include/hse_util/bloom_filter.h
@@ -12,14 +12,6 @@
 #include <hse_util/inttypes.h>
 #include <hse_util/bitmap.h>
 
-/* [HSE_REVISIT] This block bloom implementation is less of an abstraction
- * than it is a loose collection of parts from which a client may construct
- * and manage a bloom filter.  Going forward, we should endeavor to move
- * the implementation toward a self-managed object.  For simple, RAM buffer
- * based blooms that is trivial, but mcache based blooms will likely require
- * hooks and such that if not done right could impose significant overhead.
- */
-
 /* BF_BKTSHIFT defines the number of bits per bucket for newly created
  * bloom filters (i.e. 2^n bits per bucket, where n is BF_BKTSHIFT).
  * May not exceed one page worth of bits.

--- a/lib/util/src/platform.c
+++ b/lib/util/src/platform.c
@@ -107,6 +107,8 @@ hse_meminfo(ulong *freep, ulong *availp, uint shift)
     char buf[256], *str;
     ssize_t cc;
 
+    ev(1); /* monitor usage, don't call this function too often */
+
     if (hse_meminfo_cgroup(freep, availp, shift))
         return;
 
@@ -139,8 +141,6 @@ hse_meminfo(ulong *freep, ulong *availp, uint shift)
 
     if (ev(availp))
         *availp = 0;
-
-    ev(1); /* monitor usage, don't call this function too often */
 }
 
 /* For amd64 based machines we use the TSC to measure the latency

--- a/lib/util/src/table.c
+++ b/lib/util/src/table.c
@@ -42,7 +42,6 @@ table_create(uint capacity, size_t elemsz, bool zerofill)
     tab->data = mem;
     tab->zerofill = zerofill;
     tab->priv = NULL;
-    ev(1);
 
     return tab;
 }

--- a/tests/mocks/meson.build
+++ b/tests/mocks/meson.build
@@ -18,6 +18,7 @@ mocked_headers = [
     meson.project_source_root() / 'lib/cn/kblock_builder.h',
     meson.project_source_root() / 'lib/cn/kcompact.h',
     meson.project_source_root() / 'lib/cn/kvset.h',
+    meson.project_source_root() / 'lib/cn/kvs_mblk_desc.h',
     meson.project_source_root() / 'lib/cn/mbset.h',
     meson.project_source_root() / 'lib/cn/route.h',
     meson.project_source_root() / 'lib/cn/spill.h',

--- a/tests/mocks/repository/include/mocks/mock_mpool.h
+++ b/tests/mocks/repository/include/mocks/mock_mpool.h
@@ -46,6 +46,9 @@ mpm_mblock_alloc_file(u64 *blkid, const char *filename);
 merr_t
 mpm_mdc_load_file(const char *filename, char **data, int *len);
 
+merr_t
+mpm_mblock_get_base(u64 id, void **data, size_t *wlen);
+
 /* provide a function which can interpret a buffer and return
  * the length of the next record for a particular MDC
  */

--- a/tests/unit/cn/bloom_reader_test.c
+++ b/tests/unit/cn/bloom_reader_test.c
@@ -75,7 +75,7 @@ read_blooms(struct mtf_test_info *lcl_ti, char *kblock_file)
 {
     merr_t                err;
     struct mpool *        ds = (void *)-1;
-    struct bloom_desc     rgndesc = {};
+    struct bloom_desc     rgndesc = { 0 };
     struct kblock_hdr_omf kb_hdr;
     struct bloom_hdr_omf  blm_hdr;
     struct kvs_ktuple     ktuple;
@@ -84,7 +84,7 @@ read_blooms(struct mtf_test_info *lcl_ti, char *kblock_file)
     char *                endptr;
     char                  filename[PATH_MAX];
     char                  keybuf[32];
-    struct kvs_mblk_desc  blkdesc;
+    struct kvs_mblk_desc  blkdesc = { 0 };
     u64                   blkid;
     u8 *                  blm_pages;
 
@@ -95,10 +95,6 @@ read_blooms(struct mtf_test_info *lcl_ti, char *kblock_file)
     err = mpm_mblock_alloc_file(&blkid, filename);
     ASSERT_EQ(0, err);
     blkdesc.mbid = blkid;
-    blkdesc.map_idx = 0;
-
-    err = mpool_mcache_mmap(ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
 
     mpm_mblock_read(blkid, &kb_hdr, 0, sizeof(struct kblock_hdr_omf));
     ASSERT_EQ(sizeof(struct bloom_hdr_omf), omf_kbh_blm_hlen(&kb_hdr));
@@ -161,8 +157,6 @@ read_blooms(struct mtf_test_info *lcl_ti, char *kblock_file)
     /* Something's horriby wrong if the false positive rate high.
      */
     ASSERT_LT((fpc * 1000) / cnt, 25); /* < 2.5% */
-
-    mpool_mcache_munmap(blkdesc.map);
 
     free(blm_pages);
 }

--- a/tests/unit/cn/kblock_reader_test.c
+++ b/tests/unit/cn/kblock_reader_test.c
@@ -11,8 +11,6 @@
 #include <hse_util/bloom_filter.h>
 #include <hse_util/page.h>
 
-#include <hse_ikvdb/kvs_rparams.h>
-
 #include <cn/omf.h>
 #include <cn/kblock_reader.h>
 #include <cn/bloom_reader.h>
@@ -20,439 +18,318 @@
 #include <cn/wbt_reader.h>
 #include <cn/cn_metrics.h>
 
-#include <mocks/mock_mpool.h>
+/* 1 header page + 4 wbtree pages + 3 bloom pages */
+#define FAKE_WBTREE_DOFF_PG  1
+#define FAKE_WBTREE_DLEN_PG  4
 
-int
-test_collection_setup(struct mtf_test_info *info)
+#define FAKE_BLOOM_DOFF_PG   5
+#define FAKE_BLOOM_DLEN_PG   3
+
+#define FAKE_KBLOCK_SIZE ((1 + 4 + 3) * PAGE_SIZE)
+
+size_t madvise_advice;
+size_t madvise_off;
+size_t madvise_len;
+uint8_t kblock[FAKE_KBLOCK_SIZE];
+struct kvs_mblk_desc mblk;
+
+#define NUM_KEYS         1178
+#define NUM_TOMBSTONES    100
+#define TOT_KEY_BYTES    (NUM_KEYS * 20)
+#define TOT_VAL_BYTES    (NUM_KEYS * 100)
+#define TOT_KVLEN        (NUM_KEYS * 200)
+#define TOT_VUSED_BYTES  ((NUM_KEYS * 100) - 100)
+#define TOT_VGARB_BYTES   0
+
+#define HOFF_ALIGN  8
+#define WBT_HOFF ((sizeof(struct kblock_hdr_omf) + HOFF_ALIGN) & ~(HOFF_ALIGN - 1))
+#define BLM_HOFF (WBT_HOFF + ((sizeof(struct wbt_hdr_omf) + HOFF_ALIGN) & ~(HOFF_ALIGN - 1)))
+
+const struct kblk_metrics met = {
+    .num_keys = NUM_KEYS,
+    .num_tombstones = NUM_TOMBSTONES,
+    .tot_key_bytes = TOT_KEY_BYTES,
+    .tot_val_bytes = TOT_VAL_BYTES,
+    .tot_kvlen = TOT_KVLEN,
+    .tot_vused_bytes = TOT_VUSED_BYTES,
+    .tot_wbt_pages = FAKE_WBTREE_DLEN_PG,
+    .tot_blm_pages = FAKE_BLOOM_DLEN_PG,
+};
+
+const struct kblock_hdr_omf kbhro = {
+    .kbh_magic = KBLOCK_HDR_MAGIC,
+    .kbh_version = KBLOCK_HDR_VERSION,
+
+    .kbh_hlog_doff_pg = 0,
+    .kbh_hlog_dlen_pg = 0,
+
+    .kbh_entries = NUM_KEYS,
+    .kbh_tombs = NUM_TOMBSTONES,
+    .kbh_key_bytes = TOT_KEY_BYTES,
+    .kbh_val_bytes = TOT_VAL_BYTES,
+    .kbh_kvlen = TOT_KVLEN,
+    .kbh_vused_bytes = TOT_VUSED_BYTES,
+    .kbh_vgarb_bytes = TOT_VGARB_BYTES,
+
+    .kbh_min_koff = PAGE_SIZE - 100,
+    .kbh_max_koff = PAGE_SIZE - 50,
+    .kbh_min_klen = 20,
+    .kbh_max_klen = 21,
+
+    .kbh_wbt_hoff = WBT_HOFF,
+    .kbh_wbt_hlen = sizeof(struct wbt_hdr_omf),
+    .kbh_wbt_doff_pg = FAKE_WBTREE_DOFF_PG,
+    .kbh_wbt_dlen_pg = FAKE_WBTREE_DLEN_PG,
+
+    .kbh_blm_hoff = BLM_HOFF,
+    .kbh_blm_hlen = sizeof(struct bloom_hdr_omf),
+    .kbh_blm_doff_pg = FAKE_BLOOM_DOFF_PG,
+    .kbh_blm_dlen_pg = FAKE_BLOOM_DLEN_PG,
+};
+
+void
+init_kblock(struct kblock_hdr_omf *kbh)
 {
+    struct wbt_hdr_omf *wbt = (void *)kbh + WBT_HOFF;
+    struct bloom_hdr_omf *bh = (void *)kbh + BLM_HOFF;
+
+    omf_set_kbh_magic(kbh, kbhro.kbh_magic);
+    omf_set_kbh_version(kbh, kbhro.kbh_version);
+
+    omf_set_kbh_hlog_doff_pg(kbh, kbhro.kbh_hlog_doff_pg);
+    omf_set_kbh_hlog_dlen_pg(kbh, kbhro.kbh_hlog_dlen_pg);
+
+    omf_set_kbh_entries(kbh, kbhro.kbh_entries);
+    omf_set_kbh_tombs(kbh, kbhro.kbh_tombs);
+    omf_set_kbh_key_bytes(kbh, kbhro.kbh_key_bytes);
+    omf_set_kbh_val_bytes(kbh, kbhro.kbh_val_bytes);
+    omf_set_kbh_kvlen(kbh, kbhro.kbh_kvlen);
+    omf_set_kbh_vused_bytes(kbh, kbhro.kbh_vused_bytes);
+    omf_set_kbh_vgarb_bytes(kbh, kbhro.kbh_vgarb_bytes);
+
+    omf_set_kbh_min_koff(kbh, kbhro.kbh_min_koff - 100);
+    omf_set_kbh_min_klen(kbh, kbhro.kbh_min_klen);
+    omf_set_kbh_max_koff(kbh, kbhro.kbh_max_koff - 50);
+    omf_set_kbh_max_klen(kbh, kbhro.kbh_max_klen);
+
+    /* NOTE: fake wbtree is supposed to be at pages 3..12 */
+    omf_set_kbh_wbt_hoff(kbh, kbhro.kbh_wbt_hoff);
+    omf_set_kbh_wbt_hlen(kbh, kbhro.kbh_wbt_hlen);
+    omf_set_kbh_wbt_doff_pg(kbh, kbhro.kbh_wbt_doff_pg);
+    omf_set_kbh_wbt_dlen_pg(kbh, kbhro.kbh_wbt_dlen_pg);
+
+    /* NOTE: fake bloom filter at pages 1..2 */
+    omf_set_kbh_blm_hoff(kbh, kbhro.kbh_blm_hoff);
+    omf_set_kbh_blm_hlen(kbh, kbhro.kbh_blm_hlen);
+    omf_set_kbh_blm_doff_pg(kbh, kbhro.kbh_blm_doff_pg);
+    omf_set_kbh_blm_dlen_pg(kbh, kbhro.kbh_blm_dlen_pg);
+
+    /* wbtree header */
+    omf_set_wbt_magic(wbt, WBT_TREE_MAGIC);
+    omf_set_wbt_version(wbt, WBT_TREE_VERSION);
+    omf_set_wbt_root(wbt, 2);
+    omf_set_wbt_leaf(wbt, 1);
+    omf_set_wbt_leaf_cnt(wbt, 1);
+    omf_set_wbt_kmd_pgc(wbt, 1);
+
+    /* bloom header */
+    omf_set_bh_magic(bh, BLOOM_OMF_MAGIC);
+    omf_set_bh_version(bh, BLOOM_OMF_VERSION);
+    omf_set_bh_bitmapsz(bh, 128);
+    omf_set_bh_modulus(bh, 11);
+    omf_set_bh_bktshift(bh, 8);
+    omf_set_bh_rotl(bh, 8);
+    omf_set_bh_n_hashes(bh, 4);
+}
+
+merr_t
+mock_mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice)
+{
+    madvise_off = off;
+    madvise_len = len;
+    madvise_advice = advice;
     return 0;
 }
 
-int
-test_collection_teardown(struct mtf_test_info *info)
+merr_t
+mock_mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg_off, size_t pg_cnt, int advice)
 {
-    mock_mpool_unset();
+    madvise_off = pg_off * PAGE_SIZE;
+    madvise_len = pg_cnt * PAGE_SIZE;
+    madvise_advice = advice;
     return 0;
 }
 
 int
 pre(struct mtf_test_info *info)
 {
-    mock_mpool_set();
-    return 0;
-}
+    memset(kblock, 0, sizeof(kblock));
+    memset(&mblk, 0, sizeof(mblk));
 
-struct kb_hdr {
-    struct kblock_hdr_omf *kb_hdr;
-    struct wbt_hdr_omf *   wbt_hdr;
-    struct bloom_hdr_omf * blm_hdr;
-    u8                     data[4096];
-};
+    mblk.map_base = kblock;
 
-/* 1 header page + 2 bloom pages +10 wbtree pages */
-#define FAKE_KBLOCK_SIZE ((1 + 2 + 10) * PAGE_SIZE)
+    mblk.alen_pages = FAKE_KBLOCK_SIZE / PAGE_SIZE;
+    mblk.wlen_pages = FAKE_KBLOCK_SIZE / PAGE_SIZE;
+    mblk.mbid = 123;
+    mblk.mclass = 1;
 
-/* an empty buffer for writing to mblocks */
-const char fake_kblock_buf[FAKE_KBLOCK_SIZE];
+    init_kblock(mblk.map_base);
 
-void
-init_kb_hdr(struct kb_hdr *kb)
-{
-    u32 align = 8;
-    u32 wbt_off = (sizeof(struct kblock_hdr_omf) + align) & ~(align - 1);
-    u32 blm_off = wbt_off + ((sizeof(struct wbt_hdr_omf) + align) & ~(align - 1));
+    madvise_off = 12345;
+    madvise_len = 12345;
+    madvise_advice = 12345;
 
-    memset(kb->data, 0, 4096);
-    kb->kb_hdr = (struct kblock_hdr_omf *)(kb->data);
-    kb->wbt_hdr = (struct wbt_hdr_omf *)(kb->data + wbt_off);
-    kb->blm_hdr = (struct bloom_hdr_omf *)(kb->data + blm_off);
-
-    omf_set_kbh_magic(kb->kb_hdr, KBLOCK_HDR_MAGIC);
-    omf_set_kbh_version(kb->kb_hdr, KBLOCK_HDR_VERSION);
-    omf_set_kbh_entries(kb->kb_hdr, 1173);
-    omf_set_kbh_tombs(kb->kb_hdr, 87);
-    omf_set_kbh_key_bytes(kb->kb_hdr, 13789);
-    omf_set_kbh_val_bytes(kb->kb_hdr, 83787);
-    omf_set_kbh_wbt_hoff(kb->kb_hdr, wbt_off);
-
-    /* NOTE: fake bloom filter at pages 1..2 */
-    omf_set_kbh_blm_hlen(kb->kb_hdr, sizeof(struct bloom_hdr_omf));
-    omf_set_kbh_blm_doff_pg(kb->kb_hdr, 1);
-    omf_set_kbh_blm_dlen_pg(kb->kb_hdr, 2);
-
-    /* NOTE: fake wbtree is supposed to be at pages 3..12 */
-    omf_set_kbh_wbt_hlen(kb->kb_hdr, sizeof(struct wbt_hdr_omf));
-    omf_set_kbh_wbt_doff_pg(kb->kb_hdr, 3);
-    omf_set_kbh_wbt_dlen_pg(kb->kb_hdr, 10);
-    omf_set_kbh_blm_hoff(kb->kb_hdr, blm_off);
-
-    omf_set_wbt_magic(kb->wbt_hdr, WBT_TREE_MAGIC);
-    omf_set_wbt_version(kb->wbt_hdr, WBT_TREE_VERSION);
-    omf_set_wbt_root(kb->wbt_hdr, 0);
-    omf_set_wbt_leaf(kb->wbt_hdr, 0);
-    omf_set_wbt_leaf_cnt(kb->wbt_hdr, 0);
-
-    omf_set_bh_magic(kb->blm_hdr, BLOOM_OMF_MAGIC);
-    omf_set_bh_version(kb->blm_hdr, BLOOM_OMF_VERSION);
-
-    omf_set_bh_modulus(kb->blm_hdr, 11730);
-    omf_set_bh_bktshift(kb->blm_hdr, BF_BKTSHIFT);
-    omf_set_bh_rotl(kb->blm_hdr, BF_ROTL);
-    omf_set_bh_n_hashes(kb->blm_hdr, 7);
-    omf_set_bh_bitmapsz(kb->blm_hdr, ALIGN((omf_bh_modulus(kb->blm_hdr) / CHAR_BIT), PAGE_SIZE));
-}
-
-merr_t
-write_kb_hdr(struct kb_hdr *kb, struct kvs_mblk_desc *blkdesc)
-{
-    return mpm_mblock_write(blkdesc->mbid, kb->data, 0, PAGE_SIZE);
-}
-
-int
-check_read_hdrs(
-    struct kb_hdr *       kb,
-    struct kvs_mblk_desc *blkdesc,
-    int                   wbt_errno,
-    int                   blm_errno)
-{
-    merr_t            err;
-    struct wbt_desc   wb_desc;
-    struct bloom_desc blm_desc;
-
-    write_kb_hdr(kb, blkdesc);
-
-    err = kbr_read_wbt_region_desc(blkdesc, &wb_desc);
-    VERIFY_EQ_RET(merr_errno(err), wbt_errno, 1);
-
-    err = kbr_read_blm_region_desc(blkdesc, &blm_desc);
-    VERIFY_EQ_RET(merr_errno(err), blm_errno, 1);
+    MOCK_SET_FN(mblk_desc, mblk_madvise, mock_mblk_madvise);
+    MOCK_SET_FN(mblk_desc, mblk_madvise_pages, mock_mblk_madvise_pages);
 
     return 0;
 }
 
-MTF_BEGIN_UTEST_COLLECTION_PREPOST(
-    kblock_reader_test,
-    test_collection_setup,
-    test_collection_teardown);
+MTF_BEGIN_UTEST_COLLECTION(kblock_reader);
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_kbr_get_kblock_desc, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_read_wbt_region_desc, pre)
 {
-    merr_t                   err;
-    struct mpool *           ds = (void *)-1;
-    struct mpool_mcache_map *map = (struct mpool_mcache_map *)0x123;
-    u32                      map_idx = 3;
-    u64                      kbid = 0xffff;
-    struct kvs_mblk_desc     desc;
-    struct mblock_props      props = { 0 };
+    merr_t err;
+    struct wbt_desc wbt;
 
-    /* force success w/o having an actual mblock */
-    mapi_inject_ptr(mapi_idx_mpool_mcache_getbase, (void *)1);
-    err = kbr_get_kblock_desc(ds, map, &props, map_idx, kbid, &desc);
-    ASSERT_EQ(err, 0);
-
-    /* force fail */
-    mapi_inject_ptr(mapi_idx_mpool_mcache_getbase, 0);
-    err = kbr_get_kblock_desc(ds, map, &props, map_idx, kbid, &desc);
-    ASSERT_NE(err, 0);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
+    ASSERT_EQ(0, err);
+    ASSERT_EQ(wbt.wbd_first_page, kbhro.kbh_wbt_doff_pg);
+    ASSERT_EQ(wbt.wbd_n_pages, kbhro.kbh_wbt_dlen_pg);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, basic_wbt_blm_test, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_read_blm_region_desc, pre)
 {
-    merr_t               err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct wbt_desc      wb_desc;
-    struct bloom_desc    blm_desc;
-    struct kb_hdr        kb;
-    struct kblk_metrics  metrics;
-    struct kvs_mblk_desc blkdesc;
-    u64                  blkid;
+    merr_t err;
+    struct bloom_desc blm;
 
-    memset(&blkdesc, 0, sizeof(blkdesc));
-
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
+    err = kbr_read_blm_region_desc(&mblk, &blm);
     ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
-
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
-    ASSERT_EQ(0, err);
-
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
-
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
-
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(0, err);
-    ASSERT_EQ(omf_kbh_wbt_doff_pg(kb.kb_hdr), wb_desc.wbd_first_page);
-    ASSERT_EQ(omf_kbh_wbt_dlen_pg(kb.kb_hdr), wb_desc.wbd_n_pages);
-
-    err = kbr_read_blm_region_desc(&blkdesc, &blm_desc);
-    ASSERT_EQ(0, err);
-    ASSERT_EQ(omf_kbh_blm_doff_pg(kb.kb_hdr), blm_desc.bd_first_page);
-    ASSERT_EQ(omf_kbh_blm_dlen_pg(kb.kb_hdr), blm_desc.bd_n_pages);
-
-    /* BLOOM_LOOKUP_MCACHE will return base address of the bloom
-     * blocks in the mcache map.
-     */
-    blm_desc.bd_bitmap = NULL;
-    err = kbr_read_blm_pages(&blkdesc, &blm_desc);
-    ASSERT_EQ(0, err);
-    ASSERT_NE(NULL, blm_desc.bd_bitmap);
-
-    mapi_inject_once(mapi_idx_mpool_mcache_getpages, 1, EBUG);
-    blm_desc.bd_bitmap = NULL;
-    err = kbr_read_blm_pages(&blkdesc, &blm_desc);
-    ASSERT_NE(0, err);
-    ASSERT_EQ(NULL, blm_desc.bd_bitmap);
-
-    err = kbr_read_metrics(&blkdesc, &metrics);
-
-    ASSERT_EQ(0, err);
-    ASSERT_EQ(omf_kbh_entries(kb.kb_hdr), metrics.num_keys);
-    ASSERT_EQ(omf_kbh_tombs(kb.kb_hdr), metrics.num_tombstones);
-    ASSERT_EQ(omf_kbh_key_bytes(kb.kb_hdr), metrics.tot_key_bytes);
-    ASSERT_EQ(omf_kbh_val_bytes(kb.kb_hdr), metrics.tot_val_bytes);
-
-    mpool_mcache_munmap(blkdesc.map);
+    ASSERT_EQ(blm.bd_first_page, kbhro.kbh_blm_doff_pg);
+    ASSERT_EQ(blm.bd_n_pages, kbhro.kbh_blm_dlen_pg);
+    ASSERT_EQ(blm.bd_bitmap, mblk.map_base + PAGE_SIZE * blm.bd_first_page);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_kbr_madvise_bloom, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_read_metrics, pre)
 {
-    merr_t               err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct kb_hdr        kb;
-    struct kvs_mblk_desc blkdesc;
-    struct bloom_desc    blm_desc;
-    u64                  blkid;
+    merr_t err;
+    struct kblk_metrics met;
 
-    memset(&blkdesc, 0, sizeof(blkdesc));
-
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
+    err = kbr_read_metrics(&mblk, &met);
     ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
+    ASSERT_EQ(met.num_keys, kbhro.kbh_entries);
+    ASSERT_EQ(met.num_tombstones, kbhro.kbh_tombs);
+    ASSERT_EQ(met.tot_key_bytes, kbhro.kbh_key_bytes);
+    ASSERT_EQ(met.tot_val_bytes, kbhro.kbh_val_bytes);
+    ASSERT_EQ(met.tot_kvlen, kbhro.kbh_kvlen);
+    ASSERT_EQ(met.tot_vused_bytes, kbhro.kbh_vused_bytes);
+    ASSERT_EQ(met.tot_wbt_pages, kbhro.kbh_wbt_dlen_pg);
+    ASSERT_EQ(met.tot_blm_pages, kbhro.kbh_blm_dlen_pg);
 
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
-    ASSERT_EQ(0, err);
-
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
-
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
-
-    err = kbr_read_blm_region_desc(&blkdesc, &blm_desc);
-    ASSERT_EQ(err, 0);
-
-    /* once w/ forced error */
-    mapi_inject_once(mapi_idx_mpool_mcache_madvise, 1, EINVAL);
-    kbr_madvise_bloom(&blkdesc, &blm_desc, MADV_WILLNEED);
-
-    /* once w/o error */
-    kbr_madvise_bloom(&blkdesc, &blm_desc, MADV_WILLNEED);
-
-    blm_desc.bd_n_pages = 0;
-    kbr_madvise_bloom(&blkdesc, &blm_desc, MADV_WILLNEED);
-
-    mpool_mcache_munmap(blkdesc.map);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_kbr_madvise_wbt_leaf_nodes, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_read_invalid_version, pre)
 {
-    merr_t               err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct kb_hdr        kb = {};
-    struct kvs_mblk_desc blkdesc = {};
-    struct wbt_desc      wb_desc = {};
-    u64                  blkid = 0;
+    merr_t err;
+    struct wbt_desc wbt;
+    struct kblk_metrics met;
+    struct bloom_desc blm;
+    struct kblock_hdr_omf *kbh = mblk.map_base;
 
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
-    ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
+    omf_set_kbh_version(kbh, kbhro.kbh_version + 1);
 
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
-    ASSERT_EQ(0, err);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
+    ASSERT_EQ(EINVAL, merr_errno(err));
 
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
+    err = kbr_read_blm_region_desc(&mblk, &blm);
+    ASSERT_EQ(EINVAL, merr_errno(err));
 
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
-
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(err, 0);
-
-    /* once w/ forced error */
-    mapi_inject_once(mapi_idx_mpool_mcache_madvise, 1, EINVAL);
-    kbr_madvise_wbt_leaf_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    /* once w/o error */
-    kbr_madvise_wbt_leaf_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    wb_desc.wbd_leaf_cnt = 0;
-    kbr_madvise_wbt_leaf_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    mpool_mcache_munmap(blkdesc.map);
+    err = kbr_read_metrics(&mblk, &met);
+    ASSERT_EQ(EINVAL, merr_errno(err));
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_kbr_madvise_wbt_int_nodes, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_madvise_kmd, pre)
 {
-    merr_t               err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct kb_hdr        kb = {};
-    struct kvs_mblk_desc blkdesc = {};
-    struct wbt_desc      wb_desc = {};
-    u64                  blkid = 0;
+    merr_t err;
+    int adv;
+    uint32_t pg_off, pg_cnt;
+    struct wbt_desc wbt;
 
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
-    ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
-
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
     ASSERT_EQ(0, err);
 
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
+    adv = __LINE__;
+    pg_off = wbt.wbd_first_page + wbt.wbd_root + 1;
+    pg_cnt = wbt.wbd_kmd_pgc;
 
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
+    kbr_madvise_kmd(&mblk, &wbt, adv);
 
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(err, 0);
-
-    /* once w/ forced error */
-    mapi_inject_once(mapi_idx_mpool_mcache_madvise, 1, EINVAL);
-    kbr_madvise_wbt_int_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    /* once w/o error */
-    kbr_madvise_wbt_int_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    wb_desc.wbd_n_pages = 0;
-    wb_desc.wbd_leaf_cnt = 0;
-    kbr_madvise_wbt_int_nodes(&blkdesc, &wb_desc, MADV_WILLNEED);
-
-    mpool_mcache_munmap(blkdesc.map);
+    ASSERT_EQ(madvise_advice, adv);
+    ASSERT_EQ(madvise_off, PAGE_SIZE * pg_off);
+    ASSERT_EQ(madvise_len, PAGE_SIZE * pg_cnt);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, t_corrupt_header, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_madvise_wbt_leaf_nodes, pre)
 {
-    merr_t               err;
-    struct kvs_mblk_desc blkdesc;
-    struct kb_hdr        kb;
-    struct mpool *       mp_ds = (void *)-1;
-    u64                  blkid;
+    merr_t err;
+    int adv;
+    uint32_t pg_off, pg_cnt;
+    struct wbt_desc wbt;
 
-    memset(&blkdesc, 0, sizeof(blkdesc));
-
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
-    ASSERT_EQ(err, 0);
-    blkdesc.mbid = blkid;
-
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
     ASSERT_EQ(0, err);
 
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(err, 0);
+    adv = __LINE__;
+    pg_off = wbt.wbd_first_page;
+    pg_cnt = wbt.wbd_leaf_cnt;
 
-    /* verify we can read w/o corruption */
-    init_kb_hdr(&kb);
-    err = check_read_hdrs(&kb, &blkdesc, 0, 0);
-    ASSERT_EQ(err, 0);
+    kbr_madvise_wbt_leaf_nodes(&mblk, &wbt, adv);
 
-    /* corrupt kblock hdr magic */
-    init_kb_hdr(&kb);
-    omf_set_kbh_magic(kb.kb_hdr, omf_kbh_magic(kb.kb_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, EINVAL, EINVAL);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt kblock hdr version */
-    init_kb_hdr(&kb);
-    omf_set_kbh_version(kb.kb_hdr, omf_kbh_version(kb.kb_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, EINVAL, EINVAL);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt wbt hdr magic */
-    init_kb_hdr(&kb);
-    omf_set_wbt_magic(kb.wbt_hdr, omf_wbt_magic(kb.wbt_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, EINVAL, 0);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt wbt hdr version */
-    init_kb_hdr(&kb);
-    omf_set_wbt_version(kb.wbt_hdr, omf_wbt_version(kb.wbt_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, EINVAL, 0);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt blm hdr magic */
-    init_kb_hdr(&kb);
-    omf_set_bh_magic(kb.blm_hdr, omf_bh_magic(kb.blm_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, 0, EINVAL);
-    ASSERT_EQ(err, 0);
-
-    /* corrupt blm hdr version */
-    /* check should succeed, but with blooms disabled */
-    init_kb_hdr(&kb);
-    omf_set_bh_version(kb.blm_hdr, omf_bh_version(kb.blm_hdr) + 1);
-    err = check_read_hdrs(&kb, &blkdesc, 0, 0);
-    ASSERT_EQ(err, 0);
-
-    mpool_mcache_munmap(blkdesc.map);
+    ASSERT_EQ(madvise_advice, adv);
+    ASSERT_EQ(madvise_off, PAGE_SIZE * pg_off);
+    ASSERT_EQ(madvise_len, PAGE_SIZE * pg_cnt);
 }
 
-MTF_DEFINE_UTEST_PRE(kblock_reader_test, basic_kblock_error_test, pre)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_madvise_wbt_int_nodes, pre)
 {
-    merr_t               err, force_err;
-    struct mpool *       mp_ds = (void *)-1;
-    struct kb_hdr        kb;
-    struct wbt_desc      wb_desc;
-    struct bloom_desc    blm_desc;
-    struct kvs_mblk_desc blkdesc;
-    u64                  blkid;
+    merr_t err;
+    int adv;
+    uint32_t pg_off, pg_cnt;
+    struct wbt_desc wbt;
 
-    memset(&blkdesc, 0, sizeof(blkdesc));
-
-    err = mpm_mblock_alloc(FAKE_KBLOCK_SIZE, &blkid);
-    ASSERT_EQ(0, err);
-    blkdesc.mbid = blkid;
-
-    err = mpm_mblock_write(blkid, fake_kblock_buf, 0, FAKE_KBLOCK_SIZE);
+    err = kbr_read_wbt_region_desc(&mblk, &wbt);
     ASSERT_EQ(0, err);
 
-    init_kb_hdr(&kb);
-    err = write_kb_hdr(&kb, &blkdesc);
-    ASSERT_EQ(err, 0);
+    adv = __LINE__;
+    pg_off = wbt.wbd_first_page + wbt.wbd_leaf_cnt;
+    pg_cnt = wbt.wbd_n_pages - wbt.wbd_leaf_cnt - wbt.wbd_kmd_pgc;
 
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(0, err);
+    kbr_madvise_wbt_int_nodes(&mblk, &wbt, adv);
 
-    force_err = __LINE__;
-    mapi_inject_ptr(mapi_idx_mpool_mcache_getpages, (void *)force_err);
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(force_err, err);
-    mapi_inject_unset(mapi_idx_mpool_mcache_getpages);
-
-    err = kbr_read_wbt_region_desc(&blkdesc, &wb_desc);
-    ASSERT_EQ(0, err);
-
-    force_err = __LINE__;
-    mapi_inject_ptr(mapi_idx_mpool_mcache_getpages, (void *)force_err);
-    err = kbr_read_blm_region_desc(&blkdesc, &blm_desc);
-    ASSERT_EQ(force_err, err);
-    mapi_inject_unset(mapi_idx_mpool_mcache_getpages);
-
-    err = kbr_read_blm_region_desc(&blkdesc, &blm_desc);
-    ASSERT_EQ(0, err);
-
-    /* kbr_read_blm_pages() should return base address of the bloom blocks in the mcache map.
-     */
-    blm_desc.bd_bitmap = NULL;
-    err = kbr_read_blm_pages(&blkdesc, &blm_desc);
-    ASSERT_EQ(0, err);
-    ASSERT_NE(NULL, blm_desc.bd_bitmap);
+    ASSERT_EQ(madvise_advice, adv);
+    ASSERT_EQ(madvise_off, PAGE_SIZE * pg_off);
+    ASSERT_EQ(madvise_len, PAGE_SIZE * pg_cnt);
 }
 
-MTF_END_UTEST_COLLECTION(kblock_reader_test)
+MTF_DEFINE_UTEST_PRE(kblock_reader, t_kbr_madvise_bloom, pre)
+{
+    merr_t err;
+    int adv;
+    uint32_t pg_off, pg_cnt;
+    struct bloom_desc blm;
+
+    err = kbr_read_blm_region_desc(&mblk, &blm);
+    ASSERT_EQ(0, err);
+
+    adv = __LINE__;
+    pg_off = blm.bd_first_page;
+    pg_cnt = blm.bd_n_pages;
+
+    kbr_madvise_bloom(&mblk, &blm, adv);
+
+    ASSERT_EQ(madvise_advice, adv);
+    ASSERT_EQ(madvise_off, PAGE_SIZE * pg_off);
+    ASSERT_EQ(madvise_len, PAGE_SIZE * pg_cnt);
+}
+
+MTF_END_UTEST_COLLECTION(kblock_reader)

--- a/tests/unit/cn/mbset_test.c
+++ b/tests/unit/cn/mbset_test.c
@@ -16,95 +16,42 @@
 
 #define ds ((struct mpool *)1)
 
-#define mock_alloc_cap (4 * 1024 * 1024)
-#define mock_write_len (mock_alloc_cap - 128 * 1024)
-#define MBLOCKS_MAX ((1UL << 30) / (32 << 20))
-
-#define MILLION ((u64)1000000)
-
-#define id2bnum(id) ((id)-100 * MILLION)
-#define bnum2id(bnum) ((bnum) + 100 * MILLION)
-
-#define id2map(id) ((id) + 3 * MILLION)
-
-#define bnum2map(bnum) id2map(bnum2id(bnum))
+#define mock_alen_pages 358
+#define mock_wlen_pages 353
 
 struct udata {
-    uint bnum;
-    u64  id;
-    int  return_code;
+    u64  cookie;
 };
 
-#define ufn ((mbset_udata_init_fn *)t_udata_init)
+#define ufn t_udata_init
 #define usz sizeof(struct udata)
 
-/*
- * Mock mpool interfaces used by mbset.
- */
-static merr_t
-_mpool_mblock_props_get(struct mpool *dsp, uint64_t objid, struct mblock_props *props)
-{
-    memset(props, 0, sizeof(*props));
+int mocked_mblk_mmap_errno = 0;
+int mocked_mblk_munmap_errno = 0;
 
-    props->mpr_objid = objid;
-    props->mpr_alloc_cap = mock_alloc_cap;
-    props->mpr_write_len = mock_write_len;
+merr_t
+mocked_mblk_mmap(struct mpool *mp, u64 mbid, struct kvs_mblk_desc *md)
+{
+    if (mocked_mblk_mmap_errno)
+        return merr(mocked_mblk_mmap_errno);
+
+    md->map_base = (void *)0x1111;
+    md->mbid = mbid;
+    md->alen_pages = mock_alen_pages;
+    md->wlen_pages = mock_wlen_pages;
+    md->mclass = 1;
+
     return 0;
 }
 
-static merr_t
-_mpool_mcache_mmap(
-    struct mpool *            dsp,
-    size_t                    idc,
-    uint64_t *                idv,
-    struct mpool_mcache_map **map)
+merr_t
+mocked_mblk_munmap(struct mpool *mp, struct kvs_mblk_desc *md)
 {
-    size_t i;
-    u64 *  m;
+    if (mocked_mblk_munmap_errno)
+        return merr(mocked_mblk_munmap_errno);
 
-    /* In this mock, an mcache map of COUNT mblocks is an array
-     * of COUNT u64 values where value is a simple reversible obfuscation
-     * of the mblock id.
-     */
-    m = mapi_safe_malloc(sizeof(*m) * idc);
-    VERIFY_NE_RET(m, 0, -1);
-
-    for (i = 0; i < idc; i++)
-        m[i] = id2map(idv[i]);
-
-    *map = (struct mpool_mcache_map *)m;
+    md->map_base = (void *)0x2222;
     return 0;
-}
-
-static void
-_mpool_mcache_munmap(struct mpool_mcache_map *map)
-{
-    mapi_safe_free(map);
-}
-
-HSE_MAYBE_UNUSED
-static void
-mock_unset(void)
-{
-    MOCK_UNSET(mpool, _mpool_mblock_props_get);
-
-    MOCK_UNSET(mpool, _mpool_mcache_mmap);
-    MOCK_UNSET(mpool, _mpool_mcache_munmap);
-
-    mapi_inject_unset(mapi_idx_mpool_mcache_madvise);
-    mapi_inject_unset(mapi_idx_mpool_mblock_delete);
-}
-
-static void
-mock_set(void)
-{
-    MOCK_SET(mpool, _mpool_mblock_props_get);
-
-    MOCK_SET(mpool, _mpool_mcache_mmap);
-    MOCK_SET(mpool, _mpool_mcache_munmap);
-
-    mapi_inject(mapi_idx_mpool_mcache_madvise, 0);
-    mapi_inject(mapi_idx_mpool_mblock_delete, 0);
 }
 
 static int
@@ -122,7 +69,11 @@ fini(struct mtf_test_info *mtf)
 static int
 pre(struct mtf_test_info *mtf)
 {
-    mock_set();
+    mapi_inject(mapi_idx_mpool_mblock_delete, 0);
+    mapi_inject(mapi_idx_mblk_madvise, 0);
+    MOCK_SET_FN(mblk_desc, mblk_mmap, mocked_mblk_mmap);
+    MOCK_SET_FN(mblk_desc, mblk_munmap, mocked_mblk_munmap);
+
     return 0;
 }
 
@@ -132,7 +83,17 @@ post(struct mtf_test_info *mtf)
     return 0;
 }
 
-MTF_BEGIN_UTEST_COLLECTION_PREPOST(test, init, fini);
+typedef merr_t
+mbset_udata_init_fn(const struct kvs_mblk_desc *mblk, void *rock);
+
+static merr_t
+t_udata_init(const struct kvs_mblk_desc *mblk, void *rock)
+{
+    struct udata *u = rock;
+
+    u->cookie = mblk->mbid;
+    return 0;
+}
 
 struct t_callback_info {
     uint invoked;
@@ -149,307 +110,150 @@ t_callback(void *rock, bool mblock_delete_error)
         info->delete_error_detected++;
 }
 
-static merr_t
-t_udata_init(
-    struct mbset *       mbs,
-    uint                 bnum,
-    uint *               argcp,
-    u64 *                argv,
-    struct mblock_props *props,
-    void *               rock)
-{
-    struct udata *u = rock;
-
-    u->bnum = bnum;
-    u->id = props->mpr_objid;
-    return u->return_code;
-}
-
+#if 0
 static merr_t
 t_udata_update(
-    struct mbset *       mbs,
-    uint                 bnum,
-    uint *               argcp,
-    u64 *                argv,
-    struct mblock_props *props,
-    void *               rock)
+    struct udata   *u,
+    uint           *vgroupc,
+    u64            *vgroupv)
 {
-    struct udata *u = rock;
-    int           i;
-
-    for (i = 0; i < *argcp; ++i) {
-        if (argv[i] == u->id)
-            return u->return_code;
-    }
-
-    argv[i] = u->id;
-    *argcp = i + 1;
-
-    return u->return_code;
-}
-
-static u64 *
-idv_alloc(uint idc)
-{
-    int  i;
-    u64 *idv;
-
-    idv = mapi_safe_malloc(idc * sizeof(*idv));
-    if (idv) {
-        for (i = 0; i < idc; i++)
-            idv[i] = bnum2id(i);
-    }
-
-    return idv;
-}
-
-static int
-t_mbs_create(struct mtf_test_info *lcl_ti, uint idc, u64 **idv_out, struct mbset **mbs_out)
-{
-    merr_t        err;
-    u64 *         idv;
-    struct mbset *mbs;
-
-    idv = idv_alloc(idc);
-    ASSERT_NE_RET(idv, NULL, -1);
-
-    err = mbset_create(ds, idc, idv, usz, ufn, 0, &mbs);
-    ASSERT_EQ_RET(err, 0, -1);
-
-    *idv_out = idv;
-    *mbs_out = mbs;
     return 0;
 }
+#endif
 
-static int
-t_mbs_verify(struct mtf_test_info *lcl_ti, uint idc, u64 *idv, struct mbset *mbs)
+void
+idv_init(u64 *idv, uint idc)
 {
-    uint i;
-
-    ASSERT_EQ_RET(mbset_get_blkc(mbs), idc, -1);
-
-    for (i = 0; i < idc; i++) {
-
-        struct udata *u;
-        void *        map;
-
-        ASSERT_EQ_RET(mbset_get_mp(mbs), ds, -1);
-
-        ASSERT_EQ_RET(mbset_get_alen(mbs), (u64)idc * mock_alloc_cap, -1);
-
-        ASSERT_EQ_RET(mbset_get_wlen(mbs), (u64)idc * mock_write_len, -1);
-
-        ASSERT_EQ_RET(mbset_get_mbid(mbs, i), bnum2id(i), -1);
-
-        u = mbset_get_udata(mbs, i);
-        ASSERT_NE_RET(u, NULL, -1);
-        ASSERT_EQ_RET(u->bnum, i, -1);
-        ASSERT_EQ_RET(u->id, idv[i], -1);
-
-        /* Get map and map index, verify the map @ map_idx is correct.
-         * See the mocked mpool_mcache_map_create (above, in this file).
-         */
-        map = mbset_get_map(mbs);
-        ASSERT_NE_RET(map, NULL, -1);
-
-        ASSERT_EQ_RET(((u64 *)map)[i], bnum2map(i), -1);
-    }
-
-    return 0;
+    for (uint i = 0; i < idc; i++)
+        idv[i] = 1000 + i;
 }
 
-int
-t_mbs_destroy(struct mtf_test_info *lcl_ti, u64 *idv, struct mbset *mbs)
-{
-    mapi_safe_free(idv);
-    mbset_put_ref(mbs);
-    return 0;
-}
+MTF_BEGIN_UTEST_COLLECTION_PREPOST(test, init, fini);
 
 MTF_DEFINE_UTEST_PREPOST(test, t_mbset_create_simple, pre, post)
 {
-    u64 *         idv;
-    uint          idc = 2;
+    u64 idv[32];
+    uint idc = NELEM(idv);
     struct mbset *mbs;
     merr_t        err;
 
-    idv = idv_alloc(idc);
-    ASSERT_NE(idv, NULL);
+    idv_init(idv, idc);
 
-    err = mbset_create(ds, idc, idv, usz, ufn, 0, &mbs);
+    err = mbset_create(ds, idc, idv, usz, ufn, &mbs);
     ASSERT_EQ(err, 0);
     mbset_put_ref(mbs);
-
-    mapi_safe_free(idv);
 }
 
 MTF_DEFINE_UTEST_PREPOST(test, t_mbset_create_invalid_params, pre, post)
 {
-    u64 *         idv;
-    uint          idc = 2;
+    u64 idv[2];
+    uint idc = NELEM(idv);
     struct mbset *mbs;
-    merr_t        err;
+    merr_t err;
 
-    idv = idv_alloc(idc);
-    ASSERT_NE(idv, NULL);
+    idv_init(idv, idc);
 
-    err = mbset_create(0, idc, idv, usz, ufn, 0, &mbs);
+    err = mbset_create(0, idc, idv, usz, ufn, &mbs);
     ASSERT_NE(err, 0);
 
-    err = mbset_create(ds, 0, idv, usz, ufn, 0, &mbs);
+    err = mbset_create(ds, 0, idv, usz, ufn, &mbs);
     ASSERT_NE(err, 0);
 
-    err = mbset_create(ds, idc, 0, usz, ufn, 0, &mbs);
+    err = mbset_create(ds, idc, 0, usz, ufn, &mbs);
     ASSERT_NE(err, 0);
 
-    err = mbset_create(ds, idc, idv, usz, ufn, 0, 0);
+    err = mbset_create(ds, idc, idv, usz, ufn, 0);
     ASSERT_NE(err, 0);
-
-    mapi_safe_free(idv);
 }
 
 MTF_DEFINE_UTEST_PREPOST(test, t_mbset_create_alloc_fail, pre, post)
 {
-    u64 *         idv;
-    uint          idc = 2;
+    u64 idv[2];
+    uint idc = NELEM(idv);
     struct mbset *mbs;
-    merr_t        err;
-    uint          i, num_allocs;
+    merr_t err;
 
-    idv = idv_alloc(idc);
-    ASSERT_NE(idv, NULL);
+    idv_init(idv, idc);
 
-    /* mbset_create does two allocations, and the callback does one.
-     * Verify ENOMEM when first two allocs fail, verify success
-     * when third alloc fails.
-     */
-    num_allocs = 2;
-    for (i = 0; i <= num_allocs; i++) {
-        mapi_inject_once_ptr(mapi_idx_malloc, i + 1, 0);
-        err = mbset_create(ds, idc, idv, usz, ufn, 0, &mbs);
-        if (i < num_allocs) {
-            ASSERT_EQ(merr_errno(err), ENOMEM);
-        } else {
-            ASSERT_EQ(err, 0);
-            mbset_put_ref(mbs);
-        }
-        mapi_inject_unset(mapi_idx_malloc);
-    }
+    mapi_inject_ptr(mapi_idx_malloc, 0);
+    err = mbset_create(ds, idc, idv, usz, ufn, &mbs);
+    ASSERT_EQ(merr_errno(err), ENOMEM);
+    mapi_inject_unset(mapi_idx_malloc);
+}
 
-    mapi_safe_free(idv);
+MTF_DEFINE_UTEST_PREPOST(test, t_mbset_create_mblk_map_fail, pre, post)
+{
+    u64 idv[2];
+    uint idc = NELEM(idv);
+    struct mbset *mbs;
+    merr_t err;
+
+    idv_init(idv, idc);
+
+    mocked_mblk_mmap_errno = 1234;
+    err = mbset_create(ds, idc, idv, usz, ufn, &mbs);
+    ASSERT_EQ(merr_errno(err), mocked_mblk_mmap_errno);
+    mocked_mblk_mmap_errno = 0;
+}
+
+MTF_DEFINE_UTEST_PREPOST(test, t_mbset_create_mblk_unmap_errors, pre, post)
+{
+    u64 idv[2];
+    uint idc = NELEM(idv);
+    struct mbset *mbs;
+    merr_t err;
+
+    idv_init(idv, idc);
+
+    err = mbset_create(ds, idc, idv, usz, ufn, &mbs);
+    ASSERT_EQ(err, 0);
+
+    mocked_mblk_munmap_errno = 1234;
+    mbset_put_ref(mbs);
+    mocked_mblk_munmap_errno = 0;
 }
 
 MTF_DEFINE_UTEST_PREPOST(test, t_mbset_getters, pre, post)
 {
-    u64 *idv = NULL;
-    uint test_cases[] = { MBLOCKS_MAX - 1,     MBLOCKS_MAX,     MBLOCKS_MAX + 1,
-                          2 * MBLOCKS_MAX - 1, 2 * MBLOCKS_MAX, 2 * MBLOCKS_MAX + 1 };
-
-    uint          tx;
-    struct mbset *mbs = NULL;
-
-    for (tx = 0; tx < NELEM(test_cases); tx++) {
-        uint idc = test_cases[tx];
-
-        t_mbs_create(lcl_ti, idc, &idv, &mbs);
-        t_mbs_verify(lcl_ti, idc, idv, mbs);
-        t_mbs_destroy(lcl_ti, idv, mbs);
-    }
-}
-
-MTF_DEFINE_UTEST_PREPOST(test, t_mbset_create_fail, pre, post)
-{
-    u64 *idv;
-    uint test_cases[] = { MBLOCKS_MAX - 1,     MBLOCKS_MAX,     MBLOCKS_MAX + 1,
-                          2 * MBLOCKS_MAX - 1, 2 * MBLOCKS_MAX, 2 * MBLOCKS_MAX + 1 };
-
+    u64 idv[19];
+    uint idc = NELEM(idv);
     struct mbset *mbs;
-    merr_t        err;
-    uint          num_allocs;
+    merr_t err;
 
-    uint i, ax, tx;
+    idv_init(idv, idc);
 
-    struct api_table {
-        uint api;
-        bool is_ptr;
-        u64  rc;
-    } api_table[] = {
-        { mapi_idx_malloc, true, 0 },
-        { mapi_idx_mpool_mcache_mmap, false, 1 },
-        { mapi_idx_mpool_mblock_props_get, false, 1 },
-    };
+    err = mbset_create(ds, idc, idv, usz, ufn, &mbs);
+    ASSERT_EQ(err, 0);
 
-    /* For #mblocks in 1, 2, MAX-1, MAX, MAX+1, etc.. */
-    for (tx = 0; tx < NELEM(test_cases); tx++) {
+    ASSERT_EQ(mbset_get_blkc(mbs), idc);
+    ASSERT_EQ(mbset_get_mp(mbs), ds);
+    ASSERT_EQ(mbset_get_alen(mbs), idc * mock_alen_pages * PAGE_SIZE);
+    ASSERT_EQ(mbset_get_wlen(mbs), idc * mock_wlen_pages * PAGE_SIZE);
 
-        uint idc = test_cases[tx];
+    for (uint i = 0; i < idc; i++) {
+        struct udata *u;
 
-        /* Allocate id vector for said number of mblocks */
-        idv = idv_alloc(idc);
-        ASSERT_NE(idv, NULL);
+        ASSERT_EQ(mbset_get_mbid(mbs, i), 1000 + i);
 
-        /* For each mocked API that can fail in mbset_create */
-        for (ax = 0; ax < NELEM(api_table); ax++) {
-
-            uint api = api_table[ax].api;
-            bool ptr = api_table[ax].is_ptr;
-            u64  rc = api_table[ax].rc;
-
-            /* Set 'num_allocs' to number of times this api is
-             * invoked in a successful call to mbset_create.
-             */
-            mapi_inject_unset(api);
-
-            err = mbset_create(ds, idc, idv, usz, ufn, 0, &mbs);
-            ASSERT_EQ(err, 0);
-            num_allocs = mapi_calls(api);
-
-            mbset_put_ref(mbs);
-
-            /* Create an mbset 'num_allocs+1' times.
-             * On the i-th try, force a failure on the i-th call
-             * to 'api'.  mbset should fail on each one.  On last
-             * iteration, mbset_create should succeed.  To get
-             * maximum value from this test, run it under
-             * valgrind.
-             */
-            for (i = 0; i <= num_allocs; i++) {
-                mapi_inject_unset(api);
-                if (ptr)
-                    mapi_inject_once_ptr(api, i + 1, (void *)rc);
-                else
-                    mapi_inject_once(api, i + 1, rc);
-
-                err = mbset_create(ds, idc, idv, usz, ufn, 0, &mbs);
-
-                if (i < num_allocs) {
-                    ASSERT_NE(err, 0);
-                } else {
-                    ASSERT_EQ(err, 0);
-                    mbset_put_ref(mbs);
-                }
-            }
-
-            mapi_inject_unset(api);
-        }
-
-        mapi_safe_free(idv);
+        u = mbset_get_udata(mbs, i);
+        ASSERT_NE(u, NULL);
+        ASSERT_EQ(u->cookie, idv[i]);
     }
+
+    mbset_put_ref(mbs);
 }
 
 MTF_DEFINE_UTEST_PREPOST(test, t_mbset_callback, pre, post)
 {
     merr_t        err;
     struct mbset *mbs;
-    u64 *         idv;
-    uint          idc = 4;
-    uint          i;
+    u64           idv[4];
+    uint          idc = NELEM(idv);
     struct t_callback_info actual;
     struct t_callback_info expect;
     uint expect_mblock_delete_calls;
 
-    idv = idv_alloc(idc);
-    ASSERT_NE(idv, NULL);
+    idv_init(idv, idc);
 
     /* Test steps:
      * - clear put/del counts
@@ -461,11 +265,11 @@ MTF_DEFINE_UTEST_PREPOST(test, t_mbset_callback, pre, post)
      * - verify put/del called as expected
      * - verify callback invoked as expected
      */
-    for (i = 0; i < 3; i++) {
+    for (uint i = 0; i < 3; i++) {
 
         mapi_inject(mapi_idx_mpool_mblock_delete, 0);
 
-        err = mbset_create(ds, idc, idv, usz, ufn, 0, &mbs);
+        err = mbset_create(ds, idc, idv, usz, ufn, &mbs);
         ASSERT_EQ(err, 0);
 
         switch (i) {
@@ -483,12 +287,12 @@ MTF_DEFINE_UTEST_PREPOST(test, t_mbset_callback, pre, post)
             case 2:
                 mapi_inject_set(mapi_idx_mpool_mblock_delete,
                     1, 2, 0,  /* calls 1 and 2 successful */
-                    3, 0, -1  /* calls 3 to forevery fail */
+                    3, 0, -1  /* calls 3 to forever fail */
                     );
                 mbset_set_delete_flag(mbs);
                 expect.invoked = 1;
                 expect.delete_error_detected = 1;
-                expect_mblock_delete_calls = 3; /* two success calls to delete, one failed call */
+                expect_mblock_delete_calls = idc;
                 break;
 
             default:
@@ -510,62 +314,6 @@ MTF_DEFINE_UTEST_PREPOST(test, t_mbset_callback, pre, post)
         ASSERT_EQ(expect.delete_error_detected, actual.delete_error_detected);
         ASSERT_EQ(expect_mblock_delete_calls, mapi_calls(mapi_idx_mpool_mblock_delete));
     }
-
-    mapi_safe_free(idv);
-}
-
-MTF_DEFINE_UTEST_PREPOST(test, t_mbset_madvise, pre, post)
-{
-    u64 *         idv;
-    uint          idc = 2;
-    struct mbset *mbs;
-    merr_t        err;
-
-    idv = idv_alloc(idc);
-    ASSERT_NE(idv, NULL);
-
-    err = mbset_create(ds, idc, idv, usz, ufn, 0, &mbs);
-    ASSERT_EQ(err, 0);
-
-    /* This madvise will fail, but we'll get coverage...
-     */
-    mbset_madvise(mbs, MADV_WILLNEED);
-
-    mbset_put_ref(mbs);
-
-    mapi_safe_free(idv);
-}
-
-MTF_DEFINE_UTEST_PREPOST(test, t_mbset_apply, pre, post)
-{
-    u64 *         idv;
-    uint          idc = 3;
-    struct mbset *mbs;
-    merr_t        err;
-    uint          argc = 0;
-    u64           argv[idc + 1];
-
-    idv = idv_alloc(idc);
-    ASSERT_NE(idv, NULL);
-
-    err = mbset_create(ds, idc, idv, usz, ufn, 0, &mbs);
-    ASSERT_EQ(err, 0);
-
-    mbset_apply(NULL, t_udata_update, &argc, argv);
-    mbset_apply(mbs, NULL, &argc, argv);
-
-    argv[0] = 0xdeadbeefdeadbeef;
-    argv[idc] = 0xdeadbeefdeadbeef;
-
-    mbset_apply(mbs, t_udata_update, &argc, argv);
-
-    ASSERT_EQ(argc, idc);
-    ASSERT_NE(argv[0], 0xdeadbeefdeadbeef);
-    ASSERT_EQ(argv[idc], 0xdeadbeefdeadbeef);
-
-    mbset_put_ref(mbs);
-
-    mapi_safe_free(idv);
 }
 
 MTF_END_UTEST_COLLECTION(test);

--- a/tests/unit/cn/wbt_iterator_test.c
+++ b/tests/unit/cn/wbt_iterator_test.c
@@ -174,15 +174,9 @@ load_kblock(
 
     /* create mmap for mblock */
     kblk_desc->mbid = blkid;
-    kblk_desc->map_idx = 0;
-    kblk_desc->map_base = 0;
-    kblk_desc->ds = (struct mpool *)-1;
 
-    err = mpool_mcache_mmap(kblk_desc->ds, 1, &blkid, &kblk_desc->map);
+    err = mpm_mblock_get_base(blkid, &kblk_desc->map_base, NULL);
     ASSERT_EQ_RET(err, 0, -1);
-
-    kblk_desc->map_base = mpool_mcache_getbase(kblk_desc->map, kblk_desc->map_idx);
-    ASSERT_NE_RET(kblk_desc->map_base, NULL, -1);
 
     wbt_hdr = kblk_desc->map_base + omf_kbh_wbt_hoff(kblk_desc->map_base);
     desc->wbd_first_page = omf_kbh_wbt_doff_pg(kblk_desc->map_base);
@@ -190,8 +184,6 @@ load_kblock(
 
     err = wbtr_read_desc(wbt_hdr, desc);
     ASSERT_EQ_RET(err, 0, -1);
-
-    mpool_mcache_munmap(kblk_desc->map);
 
     return 0;
 }

--- a/tests/unit/cn/wbt_reader_test.c
+++ b/tests/unit/cn/wbt_reader_test.c
@@ -79,13 +79,9 @@ t_wbtr_read_vref_helper(struct mtf_test_info *lcl_ti, const char *kblock_image_f
     err = mpm_mblock_alloc_file(&blkid, filename);
     ASSERT_EQ(err, 0);
     blkdesc.mbid = blkid;
-    blkdesc.map_idx = 0;
 
-    err = mpool_mcache_mmap(mp_ds, 1, &blkdesc.mbid, &blkdesc.map);
-    ASSERT_EQ(err, 0);
-
-    blkdesc.map_base = mpool_mcache_getbase(blkdesc.map, blkdesc.map_idx);
-    ASSERT_NE(blkdesc.map_base, NULL);
+    err = mpm_mblock_get_base(blkdesc.mbid, &blkdesc.map_base, NULL);
+    ASSERT_NE(err, NULL);
 
     wbt_hdr = blkdesc.map_base + omf_kbh_wbt_hoff(blkdesc.map_base);
 
@@ -131,8 +127,6 @@ t_wbtr_read_vref_helper(struct mtf_test_info *lcl_ti, const char *kblock_image_f
 
     ASSERT_EQ(nkeys, cnt);
     wbti_destroy(wbti);
-
-    mpool_mcache_munmap(blkdesc.map);
 }
 
 MTF_BEGIN_UTEST_COLLECTION_PREPOST(

--- a/tests/unit/kvdb/kvdb_rparams_test.c
+++ b/tests/unit/kvdb/kvdb_rparams_test.c
@@ -195,7 +195,7 @@ MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, csched_policy, test_pre)
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
     ASSERT_EQ(csched_rp_kvset_iter_async, params.csched_policy);
     ASSERT_EQ(csched_rp_kvset_iter_async, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(csched_rp_kvset_iter_mcache, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(csched_rp_kvset_iter_mmap, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, csched_debug_mask, test_pre)

--- a/tests/unit/mpool/mcache_test.c
+++ b/tests/unit/mpool/mcache_test.c
@@ -16,8 +16,11 @@
 #include <hse_util/page.h>
 
 #include <mpool/mpool.h>
+#include <mpool/mcache.h>
+
 #include <mblock_file.h>
 #include <mblock_fset.h>
+#include <mclass.h>
 #include <mpool_internal.h>
 
 #include "common.h"

--- a/tools/mpool/mblock/mpiotest.c
+++ b/tools/mpool/mblock/mpiotest.c
@@ -36,6 +36,7 @@
 #include <hse_util/page.h>
 
 #include <mpool/mpool.h>
+#include <mpool/mcache.h>
 
 #define MBLOCK_SIZE_MB_DEFAULT (32 << 20)
 #define WANDERMAX              (1024 * 128)

--- a/tools/range_read/range_read.c
+++ b/tools/range_read/range_read.c
@@ -623,7 +623,7 @@ main(
             warmup_nkeys = warmup_nkeys < opts.nkeys ? warmup_nkeys : opts.nkeys;
             warmup_nkeys = (warmup_nkeys * 3) / 2;
 
-            /* 1. Warm up mcache using point gets */
+            /* 1. Warm up memory cache using point gets */
             printf("System memory %lu\n", tot_mem);
             printf("Warmup keycnt %u\n", warmup_nkeys);
             opts.range=1;

--- a/tools/scripts/plot_crossover.py
+++ b/tools/scripts/plot_crossover.py
@@ -137,8 +137,8 @@ def main():
     <p>
     This set of plots compares get performance with cursor performance as it varies with the burst length.<br>
     The keys in the kvs is evenly distributed across 64 prefixes. At each stage the test adds more suffixes<br>
-    for each prefix and this load is followed by warming up mcache and then performing get and cursor operation<br>
-    for various burstlens.<br>
+    for each prefix and this load is followed by warming up the page cache and then performing get and<br>
+    cursor operation for various burstlens.<br>
     </p>
 
     <p>


### PR DESCRIPTION
Mcache was used in the early days of HSE when mpool was kernel module.  KVDB no
longer uses it, but it remains a hidden part of mpool for testing purposes (see
mpiotest).

Summary of changes:
- Implement new mblock descriptor
- Update the following code to use mblock descriptors instead of mcache maps:
  mbsets, hblock, kblock and vblock readers, mpool mocks, unit tests.
- Bury mcache in lib/mpool

Signed-off-by: Alex Tomlinson <4172734+alexttx@users.noreply.github.com>
