### PR TITLE
Rename hse_kvdb_txn to hse_txn

### DIFF
--- a/include/hse/experimental.h
+++ b/include/hse/experimental.h
@@ -138,7 +138,7 @@ hse_err_t
 hse_kvs_prefix_probe(
     struct hse_kvs *            kvs,
     unsigned int                flags,
-    struct hse_kvdb_txn        *txn,
+    struct hse_txn        *txn,
     const void *                pfx,
     size_t                      pfx_len,
     enum hse_kvs_pfx_probe_cnt *found,

--- a/include/hse/hse.h
+++ b/include/hse/hse.h
@@ -548,7 +548,7 @@ hse_err_t
 hse_kvs_delete(
     struct hse_kvs *     kvs,
     unsigned int         flags,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     const void *         key,
     size_t               key_len);
 
@@ -588,7 +588,7 @@ hse_err_t
 hse_kvs_get(
     struct hse_kvs *     kvs,
     unsigned int         flags,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     const void *         key,
     size_t               key_len,
     bool *               found,
@@ -673,7 +673,7 @@ hse_err_t
 hse_kvs_prefix_delete(
     struct hse_kvs *     kvs,
     unsigned int         flags,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     const void *         pfx,
     size_t               pfx_len);
 
@@ -728,7 +728,7 @@ hse_err_t
 hse_kvs_put(
     struct hse_kvs *     kvs,
     unsigned int         flags,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     const void *         key,
     size_t               key_len,
     const void *         val,
@@ -769,11 +769,11 @@ hse_kvs_put(
  *        +-----------+                 +----------+
  *
  * When a transaction is initially allocated, it starts in the INVALID state.
- * When hse_kvdb_txn_begin() is called with transaction in the INVALID,
+ * When hse_txn_begin() is called with transaction in the INVALID,
  * COMMITTED, or ABORTED states, it moves to the ACTIVE state. It is an error to
- * call the hse_kvdb_txn_begin() function on a transaction in the ACTIVE state.
+ * call the hse_txn_begin() function on a transaction in the ACTIVE state.
  * For a transaction in the ACTIVE state, only the functions
- * hse_kvdb_txn_commit(), hse_kvdb_txn_abort(), or hse_kvdb_txn_free() may be
+ * hse_txn_commit(), hse_txn_abort(), or hse_kvdb_txn_free() may be
  * called (with the last doing an abort prior to the free).
  *
  * When a transaction becomes ACTIVE, it establishes an ephemeral snapshot view
@@ -800,7 +800,7 @@ hse_kvs_put(
  * @note This function is thread safe with different transactions.
  *
  * @param kvdb: KVDB handle from hse_kvdb_open().
- * @param txn: KVDB transaction handle from hse_kvdb_txn_alloc().
+ * @param txn: Transaction handle from hse_kvdb_txn_alloc().
  *
  * @remark @p kvdb must not be NULL.
  * @remark @p txn must not be NULL.
@@ -809,7 +809,7 @@ hse_kvs_put(
  */
 /* MTF_MOCK */
 hse_err_t
-hse_kvdb_txn_abort(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
+hse_txn_abort(struct hse_kvdb *kvdb, struct hse_txn *txn);
 
 /** @brief Allocate transaction object.
  *
@@ -825,7 +825,7 @@ hse_kvdb_txn_abort(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * @returns The allocated transaction structure.
  */
 /* MTF_MOCK */
-struct hse_kvdb_txn *
+struct hse_txn *
 hse_kvdb_txn_alloc(struct hse_kvdb *kvdb);
 
 /** @brief Initiate transaction.
@@ -836,7 +836,7 @@ hse_kvdb_txn_alloc(struct hse_kvdb *kvdb);
  * @note This function is thread safe with different transactions.
  *
  * @param kvdb: KVDB handle from hse_kvdb_open().
- * @param txn: KVDB transaction handle from hse_kvdb_txn_alloc().
+ * @param txn: Transaction handle from hse_kvdb_txn_alloc().
  *
  * @remark @p kvdb must not be NULL.
  * @remark @p txn must not be NULL.
@@ -845,7 +845,7 @@ hse_kvdb_txn_alloc(struct hse_kvdb *kvdb);
  */
 /* MTF_MOCK */
 hse_err_t
-hse_kvdb_txn_begin(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
+hse_txn_begin(struct hse_kvdb *kvdb, struct hse_txn *txn);
 
 /** @brief Commit all the mutations of the referenced transaction.
  *
@@ -855,7 +855,7 @@ hse_kvdb_txn_begin(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * @note This function is thread safe with different transactions.
  *
  * @param kvdb: KVDB handle from hse_kvdb_open().
- * @param txn: KVDB transaction handle from hse_kvdb_txn_alloc().
+ * @param txn: Transaction handle from hse_kvdb_txn_alloc().
  *
  * @remark @p kvdb must not be NULL.
  * @remark @p txn must not be NULL.
@@ -864,7 +864,7 @@ hse_kvdb_txn_begin(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  */
 /* MTF_MOCK */
 hse_err_t
-hse_kvdb_txn_commit(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
+hse_txn_commit(struct hse_kvdb *kvdb, struct hse_txn *txn);
 
 /** @brief Free transaction object.
  *
@@ -877,21 +877,21 @@ hse_kvdb_txn_commit(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * @note This function is thread safe with different transactions.
  *
  * @param kvdb: KVDB handle from hse_kvdb_open().
- * @param txn: KVDB transaction handle.
+ * @param txn: Transaction handle from hse_kvdb_txn_alloc().
  *
  * @remark @p kvdb must not be NULL.
  * @remark @p txn must not be NULL.
  */
 /* MTF_MOCK */
 void
-hse_kvdb_txn_free(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
+hse_kvdb_txn_free(struct hse_kvdb *kvdb, struct hse_txn *txn);
 
 /** @brief Retrieve the state of the referenced transaction.
  *
  * This function is thread safe with different transactions.
  *
  * @param kvdb: KVDB handle from hse_kvdb_open().
- * @param txn: KVDB transaction handle from hse_kvdb_txn_alloc().
+ * @param txn: Transaction handle from hse_kvdb_txn_alloc().
  *
  * @remark @p kvdb must not be NULL.
  * @remark @p txn must not be NULL.
@@ -899,8 +899,8 @@ hse_kvdb_txn_free(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
  * @returns Transaction's state.
  */
 /* MTF_MOCK */
-enum hse_kvdb_txn_state
-hse_kvdb_txn_state_get(struct hse_kvdb *kvdb, struct hse_kvdb_txn *txn);
+enum hse_txn_state
+hse_txn_state_get(struct hse_kvdb *kvdb, struct hse_txn *txn);
 
 /**@} TRANSACTIONS */
 
@@ -976,7 +976,7 @@ hse_err_t
 hse_kvs_cursor_create(
     struct hse_kvs *        kvs,
     unsigned int            flags,
-    struct hse_kvdb_txn *   txn,
+    struct hse_txn *   txn,
     const void *            filter,
     size_t                  filter_len,
     struct hse_kvs_cursor **cursor);

--- a/include/hse/types.h
+++ b/include/hse/types.h
@@ -133,18 +133,18 @@ struct hse_kvs_cursor;
  * @{
  */
 
-/** @struct hse_kvdb_txn
+/** @struct hse_txn
  * @brief Opaque structure, a pointer to which is a handle to a transaction
  * within a KVDB.
  */
-struct hse_kvdb_txn;
+struct hse_txn;
 
 /** @brief Transaction state. */
-enum hse_kvdb_txn_state {
-    HSE_KVDB_TXN_INVALID = 0,   /**< invalid state */
-    HSE_KVDB_TXN_ACTIVE = 1,    /**< active state */
-    HSE_KVDB_TXN_COMMITTED = 2, /**< committed state */
-    HSE_KVDB_TXN_ABORTED = 3,   /**< aborted state */
+enum hse_txn_state {
+    HSE_TXN_INVALID = 0,   /**< invalid state */
+    HSE_TXN_ACTIVE = 1,    /**< active state */
+    HSE_TXN_COMMITTED = 2, /**< committed state */
+    HSE_TXN_ABORTED = 3,   /**< aborted state */
 };
 
 /** @} TRANSACTIONS */

--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -1170,7 +1170,7 @@ hse_err_t
 hse_kvs_put(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     const void *               key,
     size_t                     key_len,
     const void *               val,
@@ -1210,7 +1210,7 @@ hse_err_t
 hse_kvs_get(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     const void *               key,
     size_t                     key_len,
     bool *                     found,
@@ -1272,7 +1272,7 @@ hse_err_t
 hse_kvs_delete(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     const void *               key,
     size_t                     key_len)
 {
@@ -1303,7 +1303,7 @@ hse_err_t
 hse_kvs_prefix_probe(
     struct hse_kvs *            handle,
     const unsigned int          flags,
-    struct hse_kvdb_txn *const  txn,
+    struct hse_txn *const  txn,
     const void *                pfx,
     size_t                      pfx_len,
     enum hse_kvs_pfx_probe_cnt *found,
@@ -1378,7 +1378,7 @@ hse_err_t
 hse_kvs_prefix_delete(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     const void *               pfx,
     size_t                     pfx_len)
 {
@@ -1441,7 +1441,7 @@ hse_mclass_name_get(const enum hse_mclass mclass)
     return NULL;
 }
 
-struct hse_kvdb_txn *
+struct hse_txn *
 hse_kvdb_txn_alloc(struct hse_kvdb *handle)
 {
     if (HSE_UNLIKELY(!handle))
@@ -1453,7 +1453,7 @@ hse_kvdb_txn_alloc(struct hse_kvdb *handle)
 }
 
 void
-hse_kvdb_txn_free(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
+hse_kvdb_txn_free(struct hse_kvdb *handle, struct hse_txn *txn)
 {
     if (HSE_UNLIKELY(!handle || !txn))
         return;
@@ -1464,7 +1464,7 @@ hse_kvdb_txn_free(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
 }
 
 hse_err_t
-hse_kvdb_txn_begin(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
+hse_txn_begin(struct hse_kvdb *handle, struct hse_txn *txn)
 {
     merr_t err;
     u64    tstart;
@@ -1484,7 +1484,7 @@ hse_kvdb_txn_begin(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
 }
 
 hse_err_t
-hse_kvdb_txn_commit(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
+hse_txn_commit(struct hse_kvdb *handle, struct hse_txn *txn)
 {
     merr_t err;
     u64    tstart;
@@ -1504,7 +1504,7 @@ hse_kvdb_txn_commit(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
 }
 
 hse_err_t
-hse_kvdb_txn_abort(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
+hse_txn_abort(struct hse_kvdb *handle, struct hse_txn *txn)
 {
     merr_t err;
     u64    tstart;
@@ -1523,15 +1523,15 @@ hse_kvdb_txn_abort(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
     return err;
 }
 
-enum hse_kvdb_txn_state
-hse_kvdb_txn_state_get(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
+enum hse_txn_state
+hse_txn_state_get(struct hse_kvdb *handle, struct hse_txn *txn)
 {
-    enum hse_kvdb_txn_state state = 0;
+    enum hse_txn_state state = 0;
     enum kvdb_ctxn_state    istate;
     struct kvdb_ctxn *      ctxn;
 
     if (HSE_UNLIKELY(!handle || !txn))
-        return HSE_KVDB_TXN_INVALID;
+        return HSE_TXN_INVALID;
 
     ctxn = kvdb_ctxn_h2h(txn);
 
@@ -1541,19 +1541,19 @@ hse_kvdb_txn_state_get(struct hse_kvdb *handle, struct hse_kvdb_txn *txn)
 
     switch (istate) {
         case KVDB_CTXN_ACTIVE:
-            state = HSE_KVDB_TXN_ACTIVE;
+            state = HSE_TXN_ACTIVE;
             break;
 
         case KVDB_CTXN_COMMITTED:
-            state = HSE_KVDB_TXN_COMMITTED;
+            state = HSE_TXN_COMMITTED;
             break;
 
         case KVDB_CTXN_ABORTED:
-            state = HSE_KVDB_TXN_ABORTED;
+            state = HSE_TXN_ABORTED;
             break;
 
         default:
-            state = HSE_KVDB_TXN_INVALID;
+            state = HSE_TXN_INVALID;
             break;
     }
 
@@ -1566,7 +1566,7 @@ hse_err_t
 hse_kvs_cursor_create(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     const void *               prefix,
     size_t                     pfx_len,
     struct hse_kvs_cursor **   cursor)

--- a/lib/include/hse_ikvdb/ikvdb.h
+++ b/lib/include/hse_ikvdb/ikvdb.h
@@ -43,7 +43,7 @@ struct kvs;
 struct ikvdb_kvs_hdl;
 enum hse_mclass;
 
-struct hse_kvdb_txn {
+struct hse_txn {
 };
 
 /**
@@ -419,7 +419,7 @@ merr_t
 ikvdb_kvs_put(
     struct hse_kvs *         kvs,
     unsigned int             flags,
-    struct hse_kvdb_txn *    txn,
+    struct hse_txn *    txn,
     struct kvs_ktuple *      kt,
     struct kvs_vtuple       *vt);
 
@@ -431,7 +431,7 @@ merr_t
 ikvdb_kvs_get(
     struct hse_kvs *     kvs,
     unsigned int         flags,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     struct kvs_ktuple *  kt,
     enum key_lookup_res *res,
     struct kvs_buf *     vbuf);
@@ -445,7 +445,7 @@ merr_t
 ikvdb_kvs_del(
     struct hse_kvs *     kvs,
     unsigned int         flags,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     struct kvs_ktuple *  kt);
 
 /* MTF_MOCK */
@@ -453,7 +453,7 @@ merr_t
 ikvdb_kvs_pfx_probe(
     struct hse_kvs *     handle,
     unsigned int         flags,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     struct kvs_ktuple *  kt,
     enum key_lookup_res *res,
     struct kvs_buf *     kbuf,
@@ -469,7 +469,7 @@ merr_t
 ikvdb_kvs_prefix_delete(
     struct hse_kvs *     kvs,
     unsigned int         flags,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     struct kvs_ktuple *  kt);
 
 merr_t
@@ -504,40 +504,40 @@ ikvdb_txn_horizon(struct ikvdb *store);
 /**
  * ikvdb_txn_alloc() - allocate space for a transaction
  */
-struct hse_kvdb_txn *
+struct hse_txn *
 ikvdb_txn_alloc(struct ikvdb *kvdb);
 
 /**
  * ikvdb_txn_free() - free space for a transaction
  */
 void
-ikvdb_txn_free(struct ikvdb *kvdb, struct hse_kvdb_txn *txn);
+ikvdb_txn_free(struct ikvdb *kvdb, struct hse_txn *txn);
 
 /**
  * ikvdb_txn_begin() - initiate a transaction. txn->kt_seq_num identifies it.
  */
 merr_t
-ikvdb_txn_begin(struct ikvdb *kvdb, struct hse_kvdb_txn *txn);
+ikvdb_txn_begin(struct ikvdb *kvdb, struct hse_txn *txn);
 
 /**
  * ikvdb_txn_commit() - publish all mutations performed in the context of txn.
  */
 merr_t
-ikvdb_txn_commit(struct ikvdb *kvdb, struct hse_kvdb_txn *txn);
+ikvdb_txn_commit(struct ikvdb *kvdb, struct hse_txn *txn);
 
 /**
  * ikvdb_txn_abort() - abort all mutations performed in the context of txn,
  * such that they are not visible in any subsequent access.
  */
 merr_t
-ikvdb_txn_abort(struct ikvdb *kvdb, struct hse_kvdb_txn *txn);
+ikvdb_txn_abort(struct ikvdb *kvdb, struct hse_txn *txn);
 
 /**
  * ikvdb_txn_state() - retrieve the state of a transaction.
  *
  */
 enum kvdb_ctxn_state
-ikvdb_txn_state(struct ikvdb *kvdb, struct hse_kvdb_txn *txn);
+ikvdb_txn_state(struct ikvdb *kvdb, struct hse_txn *txn);
 
 /**
  * ikvdb_kvs_create_cursor() - return a cursor that may be used to iterate
@@ -548,7 +548,7 @@ merr_t
 ikvdb_kvs_cursor_create(
     struct hse_kvs *        kvs,
     unsigned int            flags,
-    struct hse_kvdb_txn *   txn,
+    struct hse_txn *   txn,
     const void *            prefix,
     size_t                  pfx_len,
     struct hse_kvs_cursor **cursor);

--- a/lib/include/hse_ikvdb/kvdb_ctxn.h
+++ b/lib/include/hse_ikvdb/kvdb_ctxn.h
@@ -32,7 +32,7 @@ enum kvdb_ctxn_state {
 };
 
 struct kvdb_ctxn {
-    struct hse_kvdb_txn ctxn_handle;
+    struct hse_txn ctxn_handle;
 };
 
 #define kvdb_ctxn_h2h(handle) container_of(handle, struct kvdb_ctxn, ctxn_handle)

--- a/lib/include/hse_ikvdb/kvs.h
+++ b/lib/include/hse_ikvdb/kvs.h
@@ -24,7 +24,7 @@
 
 /*- Internal Key Value Store  -----------------------------------------------*/
 
-struct hse_kvdb_txn;
+struct hse_txn;
 struct kvdb_ctxn;
 struct kvdb_kvs;
 struct cndb;
@@ -169,7 +169,7 @@ kvs_perfc_pkvsl(struct ikvs *ikvs);
 merr_t
 kvs_put(
     struct ikvs *            ikvs,
-    struct hse_kvdb_txn *    txn,
+    struct hse_txn *    txn,
     struct kvs_ktuple *      kt,
     struct kvs_vtuple       *vt,
     u64                      seqno);
@@ -177,19 +177,19 @@ kvs_put(
 merr_t
 kvs_get(
     struct ikvs *        ikvs,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     struct kvs_ktuple *  key,
     u64                  seqno,
     enum key_lookup_res *res,
     struct kvs_buf *     vbuf);
 
 merr_t
-kvs_del(struct ikvs *ikvs, struct hse_kvdb_txn *txn, struct kvs_ktuple *key, u64 seqno);
+kvs_del(struct ikvs *ikvs, struct hse_txn *txn, struct kvs_ktuple *key, u64 seqno);
 
 merr_t
 kvs_pfx_probe(
     struct ikvs *        kvs,
-    struct hse_kvdb_txn *txn,
+    struct hse_txn *txn,
     struct kvs_ktuple *  kt,
     u64                  seqno,
     enum key_lookup_res *res,
@@ -197,7 +197,7 @@ kvs_pfx_probe(
     struct kvs_buf *     vbuf);
 
 merr_t
-kvs_prefix_del(struct ikvs *ikvs, struct hse_kvdb_txn *txn, struct kvs_ktuple *key, u64 seqno);
+kvs_prefix_del(struct ikvs *ikvs, struct hse_txn *txn, struct kvs_ktuple *key, u64 seqno);
 
 void
 kvs_maint_task(struct ikvs *ikvs, u64 now);

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -2402,7 +2402,7 @@ ikvdb_throttle(struct ikvdb_impl *self, u64 bytes, u64 tstart)
 }
 
 static inline bool
-is_write_allowed(struct ikvs *kvs, struct hse_kvdb_txn *const txn)
+is_write_allowed(struct ikvs *kvs, struct hse_txn *const txn)
 {
     const bool kvs_is_txn = kvs_txn_is_enabled(kvs);
     const bool op_is_txn = txn;
@@ -2411,7 +2411,7 @@ is_write_allowed(struct ikvs *kvs, struct hse_kvdb_txn *const txn)
 }
 
 static inline bool
-is_read_allowed(struct ikvs *kvs, struct hse_kvdb_txn *const txn)
+is_read_allowed(struct ikvs *kvs, struct hse_txn *const txn)
 {
     return txn && !kvs_txn_is_enabled(kvs) ? false : true;
 }
@@ -2433,7 +2433,7 @@ merr_t
 ikvdb_kvs_put(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     struct kvs_ktuple *        kt,
     struct kvs_vtuple *        vt)
 {
@@ -2515,7 +2515,7 @@ merr_t
 ikvdb_kvs_pfx_probe(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     struct kvs_ktuple *        kt,
     enum key_lookup_res *      res,
     struct kvs_buf *           kbuf,
@@ -2552,7 +2552,7 @@ merr_t
 ikvdb_kvs_get(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     struct kvs_ktuple *        kt,
     enum key_lookup_res *      res,
     struct kvs_buf *           vbuf)
@@ -2588,7 +2588,7 @@ merr_t
 ikvdb_kvs_del(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     struct kvs_ktuple *        kt)
 {
     struct kvdb_kvs *  kk = (struct kvdb_kvs *)handle;
@@ -2619,7 +2619,7 @@ merr_t
 ikvdb_kvs_prefix_delete(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     struct kvs_ktuple *        kt)
 {
     struct kvdb_kvs *  kk = (struct kvdb_kvs *)handle;
@@ -2748,7 +2748,7 @@ merr_t
 ikvdb_kvs_cursor_create(
     struct hse_kvs *           handle,
     const unsigned int         flags,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     const void *               prefix,
     size_t                     pfx_len,
     struct hse_kvs_cursor **   cursorp)
@@ -3143,7 +3143,7 @@ ikvdb_txn_tid2bkt(struct ikvdb_impl *self)
     return self->ikdb_ctxn_cache + (tls_txn_idx % NELEM(self->ikdb_ctxn_cache));
 }
 
-struct hse_kvdb_txn *
+struct hse_txn *
 ikvdb_txn_alloc(struct ikvdb *handle)
 {
     struct ikvdb_impl *   self = ikvdb_h2r(handle);
@@ -3178,7 +3178,7 @@ ikvdb_txn_alloc(struct ikvdb *handle)
 }
 
 void
-ikvdb_txn_free(struct ikvdb *handle, struct hse_kvdb_txn *txn)
+ikvdb_txn_free(struct ikvdb *handle, struct hse_txn *txn)
 {
     struct ikvdb_impl *   self = ikvdb_h2r(handle);
     struct kvdb_ctxn_bkt *bkt = ikvdb_txn_tid2bkt(self);
@@ -3205,7 +3205,7 @@ ikvdb_txn_free(struct ikvdb *handle, struct hse_kvdb_txn *txn)
 }
 
 merr_t
-ikvdb_txn_begin(struct ikvdb *handle, struct hse_kvdb_txn *txn)
+ikvdb_txn_begin(struct ikvdb *handle, struct hse_txn *txn)
 {
     struct ikvdb_impl *self = ikvdb_h2r(handle);
     struct kvdb_ctxn * ctxn = kvdb_ctxn_h2h(txn);
@@ -3222,7 +3222,7 @@ ikvdb_txn_begin(struct ikvdb *handle, struct hse_kvdb_txn *txn)
 }
 
 merr_t
-ikvdb_txn_commit(struct ikvdb *handle, struct hse_kvdb_txn *txn)
+ikvdb_txn_commit(struct ikvdb *handle, struct hse_txn *txn)
 {
     struct ikvdb_impl *self = ikvdb_h2r(handle);
     struct kvdb_ctxn * ctxn = kvdb_ctxn_h2h(txn);
@@ -3241,7 +3241,7 @@ ikvdb_txn_commit(struct ikvdb *handle, struct hse_kvdb_txn *txn)
 }
 
 merr_t
-ikvdb_txn_abort(struct ikvdb *handle, struct hse_kvdb_txn *txn)
+ikvdb_txn_abort(struct ikvdb *handle, struct hse_txn *txn)
 {
     struct ikvdb_impl *self = ikvdb_h2r(handle);
     struct kvdb_ctxn * ctxn = kvdb_ctxn_h2h(txn);
@@ -3256,7 +3256,7 @@ ikvdb_txn_abort(struct ikvdb *handle, struct hse_kvdb_txn *txn)
 }
 
 enum kvdb_ctxn_state
-ikvdb_txn_state(struct ikvdb *handle, struct hse_kvdb_txn *txn)
+ikvdb_txn_state(struct ikvdb *handle, struct hse_txn *txn)
 {
     return kvdb_ctxn_get_state(kvdb_ctxn_h2h(txn));
 }

--- a/lib/kvdb/kvdb_ctxn_internal.h
+++ b/lib/kvdb/kvdb_ctxn_internal.h
@@ -3,8 +3,8 @@
  * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
-#ifndef HSE_KVDB_TXN_INTERNAL_H
-#define HSE_KVDB_TXN_INTERNAL_H
+#ifndef HSE_KVDB_CTXN_INTERNAL_H
+#define HSE_KVDB_CTXN_INTERNAL_H
 
 #include <urcu-bp.h>
 

--- a/lib/kvs/kvs.c
+++ b/lib/kvs/kvs.c
@@ -270,7 +270,7 @@ kvs_txn_is_enabled(struct ikvs *kvs)
 merr_t
 kvs_put(
     struct ikvs *              kvs,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     struct kvs_ktuple *        kt,
     struct kvs_vtuple *        vt,
     uintptr_t                  seqnoref)
@@ -327,7 +327,7 @@ kvs_put(
 merr_t
 kvs_get(
     struct ikvs *              kvs,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     struct kvs_ktuple *        kt,
     u64                        seqno,
     enum key_lookup_res *      res,
@@ -373,7 +373,7 @@ kvs_get(
 }
 
 merr_t
-kvs_del(struct ikvs *kvs, struct hse_kvdb_txn *const txn, struct kvs_ktuple *kt, uintptr_t seqnoref)
+kvs_del(struct ikvs *kvs, struct hse_txn *const txn, struct kvs_ktuple *kt, uintptr_t seqnoref)
 {
     struct perfc_set *pkvsl_pc = kvs_perfc_pkvsl(kvs);
     struct kvdb_ctxn *ctxn = txn ? kvdb_ctxn_h2h(txn) : 0;
@@ -421,7 +421,7 @@ kvs_del(struct ikvs *kvs, struct hse_kvdb_txn *const txn, struct kvs_ktuple *kt,
 merr_t
 kvs_prefix_del(
     struct ikvs               *kvs,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     struct kvs_ktuple         *kt,
     uintptr_t                  seqnoref)
 {
@@ -471,7 +471,7 @@ kvs_prefix_del(
 merr_t
 kvs_pfx_probe(
     struct ikvs *              kvs,
-    struct hse_kvdb_txn *const txn,
+    struct hse_txn *const txn,
     struct kvs_ktuple *        kt,
     u64                        seqno,
     enum key_lookup_res *      res,

--- a/samples/ex4_transactions.c
+++ b/samples/ex4_transactions.c
@@ -54,7 +54,7 @@ main(int argc, char **argv)
 
     struct hse_kvdb *    kvdb;
     struct hse_kvs *     kvs1 = NULL, *kvs2 = NULL;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     char      vbuf[64];
     size_t    vlen;
@@ -96,7 +96,7 @@ main(int argc, char **argv)
     txn = hse_kvdb_txn_alloc(kvdb);
 
     /* txn 1 */
-    rc = hse_kvdb_txn_begin(kvdb, txn);
+    rc = hse_txn_begin(kvdb, txn);
     if (rc) {
         error(rc, "Failed to being transaction");
         goto txn_cleanup;
@@ -129,14 +129,14 @@ main(int argc, char **argv)
     }
     printf("k1 from outside txn: found = %s\n", found ? "true" : "false");
 
-    rc = hse_kvdb_txn_commit(kvdb, txn);
+    rc = hse_txn_commit(kvdb, txn);
     if (rc) {
         error(rc, "Failed to commit the transaction");
         goto txn_cleanup;
     }
 
     /* txn 2. Reuse txn object from the first allocation */
-    rc = hse_kvdb_txn_begin(kvdb, txn);
+    rc = hse_txn_begin(kvdb, txn);
     if (rc) {
         error(rc, "Failed to begin the transaction");
         goto txn_cleanup;
@@ -153,7 +153,7 @@ main(int argc, char **argv)
         goto txn_cleanup;
     }
 
-    rc = hse_kvdb_txn_abort(kvdb, txn);
+    rc = hse_txn_abort(kvdb, txn);
     if (rc) {
         error(rc, "Failed to abort the transaction");
         goto txn_cleanup;

--- a/tests/functional/api/cursor_api_test.c
+++ b/tests/functional/api/cursor_api_test.c
@@ -100,7 +100,7 @@ transactional_kvs_setup_with_data(struct mtf_test_info *lcl_ti)
     hse_err_t            err;
     char                 key_buf[8], val_buf[8];
     const char          *rparamv[] = { "transactions.enabled=true" };
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     err = fxt_kvs_setup(kvdb_handle, kvs_name, NELEM(rparamv), rparamv, 0, NULL, &kvs_handle);
     ASSERT_EQ_RET(0, hse_err_to_errno(err), hse_err_to_errno(err));
@@ -108,7 +108,7 @@ transactional_kvs_setup_with_data(struct mtf_test_info *lcl_ti)
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE_RET(NULL, txn, EINVAL);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ_RET(0, hse_err_to_errno(err), hse_err_to_errno(err));
 
     for (int i = 0; i < NUM_ENTRIES; i++) {
@@ -124,7 +124,7 @@ transactional_kvs_setup_with_data(struct mtf_test_info *lcl_ti)
         ASSERT_EQ_RET(0, hse_err_to_errno(err), hse_err_to_errno(err));
     }
 
-    err = hse_kvdb_txn_commit(kvdb_handle, txn);
+    err = hse_txn_commit(kvdb_handle, txn);
     ASSERT_EQ_RET(0, hse_err_to_errno(err), hse_err_to_errno(err));
 
     return hse_err_to_errno(err);
@@ -235,7 +235,7 @@ MTF_DEFINE_UTEST_PREPOST(
 {
     hse_err_t              err;
     struct hse_kvs_cursor *cursor;
-    struct hse_kvdb_txn   *txn;
+    struct hse_txn   *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
@@ -254,12 +254,12 @@ MTF_DEFINE_UTEST_PREPOST(
 {
     hse_err_t              err;
     struct hse_kvs_cursor *cursor;
-    struct hse_kvdb_txn   *txn;
+    struct hse_txn   *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     err = hse_kvs_cursor_create(kvs_handle, 0, txn, NULL, 0, &cursor);
@@ -276,12 +276,12 @@ MTF_DEFINE_UTEST_PREPOST(
 {
     hse_err_t              err;
     struct hse_kvs_cursor *cursor;
-    struct hse_kvdb_txn   *txn;
+    struct hse_txn   *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     err = hse_kvs_cursor_create(kvs_handle, 0, txn, NULL, 0, &cursor);
@@ -375,12 +375,12 @@ MTF_DEFINE_UTEST_PREPOST(
     size_t                 key_len, val_len;
     bool                   eof;
     char                   key_buf[8], val_buf[8];
-    struct hse_kvdb_txn   *txn;
+    struct hse_txn   *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     err = hse_kvs_cursor_create(kvs_handle, HSE_CURSOR_CREATE_REV, txn, NULL, 0, &cursor);
@@ -491,12 +491,12 @@ MTF_DEFINE_UTEST_PREPOST(
     size_t                 key_len, val_len;
     bool                   eof;
     char                   key_buf[8], val_buf[8];
-    struct hse_kvdb_txn   *txn;
+    struct hse_txn   *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     err =
@@ -608,12 +608,12 @@ MTF_DEFINE_UTEST_PREPOST(
     size_t                 key_len, val_len;
     bool                   eof;
     char                   key_buf[8], val_buf[8];
-    struct hse_kvdb_txn   *txn;
+    struct hse_txn   *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     err =
@@ -1263,12 +1263,12 @@ MTF_DEFINE_UTEST_PREPOST(
     const void            *key, *val;
     size_t                 key_len, val_len;
     bool                   eof;
-    struct hse_kvdb_txn   *txn;
+    struct hse_txn   *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
 
     err = hse_kvs_cursor_create(kvs_handle, 0, txn, NULL, 0, &cursor);
     ASSERT_EQ(0, hse_err_to_errno(err));

--- a/tests/functional/api/kvs_api_test.c
+++ b/tests/functional/api/kvs_api_test.c
@@ -116,7 +116,7 @@ transactional_kvs_setup_with_data(struct mtf_test_info *lcl_ti)
     const char          *cparamv[] = { prefix_length_param };
     const char          *rparamv[] = { "transactions.enabled=true" };
     char                 key_buf[8], val_buf[8];
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     snprintf(prefix_length_param, sizeof(prefix_length_param), "prefix.length=%lu", PFX_LEN);
 
@@ -127,7 +127,7 @@ transactional_kvs_setup_with_data(struct mtf_test_info *lcl_ti)
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE_RET(NULL, txn, EINVAL);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ_RET(0, hse_err_to_errno(err), hse_err_to_errno(err));
 
     for (int i = 0; i < NUM_ENTRIES; i++) {
@@ -143,7 +143,7 @@ transactional_kvs_setup_with_data(struct mtf_test_info *lcl_ti)
         ASSERT_EQ_RET(0, hse_err_to_errno(err), hse_err_to_errno(err));
     }
 
-    err = hse_kvdb_txn_commit(kvdb_handle, txn);
+    err = hse_txn_commit(kvdb_handle, txn);
     ASSERT_EQ_RET(0, hse_err_to_errno(err), hse_err_to_errno(err));
 
     return hse_err_to_errno(err);
@@ -378,12 +378,12 @@ MTF_DEFINE_UTEST_PREPOST(
     hse_err_t            err;
     bool                 found;
     size_t               val_len;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     err =
@@ -401,7 +401,7 @@ MTF_DEFINE_UTEST_PREPOST(
     ASSERT_EQ(0, hse_err_to_errno(err));
     ASSERT_FALSE(found);
 
-    err = hse_kvdb_txn_abort(kvdb_handle, txn);
+    err = hse_txn_abort(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     hse_kvdb_txn_free(kvdb_handle, txn);
@@ -507,12 +507,12 @@ MTF_DEFINE_UTEST_PREPOST(
     bool                 found;
     char                 valbuf[8];
     size_t               val_len;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     err =
@@ -661,7 +661,7 @@ MTF_DEFINE_UTEST_PREPOST(
     kvs_teardown)
 {
     hse_err_t            err;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
     char                 key_buf[8], val_buf[8];
     size_t               key_len, val_len;
     bool                 found;
@@ -670,7 +670,7 @@ MTF_DEFINE_UTEST_PREPOST(
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     key_len = snprintf(key_buf, sizeof(key_buf), KEY_FMT, NUM_ENTRIES);
@@ -1039,12 +1039,12 @@ MTF_DEFINE_UTEST_PREPOST(
     enum hse_kvs_pfx_probe_cnt found;
     char                       key_buf[HSE_KVS_KEY_LEN_MAX], val_buf[8];
     size_t                     key_len, val_len;
-    struct hse_kvdb_txn       *txn;
+    struct hse_txn       *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     err =
@@ -1072,10 +1072,10 @@ MTF_DEFINE_UTEST_PREPOST(
     /* By committing this transaction, we can make sure that prefix_probe() can
      * peer into persisted data and non-persisted data.
      */
-    err = hse_kvdb_txn_commit(kvdb_handle, txn);
+    err = hse_txn_commit(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     err =

--- a/tests/functional/api/transaction_api_test.c
+++ b/tests/functional/api/transaction_api_test.c
@@ -54,7 +54,7 @@ MTF_BEGIN_UTEST_COLLECTION_PREPOST(
 
 MTF_DEFINE_UTEST(transaction_api_test, alloc_null_kvdb)
 {
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     txn = hse_kvdb_txn_alloc(NULL);
 
@@ -64,68 +64,68 @@ MTF_DEFINE_UTEST(transaction_api_test, alloc_null_kvdb)
 MTF_DEFINE_UTEST(transaction_api_test, state_transitions)
 {
     hse_err_t               err;
-    struct hse_kvdb_txn    *txn;
-    enum hse_kvdb_txn_state state;
+    struct hse_txn    *txn;
+    enum hse_txn_state state;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    state = hse_kvdb_txn_state_get(kvdb_handle, txn);
-    ASSERT_EQ(HSE_KVDB_TXN_INVALID, state);
+    state = hse_txn_state_get(kvdb_handle, txn);
+    ASSERT_EQ(HSE_TXN_INVALID, state);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
-    state = hse_kvdb_txn_state_get(kvdb_handle, txn);
-    ASSERT_EQ(HSE_KVDB_TXN_ACTIVE, state);
+    state = hse_txn_state_get(kvdb_handle, txn);
+    ASSERT_EQ(HSE_TXN_ACTIVE, state);
 
-    err = hse_kvdb_txn_abort(kvdb_handle, txn);
+    err = hse_txn_abort(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
-    state = hse_kvdb_txn_state_get(kvdb_handle, txn);
-    ASSERT_EQ(HSE_KVDB_TXN_ABORTED, state);
+    state = hse_txn_state_get(kvdb_handle, txn);
+    ASSERT_EQ(HSE_TXN_ABORTED, state);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
-    err = hse_kvdb_txn_commit(kvdb_handle, txn);
+    err = hse_txn_commit(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
-    state = hse_kvdb_txn_state_get(kvdb_handle, txn);
-    ASSERT_EQ(HSE_KVDB_TXN_COMMITTED, state);
+    state = hse_txn_state_get(kvdb_handle, txn);
+    ASSERT_EQ(HSE_TXN_COMMITTED, state);
 
     hse_kvdb_txn_free(kvdb_handle, txn);
 }
 
 MTF_DEFINE_UTEST(transaction_api_test, state_get_null_kvdb)
 {
-    struct hse_kvdb_txn    *txn;
-    enum hse_kvdb_txn_state state;
+    struct hse_txn    *txn;
+    enum hse_txn_state state;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    state = hse_kvdb_txn_state_get(NULL, txn);
-    ASSERT_EQ(HSE_KVDB_TXN_INVALID, state);
+    state = hse_txn_state_get(NULL, txn);
+    ASSERT_EQ(HSE_TXN_INVALID, state);
 }
 
 MTF_DEFINE_UTEST(transaction_api_test, state_get_null_txn)
 {
-    enum hse_kvdb_txn_state state;
+    enum hse_txn_state state;
 
-    state = hse_kvdb_txn_state_get(kvdb_handle, NULL);
-    ASSERT_EQ(HSE_KVDB_TXN_INVALID, state);
+    state = hse_txn_state_get(kvdb_handle, NULL);
+    ASSERT_EQ(HSE_TXN_INVALID, state);
 }
 
 MTF_DEFINE_UTEST(transaction_api_test, begin_null_kvdb)
 {
     hse_err_t            err;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(NULL, txn);
+    err = hse_txn_begin(NULL, txn);
     ASSERT_EQ(EINVAL, hse_err_to_errno(err));
 }
 
@@ -133,19 +133,19 @@ MTF_DEFINE_UTEST(transaction_api_test, begin_null_txn)
 {
     hse_err_t err;
 
-    err = hse_kvdb_txn_begin(kvdb_handle, NULL);
+    err = hse_txn_begin(kvdb_handle, NULL);
     ASSERT_EQ(EINVAL, hse_err_to_errno(err));
 }
 
 MTF_DEFINE_UTEST(transaction_api_test, commit_null_kvdb)
 {
     hse_err_t            err;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_commit(NULL, txn);
+    err = hse_txn_commit(NULL, txn);
     ASSERT_EQ(EINVAL, hse_err_to_errno(err));
 }
 
@@ -153,19 +153,19 @@ MTF_DEFINE_UTEST(transaction_api_test, commit_null_txn)
 {
     hse_err_t err;
 
-    err = hse_kvdb_txn_commit(kvdb_handle, NULL);
+    err = hse_txn_commit(kvdb_handle, NULL);
     ASSERT_EQ(EINVAL, hse_err_to_errno(err));
 }
 
 MTF_DEFINE_UTEST(transaction_api_test, abort_null_kvdb)
 {
     hse_err_t            err;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_abort(NULL, txn);
+    err = hse_txn_abort(NULL, txn);
     ASSERT_EQ(EINVAL, hse_err_to_errno(err));
 
     hse_kvdb_txn_free(kvdb_handle, txn);
@@ -175,19 +175,19 @@ MTF_DEFINE_UTEST(transaction_api_test, abort_null_txn)
 {
     hse_err_t err;
 
-    err = hse_kvdb_txn_abort(kvdb_handle, NULL);
+    err = hse_txn_abort(kvdb_handle, NULL);
     ASSERT_EQ(EINVAL, hse_err_to_errno(err));
 }
 
 MTF_DEFINE_UTEST(transaction_api_test, commit_without_begin)
 {
     hse_err_t            err;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_commit(kvdb_handle, txn);
+    err = hse_txn_commit(kvdb_handle, txn);
     ASSERT_EQ(ECANCELED, hse_err_to_errno(err));
 
     hse_kvdb_txn_free(kvdb_handle, txn);
@@ -196,12 +196,12 @@ MTF_DEFINE_UTEST(transaction_api_test, commit_without_begin)
 MTF_DEFINE_UTEST(transaction_api_test, abort_without_begin)
 {
     hse_err_t            err;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_commit(kvdb_handle, txn);
+    err = hse_txn_commit(kvdb_handle, txn);
     ASSERT_EQ(ECANCELED, hse_err_to_errno(err));
 
     hse_kvdb_txn_free(kvdb_handle, txn);
@@ -210,13 +210,13 @@ MTF_DEFINE_UTEST(transaction_api_test, abort_without_begin)
 MTF_DEFINE_UTEST(transaction_api_test, expired)
 {
     hse_err_t err;
-    struct hse_kvdb_txn *txn;
-    enum hse_kvdb_txn_state state;
+    struct hse_txn *txn;
+    enum hse_txn_state state;
 
     txn = hse_kvdb_txn_alloc(kvdb_handle);
     ASSERT_NE(NULL, txn);
 
-    err = hse_kvdb_txn_begin(kvdb_handle, txn);
+    err = hse_txn_begin(kvdb_handle, txn);
     ASSERT_EQ(0, hse_err_to_errno(err));
 
     while (true) {
@@ -225,8 +225,8 @@ MTF_DEFINE_UTEST(transaction_api_test, expired)
         struct hse_kvs_cursor *cursor;
         char val_buf[HSE_KVS_VALUE_LEN_MAX];
 
-        state = hse_kvdb_txn_state_get(kvdb_handle, txn);
-        if (state != HSE_KVDB_TXN_ABORTED) {
+        state = hse_txn_state_get(kvdb_handle, txn);
+        if (state != HSE_TXN_ABORTED) {
             sleep(5);
             continue;
         }

--- a/tests/stress/stress_cursor.c
+++ b/tests/stress/stress_cursor.c
@@ -478,8 +478,8 @@ cursor_with_transactions(void *args)
     long int                 txn_idx, i;
     char                     key_buf[info->key_size];
     char                     val_buf[info->val_size];
-    struct hse_kvdb_txn *    txn = NULL;
-    struct hse_kvdb_txn *    txn_table[info->transaction_per_thread];
+    struct hse_txn *    txn = NULL;
+    struct hse_txn *    txn_table[info->transaction_per_thread];
     struct hse_kvs_cursor *  CURSOR;
     struct cursor_list       cursor_table[info->cursor_count_per_thread];
     long int                 cursor_index, cursor_index_this_txn;
@@ -526,12 +526,12 @@ cursor_with_transactions(void *args)
             break;
         }
 
-        err = hse_kvdb_txn_begin(info->kvdb, txn);
+        err = hse_txn_begin(info->kvdb, txn);
 
         if (err) {
             hse_strerror(err, msg, sizeof(msg));
             log_error(
-                "hse_kvdb_txn_begin: errno=%d msg=\"%s\" rank=%d txn=%ld",
+                "hse_txn_begin: errno=%d msg=\"%s\" rank=%d txn=%ld",
                 hse_err_to_errno(err),
                 msg,
                 info->rank,
@@ -545,7 +545,7 @@ cursor_with_transactions(void *args)
             ++error_count;
             goto clean_up;
         } else if (DEBUG) {
-            log_debug("hse_kvdb_txn_begin: rank=%d txn=%ld addr=%p", info->rank, txn_idx, txn);
+            log_debug("hse_txn_begin: rank=%d txn=%ld addr=%p", info->rank, txn_idx, txn);
         }
 
         for (cursor_index_this_txn = 0; cursor_index_this_txn < info->cursor_count_per_txn;
@@ -673,12 +673,12 @@ clean_up:
     for (i = 0; i < info->transaction_per_thread; i++) {
         txn = txn_table[i];
         if (NULL != txn) {
-            err = hse_kvdb_txn_abort(info->kvdb, txn);
+            err = hse_txn_abort(info->kvdb, txn);
 
             if (err) {
                 hse_strerror(err, msg, sizeof(msg));
                 log_error(
-                    "hse_kvdb_txn_abort: errno=%d msg=\"%s\" rank=%d cursor_idx=%ld txn_addr=%p",
+                    "hse_txn_abort: errno=%d msg=\"%s\" rank=%d cursor_idx=%ld txn_addr=%p",
                     hse_err_to_errno(err),
                     msg,
                     info->rank,
@@ -687,7 +687,7 @@ clean_up:
                 ++error_count;
             } else if (DEBUG) {
                 log_debug(
-                    "hse_kvdb_txn_abort: rank=%d cursor_idx=%ld txn_addr=%p", info->rank, i, txn);
+                    "hse_txn_abort: rank=%d cursor_idx=%ld txn_addr=%p", info->rank, i, txn);
             }
 
             hse_kvdb_txn_free(info->kvdb, txn);

--- a/tests/stress/stress_reverse_cursor.c
+++ b/tests/stress/stress_reverse_cursor.c
@@ -212,7 +212,7 @@ point_insertion(void *args)
 {
     struct cursor_test_data *info = (struct cursor_test_data *)args;
     long int                 i = 0;
-    struct hse_kvdb_txn *    txn;
+    struct hse_txn *    txn;
     struct hse_kvs_cursor *  CURSOR;
     char                     key_buf[info->key_size];
     char                     val_buf[info->val_size];
@@ -231,19 +231,19 @@ point_insertion(void *args)
         goto out;
     }
 
-    err = hse_kvdb_txn_begin(info->kvdb, txn);
+    err = hse_txn_begin(info->kvdb, txn);
 
     if (err) {
         hse_strerror(err, msg, sizeof(msg));
         log_error(
-            "hse_kvdb_txn_begin: errno=%d msg=\"%s\" rank=%d",
+            "hse_txn_begin: errno=%d msg=\"%s\" rank=%d",
             hse_err_to_errno(err),
             msg,
             info->rank);
         ++error_count;
         goto out2;
     } else if (DEBUG) {
-        log_debug("hse_kvdb_txn_begin: rank=%d", info->rank);
+        log_debug("hse_txn_begin: rank=%d", info->rank);
     }
 
     for (i = info->start; i < info->end; i++) {
@@ -296,19 +296,19 @@ point_insertion(void *args)
     }
 
     if (!info->uncommitted) {
-        err = hse_kvdb_txn_commit(info->kvdb, txn);
+        err = hse_txn_commit(info->kvdb, txn);
 
         if (err) {
             hse_strerror(err, msg, sizeof(msg));
             log_error(
-                "hse_kvdb_txn_commit: errno=%d msg=\"%s\" rank=%d",
+                "hse_txn_commit: errno=%d msg=\"%s\" rank=%d",
                 hse_err_to_errno(err),
                 msg,
                 info->rank);
             ++error_count;
             goto out3;
         } else if (DEBUG) {
-            log_debug("hse_kvdb_txn_commit: rank=%d", info->rank);
+            log_debug("hse_txn_commit: rank=%d", info->rank);
         }
     }
 

--- a/tests/stress/stress_reverse_cursor_unlimited_txn.c
+++ b/tests/stress/stress_reverse_cursor_unlimited_txn.c
@@ -272,7 +272,7 @@ void *
 point_insertion(void *args)
 {
     struct cursor_test_data *info = (struct cursor_test_data *)args;
-    struct hse_kvdb_txn *    txn;
+    struct hse_txn *    txn;
     long int                 i = 0;
     long int                 txn_size_idx = 0;
     char                     key_buf[info->key_size];
@@ -301,16 +301,16 @@ point_insertion(void *args)
     }
 
     for (i = info->start; i < info->end; i++) {
-        err = hse_kvdb_txn_begin(info->kvdb, txn);
+        err = hse_txn_begin(info->kvdb, txn);
 
         if (err) {
             hse_strerror(err, msg, sizeof(msg));
             log_print(
-                LOG_ERROR, "hse_kvdb_txn_begin: errno=%d msg=\"%s\"", hse_err_to_errno(err), msg);
+                LOG_ERROR, "hse_txn_begin: errno=%d msg=\"%s\"", hse_err_to_errno(err), msg);
             ++error_count;
             goto out2;
         } else if (DEBUG) {
-            log_debug("hse_kvdb_txn_begin: rank=%d i=%ld", info->rank, i);
+            log_debug("hse_txn_begin: rank=%d i=%ld", info->rank, i);
         }
 
         txn_size_idx = 0;
@@ -343,14 +343,14 @@ point_insertion(void *args)
                     sleep(10);
                     retry++;
                 } else if (hse_err_to_errno(err) == ECANCELED) {
-                    err = hse_kvdb_txn_abort(info->kvdb, txn);
+                    err = hse_txn_abort(info->kvdb, txn);
                     ++aborted_txn_count;
 
                     if (err) {
                         hse_strerror(err, msg, sizeof(msg));
                         log_print(
                             LOG_ERROR,
-                            "hse_kvdb_txn_abort: errno=%d msg=\"%s\"",
+                            "hse_txn_abort: errno=%d msg=\"%s\"",
                             hse_err_to_errno(err),
                             msg);
                         ++error_count;
@@ -359,13 +359,13 @@ point_insertion(void *args)
 
                     srand(time(0));
                     sleep((rand() % 10) / 1000);
-                    err = hse_kvdb_txn_begin(info->kvdb, txn);
+                    err = hse_txn_begin(info->kvdb, txn);
 
                     if (err) {
                         hse_strerror(err, msg, sizeof(msg));
                         log_print(
                             LOG_ERROR,
-                            "hse_kvdb_txn_begin: errno=%d msg=\"%s\"",
+                            "hse_txn_begin: errno=%d msg=\"%s\"",
                             hse_err_to_errno(err),
                             msg);
                         ++error_count;
@@ -383,20 +383,20 @@ point_insertion(void *args)
                         msg,
                         key_buf);
 
-                    err = hse_kvdb_txn_abort(info->kvdb, txn);
+                    err = hse_txn_abort(info->kvdb, txn);
 
                     if (err) {
                         hse_strerror(err, msg, sizeof(msg));
                         log_print(
                             LOG_ERROR,
-                            "hse_kvdb_txn_abort: errno=%d msg=\"%s\" i=%ld",
+                            "hse_txn_abort: errno=%d msg=\"%s\" i=%ld",
                             hse_err_to_errno(err),
                             msg,
                             i);
                         ++error_count;
                         goto out2;
                     } else if (DEBUG) {
-                        log_debug("hse_kvdb_txn_abort: i=%ld", i);
+                        log_debug("hse_txn_abort: i=%ld", i);
                     }
 
                     ++aborted_txn_count;
@@ -410,12 +410,12 @@ point_insertion(void *args)
         }
 
     commit:
-        err = hse_kvdb_txn_commit(info->kvdb, txn);
+        err = hse_txn_commit(info->kvdb, txn);
         if (err) {
             hse_strerror(err, msg, sizeof(msg));
             log_print(
                 LOG_ERROR,
-                "hse_kvdb_txn_commit: error=%d msg=\"%s\" rank=%d",
+                "hse_txn_commit: error=%d msg=\"%s\" rank=%d",
                 hse_err_to_errno(err),
                 msg,
                 info->rank);
@@ -423,7 +423,7 @@ point_insertion(void *args)
             ++error_count;
             goto out2;
         } else if (DEBUG) {
-            log_debug("hse_kvdb_txn_abort: rank=%d i=%ld", info->rank, i);
+            log_debug("hse_txn_abort: rank=%d i=%ld", info->rank, i);
         }
 
         ++committed_txn_count;

--- a/tests/stress/stress_wal.c
+++ b/tests/stress/stress_wal.c
@@ -47,7 +47,7 @@ atomic_int error_count;
 atomic_int verification_failure_count;
 
 struct txn_info {
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
     struct hse_kvs *     kvs;
 };
 
@@ -107,7 +107,7 @@ do_inserts(void *args)
     long int             txn_idx, i, key_index_offset;
     long int             keys_per_txn;
     long int             transactions_per_thread;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
     struct hse_kvs *     kvs;
     char                 kvs_name[31];
     int                  key_len;
@@ -162,11 +162,11 @@ do_inserts(void *args)
                 break;
             }
 
-            err = hse_kvdb_txn_begin(params->kvdb, txn);
+            err = hse_txn_begin(params->kvdb, txn);
             if (err) {
                 hse_strerror(err, msg, sizeof(msg));
                 log_error(
-                    "hse_kvdb_txn_begin: errno=%d msg=\"%s\" rank=%d txn=%ld",
+                    "hse_txn_begin: errno=%d msg=\"%s\" rank=%d txn=%ld",
                     hse_err_to_errno(err),
                     msg,
                     params->rank,
@@ -178,7 +178,7 @@ do_inserts(void *args)
                 ++error_count;
                 goto clean_up;
             } else {
-                log_debug("hse_kvdb_txn_begin: rank=%d txn=%ld", params->rank, txn_idx);
+                log_debug("hse_txn_begin: rank=%d txn=%ld", params->rank, txn_idx);
             }
 
             txn_table[txn_idx].txn = txn;
@@ -254,32 +254,32 @@ clean_up:
 
         if (txn != NULL) {
             if (params->transaction == INTERLEAVE_ABORTED_TXN && (txn_idx % 2) == 0) {
-                err = hse_kvdb_txn_abort(params->kvdb, txn);
+                err = hse_txn_abort(params->kvdb, txn);
                 if (err) {
                     hse_strerror(err, msg, sizeof(msg));
                     log_error(
-                        "hse_kvdb_txn_abort: errno=%d msg=\"%s\" rank=%d txn=%ld",
+                        "hse_txn_abort: errno=%d msg=\"%s\" rank=%d txn=%ld",
                         hse_err_to_errno(err),
                         msg,
                         params->rank,
                         txn_idx);
                     ++error_count;
                 } else {
-                    log_debug("hse_kvdb_txn_abort: rank=%d txn=%ld", params->rank, txn_idx);
+                    log_debug("hse_txn_abort: rank=%d txn=%ld", params->rank, txn_idx);
                 }
             } else {
-                err = hse_kvdb_txn_commit(params->kvdb, txn);
+                err = hse_txn_commit(params->kvdb, txn);
                 if (err) {
                     hse_strerror(err, msg, sizeof(msg));
                     log_error(
-                        "hse_kvdb_txn_commit: errno=%d msg=\"%s\" rank=%d txn=%ld",
+                        "hse_txn_commit: errno=%d msg=\"%s\" rank=%d txn=%ld",
                         hse_err_to_errno(err),
                         msg,
                         params->rank,
                         txn_idx);
                     ++error_count;
                 } else {
-                    log_debug("hse_kvdb_txn_commit: rank=%d txn=%ld", params->rank, txn_idx);
+                    log_debug("hse_txn_commit: rank=%d txn=%ld", params->rank, txn_idx);
                 }
             }
 

--- a/tests/unit/kvdb/ikvdb_test.c
+++ b/tests/unit/kvdb/ikvdb_test.c
@@ -274,7 +274,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, basic_txn_alloc, test_pre, test_post)
 {
     const char *         mpool = __func__;
     struct ikvdb *       store;
-    struct hse_kvdb_txn *txn1, *txn2;
+    struct hse_txn *txn1, *txn2;
     merr_t               err;
     const char *const    paramv[] = { "c0_diag_mode=true" };
     struct kvdb_rparams  params = kvdb_rparams_defaults();
@@ -304,7 +304,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, basic_lifecycle, test_pre, test_post)
 {
     const char *         mpool = __func__;
     struct ikvdb *       store;
-    struct hse_kvdb_txn *txn1, *txn2;
+    struct hse_txn *txn1, *txn2;
     const char *const    paramv[] = { "c0_diag_mode=true" };
     merr_t               err;
     struct kvdb_rparams  params = kvdb_rparams_defaults();
@@ -382,7 +382,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, basic_lifecycle, test_pre, test_post)
     ikvdb_txn_free(store, txn2);
 
     // At this point one of the previous txns will be recycled for txn3
-    struct hse_kvdb_txn *txn3 = ikvdb_txn_alloc(store);
+    struct hse_txn *txn3 = ikvdb_txn_alloc(store);
     ASSERT_EQ(KVDB_CTXN_INVALID, ikvdb_txn_state(store, txn3));
     ikvdb_txn_free(store, txn3);
 
@@ -533,7 +533,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, txn_del_test, test_pre, test_post)
     const char *const    kvs_open_paramv[] =
     { "transactions.enabled=true", "mclass.policy=\"capacity_only\"" };
     merr_t               err;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
     struct kvs_ktuple    kt;
     struct kvs_vtuple    vt;
     struct kvs_buf       vbuf;
@@ -618,7 +618,7 @@ parallel_transactions(void *info)
     char                 kbuf[16];
     struct kvs_ktuple    kt;
     struct kvs_vtuple    vt;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
     struct kvs_buf       val;
     enum key_lookup_res  found;
     char                 vbuf[100];
@@ -725,7 +725,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, aborted_txn_bind, test_pre, test_post)
     const char *const      kvs_open_paramv[] =
     { "transactions.enabled=true", "mclass.policy=\"capacity_only\"" };
     merr_t                 err;
-    struct hse_kvdb_txn *  txn;
+    struct hse_txn *  txn;
     struct hse_kvs_cursor *cur;
     struct kvdb_rparams    kvdb_rp = kvdb_rparams_defaults();
     struct kvs_rparams     kvs_rp = kvs_rparams_defaults();
@@ -780,7 +780,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, cursor_0, test_pre, test_post)
     const char *const      kvdb_open_paramv[] = { "c0_debug=16", "c0_diag_mode=true" };
     const char *const      kvs_open_paramv[] = { "mclass.policy=\"capacity_only\"" };
     merr_t                 err;
-    struct hse_kvdb_txn *  txn = NULL;
+    struct hse_txn *  txn = NULL;
     struct hse_kvs_cursor *cur;
     const void *           key, *val;
     size_t                 klen, vlen;
@@ -843,7 +843,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, cursor_1, test_pre_c0, test_post_c0)
     const char *           kvs = "kvs";
     const char *const      kvdb_open_paramv[] = { "c0_diag_mode=true" };
     const char *const      kvs_open_paramv[] = { "mclass.policy=\"capacity_only\"" };
-    struct hse_kvdb_txn *  txn = NULL;
+    struct hse_txn *  txn = NULL;
     struct hse_kvs_cursor *cur;
     struct kvs_ktuple      kt = { 0 };
     struct kvs_vtuple      vt = { 0 };
@@ -1004,9 +1004,9 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, cursor_tx, test_pre_c0, test_post_c0)
     struct mpool *         ds = (struct mpool *)-1;
     const char *const      kvdb_open_paramv[] = { "c0_diag_mode=true" };
     const char *const      kvs_open_paramv[] = { "transactions.enabled=true" };
-    struct hse_kvdb_txn *  txn1;
+    struct hse_txn *  txn1;
     unsigned int           flags1 = 0;
-    struct hse_kvdb_txn *  txn2;
+    struct hse_txn *  txn2;
     unsigned int           flags2 = 0;
     struct hse_kvs_cursor *cur, *spam, *bound;
     struct kvs_ktuple      kt = { 0 };

--- a/tools/boundcur/boundcur.c
+++ b/tools/boundcur/boundcur.c
@@ -50,7 +50,7 @@ do_work(void *arg)
 {
     struct kh_thread_arg  *targ = arg;
     struct thread_info *ti = targ->arg;
-    struct hse_kvdb_txn *txn;
+    struct hse_txn *txn;
     unsigned int flags = 0;
     int                 i;
     char                val[VLEN];
@@ -67,7 +67,7 @@ do_work(void *arg)
 
     memset(val, 0xfe, sizeof(val));
 
-    hse_kvdb_txn_begin(targ->kvdb, txn);
+    hse_txn_begin(targ->kvdb, txn);
     for (i = ti->start; i < ti->end; i++) {
         *k = htobe64(i);
 
@@ -92,7 +92,7 @@ do_work(void *arg)
     if (rc)
         fatal(rc, "Failed to create cursor");
 
-    hse_kvdb_txn_commit(targ->kvdb, txn);
+    hse_txn_commit(targ->kvdb, txn);
     hse_kvdb_txn_free(targ->kvdb, txn);
 
     cnt = 0;

--- a/tools/kmt/kmt.c
+++ b/tools/kmt/kmt.c
@@ -526,7 +526,7 @@ struct km_inst {
     mongoc_write_concern_t *wcmaj;
     void *                  tdval;
     unsigned int            flags;
-    struct hse_kvdb_txn *   txn;
+    struct hse_txn *   txn;
     char                    mode[32];
     pthread_t               td;
     hse_err_t                  err;
@@ -613,7 +613,7 @@ struct hse_kvs {
 };
 
 struct hse_kvdb;
-struct hse_kvdb_txn;
+struct hse_txn;
 
 struct hse_kvs *kvs;
 #endif /* XKMT */
@@ -924,19 +924,19 @@ static void
 hse_kvdb_txn_free(void *kvdb, void *txn){};
 
 static int
-hse_kvdb_txn_begin(void *kvdb, void *txn)
+hse_txn_begin(void *kvdb, void *txn)
 {
     return EINVAL;
 };
 
 static int
-hse_kvdb_txn_commit(void *kvdb, void *txn)
+hse_txn_commit(void *kvdb, void *txn)
 {
     return EINVAL;
 };
 
 static void
-hse_kvdb_txn_abort(void *kvdb, void *txn){};
+hse_txn_abort(void *kvdb, void *txn){};
 
 static char *
 hse_strerror(u64 err, char *buf, size_t bufsz)
@@ -2894,7 +2894,7 @@ td_test(struct km_inst *inst)
     struct km_rec *        recx, *recy;
     uint64_t               ridx, ridy;
     struct km_impl *       impl;
-    struct hse_kvdb_txn *  txn;
+    struct hse_txn *  txn;
     struct km_lor          lor;
     hse_err_t                 err;
     int                    rc;
@@ -2958,7 +2958,7 @@ td_test(struct km_inst *inst)
             inst->stats.op = OP_TXN_BEGIN;
             inst->stats.begin++;
 
-            rc = hse_kvdb_txn_begin(impl->kvdb, txn);
+            rc = hse_txn_begin(impl->kvdb, txn);
             if (rc) {
                 inst->fmt = "txn begin failed: %s";
                 err = rc;
@@ -2983,7 +2983,7 @@ td_test(struct km_inst *inst)
                 inst->stats.op = OP_TXN_ABORT;
                 inst->stats.abort++;
 
-                hse_kvdb_txn_abort(impl->kvdb, txn);
+                hse_txn_abort(impl->kvdb, txn);
             }
             goto unlock;
         }
@@ -2996,7 +2996,7 @@ td_test(struct km_inst *inst)
                 inst->stats.op = OP_TXN_ABORT;
                 inst->stats.abort++;
 
-                hse_kvdb_txn_abort(impl->kvdb, txn);
+                hse_txn_abort(impl->kvdb, txn);
                 err = 0;
             } else {
                 inst->fmt = inst->fmt ?: "put 1 failed: %s";
@@ -3010,7 +3010,7 @@ td_test(struct km_inst *inst)
                 inst->stats.op = OP_TXN_ABORT;
                 inst->stats.abort++;
 
-                hse_kvdb_txn_abort(impl->kvdb, txn);
+                hse_txn_abort(impl->kvdb, txn);
                 err = 0;
             } else {
                 inst->fmt = inst->fmt ?: "put 2 failed: %s";
@@ -3028,7 +3028,7 @@ td_test(struct km_inst *inst)
             inst->stats.op = OP_TXN_COMMIT;
             inst->stats.commit++;
 
-            rc = hse_kvdb_txn_commit(impl->kvdb, txn);
+            rc = hse_txn_commit(impl->kvdb, txn);
             if (rc) {
                 inst->fmt = "txn commit failed: %s";
                 err = rc;
@@ -3047,7 +3047,7 @@ td_test(struct km_inst *inst)
     }
 
     if (txn) {
-        hse_kvdb_txn_abort(impl->kvdb, txn);
+        hse_txn_abort(impl->kvdb, txn);
         hse_kvdb_txn_free(impl->kvdb, txn);
         inst->txn = NULL;
     }

--- a/tools/ksync/ksync.c
+++ b/tools/ksync/ksync.c
@@ -172,7 +172,7 @@ stuff(void)
     }
 
     if (ktxn > 0) {
-        struct hse_kvdb_txn *  txn;
+        struct hse_txn *  txn;
 
         gettimeofday(&tstart, NULL);
 
@@ -181,9 +181,9 @@ stuff(void)
             abort();
 
         for (i = 0; i < ktxn; ++i) {
-            herr = hse_kvdb_txn_begin(kvdb, txn);
+            herr = hse_txn_begin(kvdb, txn);
             if (herr) {
-                herr_print(herr, "hse_kvdb_txn_begin() failed: ");
+                herr_print(herr, "hse_txn_begin() failed: ");
                 abort();
             }
 
@@ -200,9 +200,9 @@ stuff(void)
                 }
             }
 
-            herr = hse_kvdb_txn_commit(kvdb, txn);
+            herr = hse_txn_commit(kvdb, txn);
             if (herr) {
-                herr_print(herr, "hse_kvdb_txn_commit() failed: ");
+                herr_print(herr, "hse_txn_commit() failed: ");
                 break;
             }
         }

--- a/tools/kvs_helper.c
+++ b/tools/kvs_helper.c
@@ -263,7 +263,7 @@ struct hse_kvs_cursor *
 kh_cursor_create(
 	struct hse_kvs *     kvs,
 	unsigned int         flags,
-	struct hse_kvdb_txn *txn,
+	struct hse_txn *txn,
 	void *               pfx,
 	size_t               pfxlen)
 {

--- a/tools/kvs_helper.h
+++ b/tools/kvs_helper.h
@@ -62,7 +62,7 @@ struct hse_kvs_cursor *
 kh_cursor_create(
 	struct hse_kvs *     kvs,
 	unsigned int         flags,
-	struct hse_kvdb_txn *txn,
+	struct hse_txn *txn,
 	void *               pfx,
 	size_t               pfxlen);
 

--- a/tools/multicursor/multicursor.c
+++ b/tools/multicursor/multicursor.c
@@ -107,8 +107,8 @@ do_things(void *arg)
     }
 
     if (opts.load) {
-        struct hse_kvdb_txn *txn = hse_kvdb_txn_alloc(targ->kvdb);
-        hse_kvdb_txn_begin(targ->kvdb, txn);
+        struct hse_txn *txn = hse_kvdb_txn_alloc(targ->kvdb);
+        hse_txn_begin(targ->kvdb, txn);
         i = ti->start;
         for (i = ti->start; i < ti->end; i++) {
             *key = htobe64(i); /* key */
@@ -119,7 +119,7 @@ do_things(void *arg)
 
             atomic_inc(&ti->puts);
         }
-        hse_kvdb_txn_commit(targ->kvdb, txn);
+        hse_txn_commit(targ->kvdb, txn);
         hse_kvdb_txn_free(targ->kvdb, txn);
     }
 

--- a/tools/put_flush/put_flush.c
+++ b/tools/put_flush/put_flush.c
@@ -62,12 +62,12 @@ void
 seq_inc(void *arg)
 {
 	struct kh_thread_arg  *targ = arg;
-	struct hse_kvdb_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
+	struct hse_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
 
 	while (!killthreads) {
 
-		hse_kvdb_txn_begin(targ->kvdb, txn);
-		hse_kvdb_txn_abort(targ->kvdb, txn);
+		hse_txn_begin(targ->kvdb, txn);
+		hse_txn_abort(targ->kvdb, txn);
 	}
 
 	hse_kvdb_txn_free(targ->kvdb, txn);

--- a/tools/put_txget/put_txget.c
+++ b/tools/put_txget/put_txget.c
@@ -43,7 +43,7 @@ void
 txget(void *arg)
 {
 	struct kh_thread_arg  *targ = arg;
-	struct hse_kvdb_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
+	struct hse_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
 	uint64_t            val1, val2;
 	bool                found;
 	size_t              vlen;
@@ -51,7 +51,7 @@ txget(void *arg)
 	while (!killthreads) {
 		val1 = val2 = 0;
 
-		hse_kvdb_txn_begin(targ->kvdb, txn);
+		hse_txn_begin(targ->kvdb, txn);
 		hse_kvs_get(targ->kvs, 0, txn, "abc", 3, &found, &val1,
 			sizeof(val1), &vlen);
 		if (!found)
@@ -68,7 +68,7 @@ txget(void *arg)
 			return;
 		}
 
-		hse_kvdb_txn_abort(targ->kvdb, txn);
+		hse_txn_abort(targ->kvdb, txn);
 	}
 
 	hse_kvdb_txn_free(targ->kvdb, txn);

--- a/tools/txn_thrash/txn_thrash.c
+++ b/tools/txn_thrash/txn_thrash.c
@@ -43,7 +43,7 @@ txn_puts(
 {
     struct kh_thread_arg *targ = arg;
     struct thread_info *ti = targ->arg;
-    struct hse_kvdb_txn    *txn;
+    struct hse_txn    *txn;
     char key[64] = {0};
     char val[1024];
     uint64_t *k; /* key */
@@ -58,7 +58,7 @@ txn_puts(
         fatal(ENOMEM, "Failed to allocate resources for txn");
 
     printf("Loading keys\n");
-    hse_kvdb_txn_begin(targ->kvdb, txn);
+    hse_txn_begin(targ->kvdb, txn);
     for (i = 0, kid = ti->kidx; i < opts.count; i++) {
         *k = htobe64(++kid);
 
@@ -68,10 +68,10 @@ txn_puts(
             fatal(rc, "Put failure");
     }
 
-    rc = hse_kvdb_txn_commit(targ->kvdb, txn);
+    rc = hse_txn_commit(targ->kvdb, txn);
     if (rc) {
         fatal(rc, "TX Commit failure");
-        hse_kvdb_txn_abort(targ->kvdb, txn);
+        hse_txn_abort(targ->kvdb, txn);
     }
 
     hse_kvdb_txn_free(targ->kvdb, txn);

--- a/tools/txput_flush/txput_flush.c
+++ b/tools/txput_flush/txput_flush.c
@@ -40,7 +40,7 @@ void
 txput(void *arg)
 {
 	struct kh_thread_arg *targ = arg;
-	struct hse_kvdb_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
+	struct hse_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
 	uint idx;
 	uint64_t  vidx;
 	int rc;
@@ -56,7 +56,7 @@ txput(void *arg)
 
 	vidx = 0;
 	while (!killthreads) {
-		hse_kvdb_txn_begin(targ->kvdb, txn);
+		hse_txn_begin(targ->kvdb, txn);
 		*v = htonl(vidx++);
 		rc = hse_kvs_put(targ->kvs, 0, txn, key, sizeof(key),
 			     val, sizeof(val));
@@ -64,7 +64,7 @@ txput(void *arg)
 			err = 1;
 			killthreads = true;
 		}
-		hse_kvdb_txn_commit(targ->kvdb, txn);
+		hse_txn_commit(targ->kvdb, txn);
 	}
 
 	hse_kvdb_txn_free(targ->kvdb, txn);

--- a/tools/waltest/waltest.c
+++ b/tools/waltest/waltest.c
@@ -752,7 +752,7 @@ test_put(struct thread_info *ti, uint salt, bool istxn)
     hse_err_t err;
     u64       i, last_key;
 
-    struct hse_kvdb_txn    *txn = NULL;
+    struct hse_txn    *txn = NULL;
 
     test_start_phase(ti, salt ? "Update existing keys" : "Insert new keys");
 
@@ -780,7 +780,7 @@ test_put(struct thread_info *ti, uint salt, bool istxn)
             continue;
 
         if (istxn)
-            hse_kvdb_txn_begin(ti->kvdb, txn);
+            hse_txn_begin(ti->kvdb, txn);
 
         err = hse_kvs_put(ti->kvs, 0, txn, (char *)ti->ref_key, ti->ref_klen,
                           (char *)ti->ref_val, ti->ref_vlen);
@@ -811,7 +811,7 @@ test_put(struct thread_info *ti, uint salt, bool istxn)
         }
 
         if (istxn)
-            hse_kvdb_txn_commit(ti->kvdb, txn);
+            hse_txn_commit(ti->kvdb, txn);
     }
 
     test_end_phase(ti, false);
@@ -827,7 +827,7 @@ test_delete(
     u64 i, last_key;
     uint salt = -1; /* not important for delete */
 
-    struct hse_kvdb_txn    *txn = NULL;
+    struct hse_txn    *txn = NULL;
 
     test_start_phase(ti, prefix ? "Prefix delete keys" : "Delete keys");
 
@@ -846,7 +846,7 @@ test_delete(
             continue;
 
         if (istxn)
-            hse_kvdb_txn_begin(ti->kvdb, txn);
+            hse_txn_begin(ti->kvdb, txn);
 
         if (!prefix) {
             err = hse_kvs_delete(ti->kvs, 0, txn, (char *)ti->ref_key, ti->ref_klen);
@@ -861,7 +861,7 @@ test_delete(
         atomic_inc(&del_cnt);
 
         if (istxn)
-            hse_kvdb_txn_commit(ti->kvdb, txn);
+            hse_txn_commit(ti->kvdb, txn);
     }
 
     test_end_phase(ti, false);


### PR DESCRIPTION
kvdb prefix feels unnecessary.

Signed-off-by: Tristan Partin <tpartin@micron.com>
