### PR TITLE
Fix ks->ks_kvsetid != 0 assert in kvset_open2()

### DIFF
--- a/lib/cn/blk_list.c
+++ b/lib/cn/blk_list.c
@@ -51,7 +51,7 @@ commit_mblocks(struct mpool *mp, struct blk_list *blks)
     return 0;
 }
 
-merr_t
+void
 delete_mblock(struct mpool *mp, uint64_t mbid)
 {
     merr_t err;
@@ -61,8 +61,6 @@ delete_mblock(struct mpool *mp, uint64_t mbid)
     err = mpool_mblock_delete(mp, mbid);
     if (err)
         log_errx("Failed to delete mblock 0x%lx", err, mbid);
-
-    return err;
 }
 
 void
@@ -71,8 +69,10 @@ delete_mblocks(struct mpool *mp, struct blk_list *blks)
     INVARIANT(mp);
     INVARIANT(blks);
 
-    for (uint32_t i = 0; i < blks->idc; i++)
+    for (uint32_t i = 0; i < blks->idc; i++) {
         delete_mblock(mp, blks->idv[i]);
+        blks->idv[i] = 0;
+    }
 }
 
 void

--- a/lib/cn/blk_list.h
+++ b/lib/cn/blk_list.h
@@ -19,7 +19,7 @@ struct mpool;
 #define BLK_LIST_PRE_ALLOC 64
 
 /* MTF_MOCK */
-merr_t
+void
 delete_mblock(struct mpool *mp, uint64_t mbid);
 
 /* MTF_MOCK */

--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -168,7 +168,7 @@ cn_is_replay(const struct cn *cn)
 }
 
 struct mpool *
-cn_get_dataset(const struct cn *cn)
+cn_get_mpool(const struct cn *cn)
 {
     return cn->cn_dataset;
 }
@@ -413,6 +413,8 @@ cn_mblocks_destroy(
 {
     for (uint32_t i = 0; i < num_lists; i++) {
         delete_mblock(mp, list[i].hblk_id);
+        list[i].hblk_id = 0;
+
         delete_mblocks(mp, &list[i].kblks);
         if (!kcompact)
             delete_mblocks(mp, &list[i].vblks);

--- a/lib/cn/hblock_builder.c
+++ b/lib/cn/hblock_builder.c
@@ -164,7 +164,7 @@ hbb_create(struct hblock_builder **bld_out, const struct cn *const cn, struct pe
         return merr(ENOMEM);
 
     bld->nptombs = 0;
-    bld->mpool = cn_get_dataset(cn);
+    bld->mpool = cn_get_mpool(cn);
     bld->cn = cn;
     bld->pc = pc;
     bld->agegroup = HSE_MPOLICY_AGE_LEAF;

--- a/lib/cn/node_split.c
+++ b/lib/cn/node_split.c
@@ -598,6 +598,7 @@ cn_split(struct cn_compaction_work *w)
                     /* Drop contiguous kvsets containing only ptombs, starting from the oldest.
                      */
                     delete_mblock(w->cw_mp, blks->hblk_id);
+                    blks->hblk_id = 0;
                     blk_list_free(result->ks[k].blks_commit);
                 } else {
                     w->cw_kvsetidv[idx] = cndb_kvsetid_mint(cndb);

--- a/lib/include/hse_ikvdb/cn.h
+++ b/lib/include/hse_ikvdb/cn.h
@@ -89,7 +89,7 @@ cn_get_rp(const struct cn *cn);
 
 /* MTF_MOCK */
 struct mpool *
-cn_get_dataset(const struct cn *cn);
+cn_get_mpool(const struct cn *cn);
 
 /* MTF_MOCK */
 struct mclass_policy *

--- a/tests/functional/smoke/modes.sh
+++ b/tests/functional/smoke/modes.sh
@@ -33,49 +33,52 @@ do
     cmd kvt -cv -m1 "$props" "$home" kvdb-oparms mode="$mode"
 done
 
-# Remove write permission from $home
-omode=$(stat -c %a "$home")
-cmd chmod 555 "$home"
+# Restricting write permission on $home works only for a non-root user
+if [[ $(id -u) -ne 0 ]]; then
+    # Remove write permission from $home
+    omode=$(stat -c %a "$home")
+    cmd chmod 555 "$home"
 
-# PUTs must fail
-cmd -e kvt -T5,4 -l8 -m1 "$props" "$home"
+    # PUTs must fail
+    cmd -e kvt -T5,4 -l8 -m1 "$props" "$home"
 
-# Cannot open KVDB in the following modes without write permission on $home
-modes="rdonly_replay rdwr"
-for mode in $modes
-do
-    cmd -e kvt -cv -m1 "$props" "$home" kvdb-oparms mode="$mode"
-done
+    # Cannot open KVDB in the following modes without write permission on $home
+    modes="rdonly_replay rdwr"
+    for mode in $modes
+    do
+        cmd -e kvt -cv -m1 "$props" "$home" kvdb-oparms mode="$mode"
+    done
 
-# GETs must succeed on a KVDB opened in the following modes without write permission on $home
-modes="rdonly diag"
-for mode in $modes
-do
-    cmd kvt -cv -m1 "$props" "$home" kvdb-oparms mode="$mode"
-done
-cmd chmod "$omode" "$home"
+    # GETs must succeed on a KVDB opened in the following modes without write permission on $home
+    modes="rdonly diag"
+    for mode in $modes
+    do
+        cmd kvt -cv -m1 "$props" "$home" kvdb-oparms mode="$mode"
+    done
+    cmd chmod "$omode" "$home"
 
-# Remove write permission from $home/capacity
-omode=$(stat -c %a "$home"/capacity)
-cmd chmod 555 "$home"/capacity
+    # Remove write permission from $home/capacity
+    omode=$(stat -c %a "$home"/capacity)
+    cmd chmod 555 "$home"/capacity
 
-# PUTs must fail
-cmd -e kvt -T5,4 -l8 -m1 "$props" "$home"
+    # PUTs must fail
+    cmd -e kvt -T5,4 -l8 -m1 "$props" "$home"
 
-# Cannot open KVDB in the following modes without write permission on the capacity FS
-modes="rdonly_replay rdwr"
-for mode in $modes
-do
-    cmd -e kvt -cv -m1 "$props" "$home" kvdb-oparms mode="$mode"
-done
+    # Cannot open KVDB in the following modes without write permission on the capacity FS
+    modes="rdonly_replay rdwr"
+    for mode in $modes
+    do
+        cmd -e kvt -cv -m1 "$props" "$home" kvdb-oparms mode="$mode"
+    done
 
-# GETs must succeed on a KVDB opened in the following modes without write perm on capacity FS
-modes="rdonly diag"
-for mode in $modes
-do
-    cmd kvt -cv -m1 "$props" "$home" kvdb-oparms mode="$mode"
-done
-cmd chmod "$omode" "$home"/capacity
+    # GETs must succeed on a KVDB opened in the following modes without write perm on capacity FS
+    modes="rdonly diag"
+    for mode in $modes
+    do
+        cmd kvt -cv -m1 "$props" "$home" kvdb-oparms mode="$mode"
+    done
+    cmd chmod "$omode" "$home"/capacity
+fi
 
 # Force the KVDB into dirty state by crashing kvt
 cmd -s 9 kvt -T30,4 -l8 -m1 -K9,5,7 "${props}" "$home"

--- a/tests/mocks/repository/lib/mock_c0cn.c
+++ b/tests/mocks/repository/lib/mock_c0cn.c
@@ -658,7 +658,7 @@ static struct mapi_injection cn_inject_list[] = {
 
     { mapi_idx_cn_get_rp,            MAPI_RC_PTR, &mocked_kvs_rparams },
     { mapi_idx_cn_get_cparams,       MAPI_RC_PTR, &mocked_kvs_cparams },
-    { mapi_idx_cn_get_dataset,       MAPI_RC_PTR, NULL },
+    { mapi_idx_cn_get_mpool,         MAPI_RC_PTR, NULL },
     { mapi_idx_cn_get_mclass_policy, MAPI_RC_PTR, NULL },
     { mapi_idx_cn_get_ingest_perfc,  MAPI_RC_PTR, NULL },
 

--- a/tests/unit/cn/blk_list_test.c
+++ b/tests/unit/cn/blk_list_test.c
@@ -159,8 +159,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = delete_mblock(ds, b.idv[0]);
-    ASSERT_EQ(err, 0);
+    delete_mblock(ds, b.idv[0]);
     blk_list_free(&b);
 
     /* delete with handle and with mpool_mblock_delete failure */
@@ -169,8 +168,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = delete_mblock(ds, b.idv[0]);
-    ASSERT_NE(err, 0);
+    delete_mblock(ds, b.idv[0]);
     blk_list_free(&b);
     mapi_inject(api, 0);
 
@@ -178,8 +176,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblock, pre, post)
     blk_list_init(&b);
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
-    err = delete_mblock(ds, b.idv[0]);
-    ASSERT_EQ(err, 0);
+    delete_mblock(ds, b.idv[0]);
     blk_list_free(&b);
 }
 
@@ -194,6 +191,7 @@ MTF_DEFINE_UTEST_PREPOST(blk_list_test, t_delete_mblocks, pre, post)
     err = blk_list_append(&b, BLK_ID);
     ASSERT_EQ(err, 0);
     delete_mblocks(ds, &b);
+    ASSERT_EQ(b.idv[0], 0);
     blk_list_free(&b);
 
     blk_list_init(&b);

--- a/tests/unit/cn/hblock_builder_test.c
+++ b/tests/unit/cn/hblock_builder_test.c
@@ -89,7 +89,7 @@ test_pre(struct mtf_test_info *info)
     mapi_inject_ptr(mapi_idx_cn_get_mclass_policy, &mocked_mpolicy);
 
     mapi_inject(mapi_idx_cn_get_cnid, 1001);
-    mapi_inject(mapi_idx_cn_get_dataset, 0);
+    mapi_inject(mapi_idx_cn_get_mpool, 0);
     mapi_inject(mapi_idx_cn_get_flags, 0);
 
     return 0;

--- a/tests/unit/cn/kblock_builder_test.c
+++ b/tests/unit/cn/kblock_builder_test.c
@@ -155,7 +155,7 @@ test_setup(struct mtf_test_info *lcl_ti)
     mapi_inject_ptr(mapi_idx_cn_get_mclass_policy, &mocked_mpolicy);
 
     mapi_inject(mapi_idx_cn_get_cnid, 1001);
-    mapi_inject(mapi_idx_cn_get_dataset, 0);
+    mapi_inject(mapi_idx_cn_get_mpool, 0);
     mapi_inject(mapi_idx_cn_get_flags, 0);
 
     mapi_inject(mapi_idx_delete_mblock, 0);

--- a/tests/unit/cn/kvset_builder_test.c
+++ b/tests/unit/cn/kvset_builder_test.c
@@ -46,7 +46,7 @@ pre(struct mtf_test_info *mtf)
     const char key = 'f';
 
     mapi_inject(mapi_idx_cn_get_cnid, TEST_DEF_UTAG);
-    mapi_inject(mapi_idx_cn_get_dataset, 0);
+    mapi_inject(mapi_idx_cn_get_mpool, 0);
     mapi_inject(mapi_idx_cn_get_flags, 0);
 
     mapi_inject(mapi_idx_delete_mblock, 0);

--- a/tests/unit/cn/vblock_builder_test.c
+++ b/tests/unit/cn/vblock_builder_test.c
@@ -73,7 +73,7 @@ test_setup(struct mtf_test_info *lcl_ti)
     mapi_inject_ptr(mapi_idx_cn_get_mclass_policy, &mocked_mpolicy);
 
     mapi_inject(mapi_idx_cn_get_cnid, 1001);
-    mapi_inject(mapi_idx_cn_get_dataset, 0);
+    mapi_inject(mapi_idx_cn_get_mpool, 0);
     mapi_inject(mapi_idx_cn_get_flags, 0);
 
     mapi_inject(mapi_idx_delete_mblock, 0);


### PR DESCRIPTION
The fix is to reset the hblock ID to zero in cn_split() after calling delete_mblock() on it.

We used to rely on delete_mblock() to reset the blkid for us when it was taking in a ptr to struct kvs_block. With the recent code refactoring, delete_mblock() now takes in an mblock ID which puts the onus on the caller to reset the blkid after delete_mblock(). To be safe, I've fixed all callers of delete_mblock().

Fix "modes" smoke test to run the EROFS/EPERM test only when smoke is run as a non-root user.

Signed-off-by: Nabeel M Mohamed <50154757+nabeelmmd@users.noreply.github.com>

## Issue(s) Addressed
NFSE-5384