### PR TITLE
Move bind structure inside transaction structure

### DIFF
--- a/lib/include/hse_ikvdb/kvdb_ctxn.h
+++ b/lib/include/hse_ikvdb/kvdb_ctxn.h
@@ -44,17 +44,12 @@ struct kvdb_ctxn {
  * @b_gen:      generation count; if mismatch, must update
  * @b_ref:      reference counts; last one in frees
  * @b_update:   updated by cursor when it changes the tombspan
- * @b_preserve: updated by transaction when it ends
- *              committed transactions preserve the tombspan
- *              aborted transactions don't preserve it, if there were puts/dels
- *              (potentially uncommitted tombstones)
  */
 struct kvdb_ctxn_bind {
     struct kvdb_ctxn *b_ctxn;
     atomic_ulong      b_gen;
     atomic_int        b_ref;
     bool              b_update;
-    bool              b_preserve;
 };
 
 /* MTF_MOCK */

--- a/lib/include/hse_ikvdb/kvs.h
+++ b/lib/include/hse_ikvdb/kvs.h
@@ -47,7 +47,6 @@ struct hse_kvs_cursor {
     struct perfc_set *     kc_pkvsl_pc;
     struct kvdb_kvs *      kc_kvs;
     struct kvdb_ctxn_bind *kc_bind;
-    struct kvdb_ctxn *     kc_ctxn;
     u64                    kc_gen;
     u64                    kc_seq;
     u64                    kc_create_time;

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -2806,7 +2806,6 @@ ikvdb_kvs_cursor_create(
 
     cur->kc_kvs = kk;
     cur->kc_gen = 0;
-    cur->kc_ctxn = ctxn;
     cur->kc_bind = ctxn ? kvdb_ctxn_cursor_bind(ctxn) : NULL;
 
     /* Temporarily lock a view until this cursor gets refs on cn kvsets. */
@@ -2855,8 +2854,10 @@ ikvdb_kvs_cursor_update_view(struct hse_kvs_cursor *cur, unsigned int flags)
     if (ev(cur->kc_err))
         return cur->kc_err;
 
-    if (ev(cur->kc_ctxn))
-        return merr(EINVAL);
+    /* This is a no-op for a transaction cursor.
+     */
+    if (cur->kc_bind)
+        return 0;
 
     cur->kc_seq = HSE_SQNREF_UNDEFINED;
 

--- a/lib/kvdb/kvdb_ctxn.c
+++ b/lib/kvdb/kvdb_ctxn.c
@@ -83,7 +83,6 @@ kvdb_ctxn_bind_putref(struct kvdb_ctxn_bind *bind)
     assert(refcnt >= 0);
     if (refcnt == 0)
         bind->b_ctxn = NULL;
-
 }
 
 static inline void

--- a/lib/kvdb/kvdb_ctxn_internal.h
+++ b/lib/kvdb/kvdb_ctxn_internal.h
@@ -49,11 +49,11 @@ struct kvdb_ctxn_impl {
     struct kvdb_pfxlock      *ctxn_kvdb_pfxlock;
     struct kvdb_ctxn_pfxlock *ctxn_pfxlock_handle;
 
-    struct kvdb_ctxn_bind   ctxn_bind;
     struct c0sk            *ctxn_c0sk;
     struct kvdb_ctxn_set   *ctxn_kvdb_ctxn_set;
     atomic_ulong           *ctxn_kvdb_seq_addr;
     struct c0snr_set       *ctxn_c0snr_set;
+    struct kvdb_ctxn_bind   ctxn_bind;
 
     struct wal             *ctxn_wal HSE_ACP_ALIGNED;
     int64_t                 ctxn_wal_cookie;

--- a/lib/kvdb/kvdb_ctxn_internal.h
+++ b/lib/kvdb/kvdb_ctxn_internal.h
@@ -49,7 +49,7 @@ struct kvdb_ctxn_impl {
     struct kvdb_pfxlock      *ctxn_kvdb_pfxlock;
     struct kvdb_ctxn_pfxlock *ctxn_pfxlock_handle;
 
-    struct kvdb_ctxn_bind  *ctxn_bind;
+    struct kvdb_ctxn_bind   ctxn_bind;
     struct c0sk            *ctxn_c0sk;
     struct kvdb_ctxn_set   *ctxn_kvdb_ctxn_set;
     atomic_ulong           *ctxn_kvdb_seq_addr;

--- a/tests/functional/kvpy/bind.py
+++ b/tests/functional/kvpy/bind.py
@@ -83,5 +83,6 @@ try:
             cursor2.destroy()
 
         cursor1.destroy()
+
 finally:
     hse.fini()


### PR DESCRIPTION
Signed-off-by: Gaurav Ramdasi <10132364+gsramdasi@users.noreply.github.com>

## Description
Move the bind structure (`struct kvdb_ctxn_bind`) inside `struct kvdb_ctxn_impl`.

## Issue(s) Addressed
NFSE-5361
NFSE-5362
