### PR TITLE
Finalize initial LTO support

### DIFF
--- a/.github/workflows/builds.ignore.yaml
+++ b/.github/workflows/builds.ignore.yaml
@@ -73,3 +73,14 @@ jobs:
     steps:
       - run: |
           echo "Skipping ${{ github.workflow }}/${{ github.job }}/${{ matrix.buildtype }}"
+
+  lto:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [release, debug]
+
+    steps:
+      - run: |
+          echo "Skipping ${{ github.workflow }}/${{ github.job }}/${{ matrix.buildtype }}"

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -302,3 +302,48 @@ jobs:
             builddir/meson-logs/
             /var/log/messages
             /var/log/syslog
+
+  lto:
+    runs-on: ubuntu-latest
+    needs:
+      - determine-tag
+    container:
+      image: ghcr.io/hse-project/ci-images/fedora-36:${{ needs.determine-tag.outputs.tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [release, debug]
+
+    steps:
+      - name: Checkout HSE
+        uses: actions/checkout@v3
+
+      - name: Cache Meson packagecache
+        uses: actions/cache@v3
+        with:
+          path: subprojects/packagecache
+          key: meson-packagecache-${{ hashFiles('subprojects/*.wrap') }}
+
+        # HSE doesn't work with gcc LTO at the moment, only clang.
+      - name: Setup
+        run: |
+          CC=clang CXX=clang++ meson setup builddir --werror \
+            --buildtype=${{ matrix.buildtype }} -Db_lto=true -Dtools=enabled \
+            -Ddocs=disabled -Dbindings=none
+
+      - name: Build
+        run: |
+          ninja -C builddir
+
+      - name: Test
+        run: |
+          meson test -C builddir --setup=ci --print-errorlogs --no-stdsplit
+
+      - uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: ${{ github.job }}-${{ matrix.buildtype }}
+          path: |
+            builddir/meson-logs/
+            /var/log/messages
+            /var/log/syslog

--- a/lib/build_config.h.in
+++ b/lib/build_config.h.in
@@ -8,25 +8,28 @@
 
 #define BUILD_CONFIG (@build_config@)
 
-#mesondefine SUPPORTS_ATTR_ALWAYS_INLINE
-#mesondefine SUPPORTS_ATTR_FORMAT
-#mesondefine SUPPORTS_ATTR_PACKED
 #mesondefine SUPPORTS_ATTR_ALIGNED
+#mesondefine SUPPORTS_ATTR_ALWAYS_INLINE
+#mesondefine SUPPORTS_ATTR_COLD
+#mesondefine SUPPORTS_ATTR_CONST
+#mesondefine SUPPORTS_ATTR_FORMAT
+#mesondefine SUPPORTS_ATTR_HOT
+#mesondefine SUPPORTS_ATTR_NOINLINE
+#mesondefine SUPPORTS_ATTR_NONNULL
+#mesondefine SUPPORTS_ATTR_PACKED
+#mesondefine SUPPORTS_ATTR_RETURNS_NONNULL
 #mesondefine SUPPORTS_ATTR_SECTION
+#mesondefine SUPPORTS_ATTR_SENTINEL
 #mesondefine SUPPORTS_ATTR_UNUSED
 #mesondefine SUPPORTS_ATTR_USED
-#mesondefine SUPPORTS_ATTR_HOT
-#mesondefine SUPPORTS_ATTR_COLD
-#mesondefine SUPPORTS_ATTR_RETURNS_NONNULL
-#mesondefine SUPPORTS_ATTR_CONST
+#mesondefine SUPPORTS_ATTR_WARN_UNUSED_RESULT
 #mesondefine SUPPORTS_ATTR_WEAK
-#mesondefine SUPPORTS_ATTR_SENTINEL
-#mesondefine SUPPORTS_ATTR_NONNULL
 
 #mesondefine HAVE_PMEM
 
 #mesondefine WITH_COVERAGE
 #mesondefine WITH_INVARIANTS
+#mesondefine WITH_LTO
 #mesondefine WITH_UBSAN
 
 #endif

--- a/lib/cn/intern_builder.c
+++ b/lib/cn/intern_builder.c
@@ -29,7 +29,7 @@ struct intern_node {
 struct intern_key {
     uint          child_idx;
     uint          klen;
-    unsigned char kdata[] HSE_ALIGNED(HSE_KVS_KEY_CPE_ALIGNMENT);
+    unsigned char kdata[] HSE_ALIGNED(HSE_KEY_CPE_ALIGNMENT);
 };
 
 /**

--- a/lib/cn/wbt_builder.c
+++ b/lib/cn/wbt_builder.c
@@ -91,7 +91,7 @@ struct wbb {
 struct key_stage_entry_leaf {
     uint32_t kmd_off;
     uint16_t klen;
-    uint8_t  kdata[] HSE_ALIGNED(HSE_KVS_KEY_CPE_ALIGNMENT);
+    uint8_t  kdata[] HSE_ALIGNED(HSE_KEY_CPE_ALIGNMENT);
 };
 
 static HSE_ALWAYS_INLINE size_t

--- a/lib/cn/wbt_builder.h
+++ b/lib/cn/wbt_builder.h
@@ -32,10 +32,10 @@ struct wbt_desc;
  * but can be faster if keys have long common prefixes.  It has no known issues
  * with alignment.
  */
-static_assert(HSE_KVS_KEY_CPE_ALIGNMENT == 4 || HSE_KVS_KEY_CPE_ALIGNMENT == 8,
+static_assert(HSE_KEY_CPE_ALIGNMENT == 4 || HSE_KEY_CPE_ALIGNMENT == 8,
               "invalid alignment for structs key_state_entry_leaf and intern_key");
 
-#if HSE_KVS_KEY_CPE_ALIGNMENT == 8
+#if HSE_KEY_CPE_ALIGNMENT == 8
 #define memlcp_cpe      memlcpq
 #else
 #define memlcp_cpe      memlcp

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -14,23 +14,22 @@ endif
 
 build_config_h_data = configuration_data({
     'build_config': '"@0@"'.format(' '.join(build_opts)),
-    'SUPPORTS_ATTR_ALWAYS_INLINE': cc.has_function_attribute('always_inline'),
-    'SUPPORTS_ATTR_FORMAT': cc.has_function_attribute('format'),
-    'SUPPORTS_ATTR_PACKED': true,
     'SUPPORTS_ATTR_ALIGNED': cc.has_function_attribute('aligned'),
+    'SUPPORTS_ATTR_ALWAYS_INLINE': cc.has_function_attribute('always_inline'),
+    'SUPPORTS_ATTR_COLD': cc.has_function_attribute('cold'),
+    'SUPPORTS_ATTR_CONST': cc.has_function_attribute('const'),
+    'SUPPORTS_ATTR_FORMAT': cc.has_function_attribute('format'),
+    'SUPPORTS_ATTR_HOT': cc.has_function_attribute('hot'),
+    'SUPPORTS_ATTR_NOINLINE': cc.has_function_attribute('noinline'),
+    'SUPPORTS_ATTR_NONNULL': cc.has_function_attribute('nonnull'),
+    'SUPPORTS_ATTR_PACKED': true,
+    'SUPPORTS_ATTR_RETURNS_NONNULL': cc.has_function_attribute('returns_nonnull'),
     'SUPPORTS_ATTR_SECTION': cc.compiles(
         '''
         int x __attribute__((__section__(".read_mostly"))) = 0;
         ''',
         name: '__attribute__((__section__(".read_mostly")))',
     ),
-    'SUPPORTS_ATTR_UNUSED': cc.has_function_attribute('unused'),
-    'SUPPORTS_ATTR_USED': cc.has_function_attribute('used'),
-    'SUPPORTS_ATTR_HOT': cc.has_function_attribute('hot'),
-    'SUPPORTS_ATTR_COLD': cc.has_function_attribute('cold'),
-    'SUPPORTS_ATTR_RETURNS_NONNULL': cc.has_function_attribute('returns_nonnull'),
-    'SUPPORTS_ATTR_CONST': cc.has_function_attribute('const'),
-    'SUPPORTS_ATTR_WEAK': cc.has_function_attribute('weak'),
     'SUPPORTS_ATTR_SENTINEL': cc.compiles(
         '''
         int __attribute__((__sentinel__))
@@ -41,11 +40,14 @@ build_config_h_data = configuration_data({
         ''',
         name: '__attribute__((__sentinel__))',
     ),
-    'SUPPORTS_ATTR_NONNULL': cc.has_function_attribute('nonnull'),
+    'SUPPORTS_ATTR_UNUSED': cc.has_function_attribute('unused'),
+    'SUPPORTS_ATTR_USED': cc.has_function_attribute('used'),
     'SUPPORTS_ATTR_WARN_UNUSED_RESULT': cc.has_function_attribute('warn_unused_result'),
+    'SUPPORTS_ATTR_WEAK': cc.has_function_attribute('weak'),
     'HAVE_PMEM': libpmem_dep.found(),
     'WITH_COVERAGE': get_option('b_coverage'),
     'WITH_INVARIANTS': get_option('debug'),
+    'WITH_LTO': get_option('b_lto'),
     'WITH_UBSAN': get_option('b_sanitize').contains('undefined'),
 })
 

--- a/lib/util/include/hse_util/compiler.h
+++ b/lib/util/include/hse_util/compiler.h
@@ -24,10 +24,28 @@
 #define HSE_LIKELY(_expr)       __builtin_expect(!!(_expr), 1)
 #define HSE_UNLIKELY(_expr)     __builtin_expect(!!(_expr), 0)
 
+#ifdef SUPPORTS_ATTR_ALIGNED
+#define HSE_ALIGNED(_size)      __attribute__((__aligned__(_size)))
+#else
+#define HSE_ALIGNED(_size)
+#endif
+
 #ifdef SUPPORTS_ATTR_ALWAYS_INLINE
 #define HSE_ALWAYS_INLINE       inline __attribute__((__always_inline__))
 #else
 #define HSE_ALWAYS_INLINE       inline
+#endif
+
+#ifdef SUPPORTS_ATTR_COLD
+#define HSE_COLD                __attribute__((__cold__))
+#else
+#define HSE_COLD
+#endif
+
+#ifdef SUPPORTS_ATTR_CONST
+#define HSE_CONST               __attribute__((__const__))
+#else
+#define HSE_CONST
 #endif
 
 #ifdef SUPPORTS_ATTR_FORMAT
@@ -37,16 +55,34 @@
 #define HSE_PRINTF(_fmtidx, _argidx)
 #endif
 
+#ifdef SUPPORTS_ATTR_HOT
+#define HSE_HOT                 __attribute__((__hot__))
+#else
+#define HSE_HOT
+#endif
+
+#ifdef SUPPORTS_ATTR_NOINLINE
+#define HSE_NOINLINE            __attribute__((__noinline__))
+#else
+#define HSE_NOINLINE
+#endif
+
+#ifdef SUPPORTS_ATTR_NONNULL
+#define HSE_NONNULL(...)        __attribute__((__nonnull__(__VA_ARGS__)))
+#else
+#define HSE_NONNULL(...)
+#endif
+
 #ifdef SUPPORTS_ATTR_PACKED
 #define HSE_PACKED              __attribute__((__packed__))
 #else
 #define HSE_PACKED
 #endif
 
-#ifdef SUPPORTS_ATTR_ALIGNED
-#define HSE_ALIGNED(_size)      __attribute__((__aligned__(_size)))
+#ifdef SUPPORTS_ATTR_RETURNS_NONNULL
+#define HSE_RETURNS_NONNULL     __attribute__((__returns_nonnull__))
 #else
-#define HSE_ALIGNED(_size)
+#define HSE_RETURNS_NONNULL
 #endif
 
 #ifdef SUPPORTS_ATTR_SECTION
@@ -67,28 +103,16 @@
 #define HSE_USED
 #endif
 
-#ifdef SUPPORTS_ATTR_HOT
-#define HSE_HOT                 __attribute__((__hot__))
+#ifdef SUPPORTS_ATTR_SENTINEL
+#define HSE_SENTINEL            __attribute__((__sentinel__))
 #else
-#define HSE_HOT
+#define HSE_SENTINEL
 #endif
 
-#ifdef SUPPORTS_ATTR_COLD
-#define HSE_COLD                __attribute__((__cold__))
+#ifdef SUPPORTS_ATTR_WARN_UNUSED_RESULT
+#define HSE_WARN_UNUSED_RESULT  __attribute__((__warn_unused_result__))
 #else
-#define HSE_COLD
-#endif
-
-#ifdef SUPPORTS_ATTR_RETURNS_NONNULL
-#define HSE_RETURNS_NONNULL     __attribute__((__returns_nonnull__))
-#else
-#define HSE_RETURNS_NONNULL
-#endif
-
-#ifdef SUPPORTS_ATTR_CONST
-#define HSE_CONST               __attribute__((__const__))
-#else
-#define HSE_CONST
+#define HSE_WARN_UNUSED_RESULT
 #endif
 
 #ifdef SUPPORTS_ATTR_WEAK
@@ -97,27 +121,13 @@
 #define HSE_WEAK
 #endif
 
-#ifdef SUPPORTS_ATTR_SENTINEL
-#define HSE_SENTINEL            __attribute__((__sentinel__))
-#else
-#define HSE_SENTINEL
-#endif
-
-#ifdef SUPPORTS_ATTR_NONNULL
-#define HSE_NONNULL(...)        __attribute__((__nonnull__(__VA_ARGS__)))
-#else
-#define HSE_NONNULL(...)
-#endif
-
-#ifdef SUPPORTS_ATTR_WARN_UNUSED_RESULT
-#define HSE_WARN_USUSED_RESULT  __attribute__((warn_unused_result))
-#else
-#define HSE_WARN_UNUSED_RESULT
-#endif
-
-#if defined(__has_include) && __has_include(<stdnoreturn.h>)
+#if defined(__has_include)
+#if __has_include(<stdnoreturn.h>)
 #include <stdnoreturn.h>
 #define HSE_NORETURN noreturn
+#else
+#define HSE_NORETURN
+#endif
 #else
 #define HSE_NORETURN
 #endif

--- a/lib/util/src/arch.c
+++ b/lib/util/src/arch.c
@@ -10,12 +10,11 @@
 
 /* GCOV_EXCL_START */
 
-#if __amd64__
+#if __amd64__ && defined(SUPPORTS_ATTR_NOINLINE)
 
-/* Use noinline to try to prevent -flto from inlining assembly.
+/* Use noinline to try to prevent LTO from inlining assembly.
  */
-__attribute__((__noinline__))
-size_t
+HSE_NOINLINE size_t
 memlcp(const void *s1, const void *s2, size_t len)
 {
     size_t rc;
@@ -39,8 +38,7 @@ memlcp(const void *s1, const void *s2, size_t len)
 
 /* Use noinline to try to prevent -flto from inlining assembly.
  */
-__attribute__((__noinline__))
-size_t
+HSE_NOINLINE size_t
 memlcpq(const void *s1, const void *s2, size_t len)
 {
     size_t rc;

--- a/meson.build
+++ b/meson.build
@@ -139,12 +139,12 @@ endif
 
 if get_option('key-cpe') == 'size'
     add_project_arguments(
-        '-DHSE_KVS_KEY_CPE_ALIGNMENT=4',
+        '-DHSE_KEY_CPE_ALIGNMENT=4',
         language: 'c'
-	)
+    )
 elif get_option('key-cpe') == 'speed'
     add_project_arguments(
-        '-DHSE_KVS_KEY_CPE_ALIGNMENT=8',
+        '-DHSE_KEY_CPE_ALIGNMENT=8',
         language: 'c'
     )
 else


### PR DESCRIPTION
`memlcp*()` will use their assembly implementation if the compiler is an amd64 compiler and the compiler supports the `noinline` attribute.

Adds LTO builds to the CI so support doesn't regress.

Signed-off-by: Tristan Partin <tpartin@micron.com>
