### PR TITLE
Add comment explaining why zspills work only on the oldest kvsets in root

### DIFF
--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -170,8 +170,11 @@ sp3_work_wtype_root(
 
     znode = cn_kvset_can_zspill(le->le_kvset, rmap);
 
-    /* Don't start a zspill if there the older busy kvsets.  This avoids
-     * tying up a spill thread that will just end up waiting on an rspill.
+    /* Don't start a zspill if there are older busy kvsets.  This ensures that when a zspill
+     * does run, it's the oldest spill running and wouldn't have to wait behind any other spill
+     * thread.  This is important because zspill uses cn_move() which unlinks the input kvsets
+     * immediately when cn_subspill_apply() is called.  There cannot be any older spills active
+     * when the input kvsets are unlinkd.
      */
     if (znode && list_next_entry_or_null(le, le_link, &tn->tn_kvset_list)) {
         ev_debug(1);

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -170,11 +170,11 @@ sp3_work_wtype_root(
 
     znode = cn_kvset_can_zspill(le->le_kvset, rmap);
 
-    /* Don't start a zspill if there are older busy kvsets.  This ensures that when a zspill
-     * does run, it's the oldest spill running and wouldn't have to wait behind any other spill
-     * thread.  This is important because zspill uses cn_move() which unlinks the input kvsets
-     * immediately when cn_subspill_apply() is called.  There cannot be any older spills active
-     * when the input kvsets are unlinkd.
+    /* Don't start a zspill if there are older busy kvsets.  This ensures that when a zspill does
+     * run, there's no other active spill that was started before it. i.e. it wouldn't have to wait
+     * behind any other spill thread.  This is important because zspill uses cn_move() which unlinks
+     * the input kvsets immediately when cn_subspill_apply() is called.  When the input kvsets are
+     * unlinked, there cannot be any active spills that started before the zspill.
      */
     if (znode && list_next_entry_or_null(le, le_link, &tn->tn_kvset_list)) {
         ev_debug(1);


### PR DESCRIPTION
Signed-off-by: Gaurav Ramdasi <10132364+gsramdasi@users.noreply.github.com>

## Description
It's best to handle this before a zspill is scheduled. The code to do this is already in master. This PR merely adds a comment explaining the reason for doing it wrt zspill.

## Issue(s) Addressed
NFSE-5383
