### PR TITLE
Fix !bld->destruct assert in vbb_finish() (NFSE-5379)

### DIFF
--- a/lib/c0/c0sk_internal.c
+++ b/lib/c0/c0sk_internal.c
@@ -324,7 +324,11 @@ c0sk_cningest_cb(void *rock, struct bonsai_kv *bkv, struct bonsai_val *vlist)
         if (ev(err))
             return err;
 
-        kvset_builder_set_agegroup(bldr, HSE_MPOLICY_AGE_ROOT);
+        err = kvset_builder_set_agegroup(bldr, HSE_MPOLICY_AGE_ROOT);
+        if (err) {
+            kvset_builder_destroy(bldr);
+            return err;
+        }
 
         kvbldrs[skidx] = bldr;
     }

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -798,7 +798,8 @@ sp3_node_unlink(struct sp3 *sp, struct sp3_node *spn)
 static void
 sp3_node_unlink_all(struct sp3 *sp, struct sp3_node *spn)
 {
-    assert(spn->spn_initialized);
+    if (ev(!spn->spn_initialized))
+        return;
 
     sp3_node_unlink(sp, spn);
     list_del_init(&spn->spn_rlink);

--- a/lib/cn/kcompact.c
+++ b/lib/cn/kcompact.c
@@ -309,7 +309,10 @@ cn_kcompact(struct cn_compaction_work *w)
     if (ev(err))
         return err;
 
-    kvset_builder_set_agegroup(bldr, HSE_MPOLICY_AGE_LEAF);
+    err = kvset_builder_set_agegroup(bldr, HSE_MPOLICY_AGE_LEAF);
+    if (err)
+        goto done;
+
     kvset_builder_set_merge_stats(bldr, &w->cw_stats);
 
     err = kcompact(w, bldr);

--- a/lib/cn/kvcompact.c
+++ b/lib/cn/kvcompact.c
@@ -144,7 +144,10 @@ cn_kvcompact(struct cn_compaction_work *w)
         goto out;
 
     kvset_builder_set_merge_stats(bldr, &w->cw_stats);
-    kvset_builder_set_agegroup(bldr, HSE_MPOLICY_AGE_LEAF);
+
+    err = kvset_builder_set_agegroup(bldr, HSE_MPOLICY_AGE_LEAF);
+    if (err)
+        goto out;
 
     new_key = true;
 
@@ -287,7 +290,7 @@ cn_kvcompact(struct cn_compaction_work *w)
         }
 
         if (err)
-            break;
+            goto out;
 
         prev_kobj = curr->kobj;
 

--- a/lib/cn/kvset_builder.c
+++ b/lib/cn/kvset_builder.c
@@ -507,14 +507,21 @@ kvset_builder_get_mblocks(struct kvset_builder *self, struct kvset_mblocks *mblk
     return 0;
 }
 
-void
+merr_t
 kvset_builder_set_agegroup(struct kvset_builder *self, enum hse_mclass_policy_age age)
 {
+    merr_t err;
+
     INVARIANT(age < HSE_MPOLICY_AGE_CNT);
 
-    hbb_set_agegroup(self->hbb, age);
-    kbb_set_agegroup(self->kbb, age);
-    vbb_set_agegroup(self->vbb, age);
+    err = hbb_set_agegroup(self->hbb, age);
+    if (!err) {
+        err = kbb_set_agegroup(self->kbb, age);
+        if (!err)
+            err = vbb_set_agegroup(self->vbb, age);
+    }
+
+    return err;
 }
 
 void

--- a/lib/include/hse_ikvdb/kvset_builder.h
+++ b/lib/include/hse_ikvdb/kvset_builder.h
@@ -118,7 +118,7 @@ void
 kvset_mblocks_destroy(struct kvset_mblocks *kvset);
 
 /* MTF_MOCK */
-void
+merr_t
 kvset_builder_set_agegroup(struct kvset_builder *self, enum hse_mclass_policy_age age);
 
 /* MTF_MOCK */


### PR DESCRIPTION
Both spill and kv-compact erroneously invoked kvset_builder_finish() in its error paths causing this assert to trigger.

Set bld->destruct in all applicable error paths in the vblock builder.

Signed-off-by: Nabeel M Mohamed <50154757+nabeelmmd@users.noreply.github.com>
