### PR TITLE
Override b_lto for the crc32c dependency

### DIFF
--- a/lib/util/src/arch.c
+++ b/lib/util/src/arch.c
@@ -92,6 +92,10 @@ memlcpq(const void *s1, const void *s2, size_t len)
     return ((const char *)s1q - (const char *)s1);
 }
 
+#endif
+
+#if !__amd64__
+
 /* We call hse_getcpu() frequently enough that the vDSO based getcpu call
  * is too expensive for our purposes.  To ameliorate the expense, we sample
  * getcpu() every so often on a per-thread basis.  This works fairly well

--- a/subprojects/crc32c/meson.build
+++ b/subprojects/crc32c/meson.build
@@ -1,12 +1,21 @@
 project(
     'crc32c',
-    ['c']
+    'c'
 )
 
 crc32c = library(
     meson.project_name(),
-    ['crc32c.c'],
-    gnu_symbol_visibility: 'hidden'
+    'crc32c.c',
+    gnu_symbol_visibility: 'hidden',
+    override_options: [
+        # Inline assembly functions cannot be properly LTOed. One workaround
+        # would be to always call crc32c_sw(), but then you would lose out in
+        # the case when LTO is disabled. Another solution would be to mark
+        # assembly function as noinline, but since these files come from
+        # elsewhere, it is probably best to not edit them. For these reasons,
+        # always forcibly disable LTO.
+        'b_lto=false',
+    ]
 )
 
 crc32c_dep = declare_dependency(


### PR DESCRIPTION
Not the most elegant solution, but good enough until https://github.com/mesonbuild/meson/issues/9398 is worked out.

Note that this does not enable LTO with gcc due to LTO `O3` builds failing in `key_util_test.memlcp_test`.

Signed-off-by: Tristan Partin <tpartin@micron.com>
