### PR TITLE
Make REST operations fallible

### DIFF
--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -27,6 +27,7 @@
 #include <hse_ikvdb/sched_sts.h>
 #include <hse_ikvdb/throttle.h>
 #include <hse_ikvdb/kvdb_rparams.h>
+#include <hse_ikvdb/hse_gparams.h>
 
 #include "csched_sp3.h"
 #include "csched_sp3_work.h"
@@ -35,6 +36,8 @@
 #include "cn_tree_internal.h"
 #include "kvset.h"
 #include "route.h"
+
+#define ENDPOINT_FMT_KVDB_CSCED "/kvdbs/%s/csched"
 
 struct mpool;
 
@@ -2632,7 +2635,7 @@ sp3_destroy(struct csched *handle)
     mutex_destroy(&sp->sp_dlist_lock);
     cv_destroy(&sp->mon_cv);
 
-    rest_server_remove_endpoint("/kvdbs/%s/csched", sp->kvdb_alias);
+    rest_server_remove_endpoint(ENDPOINT_FMT_KVDB_CSCED, sp->kvdb_alias);
 
     free(sp->wp);
     free(sp);
@@ -2707,9 +2710,14 @@ sp3_create(
 
     sp->kvdb_alias = kvdb_alias;
 
-    err = rest_server_add_endpoint(REST_ENDPOINT_EXACT, handlers, sp, "/kvdbs/%s/csched", kvdb_alias);
-    if (ev_warn(err))
-        log_warnx("Failed to add REST endpoint (/kvdbs/%s/csched)", err, kvdb_alias);
+    if (hse_gparams.gp_rest.enabled) {
+        err = rest_server_add_endpoint(REST_ENDPOINT_EXACT, handlers, sp, ENDPOINT_FMT_KVDB_CSCED,
+            kvdb_alias);
+        if (err) {
+            log_errx("Failed to add REST endpoint (" ENDPOINT_FMT_KVDB_CSCED ")", err, kvdb_alias);
+            goto err_exit;
+        }
+    }
 
     INIT_WORK(&sp->mon_work, sp3_monitor);
     queue_work(sp->mon_wq, &sp->mon_work);
@@ -2719,6 +2727,7 @@ sp3_create(
     return 0;
 
 err_exit:
+    destroy_workqueue(sp->mon_wq);
     sts_destroy(sp->sts);
 
     mutex_destroy(&sp->mon_lock);

--- a/lib/kvdb/kvdb_rest.h
+++ b/lib/kvdb/kvdb_rest.h
@@ -11,11 +11,11 @@ struct kvdb_kvs;
 merr_t
 kvdb_rest_add_endpoints(struct ikvdb *kvdb);
 
-merr_t
+void
 kvdb_rest_remove_endpoints(struct ikvdb *kvdb);
 
 merr_t
 kvs_rest_add_endpoints(struct ikvdb *kvdb, struct kvdb_kvs *kvs);
 
-merr_t
+void
 kvs_rest_remove_endpoints(struct ikvdb *kvdb, struct kvdb_kvs *kvs);

--- a/lib/rest/lib/server.c
+++ b/lib/rest/lib/server.c
@@ -386,7 +386,7 @@ rest_server_remove_endpoint(const char *const path_fmt, ...)
     }
 
     if (!deleted) {
-        err = merr(EINVAL);
+        err = merr(ENOENT);
         goto out;
     }
 

--- a/tests/unit/rest/rest_test.c
+++ b/tests/unit/rest/rest_test.c
@@ -120,7 +120,7 @@ MTF_DEFINE_UTEST_PREPOST(rest_test, remove_endpoint, test_pre, test_post)
 
     /* Endpoint does not exist */
     err = rest_server_remove_endpoint("test");
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 }
 
 struct response_ctx


### PR DESCRIPTION
Previously, if route registration failed or server startup failed, it was just a warning and HSE would keep chugging along. That is now no longer the case.

Signed-off-by: Tristan Partin <tpartin@micron.com>
