### PR TITLE
Return more informative REST errors

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -78,6 +78,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -147,6 +150,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -219,6 +225,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -294,6 +303,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -501,6 +513,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -544,6 +559,9 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/paramsRetrieved"
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -584,6 +602,9 @@
           "200": {
             "$ref": "#/components/responses/paramRetrieved"
           },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
+          },
           "404": {
             "$ref": "#/components/responses/notFound"
           }
@@ -609,6 +630,9 @@
           },
           "404": {
             "$ref": "#/components/responses/notFound"
+          },
+          "423": {
+            "$ref": "#/components/responses/locked"
           }
         }
       }
@@ -650,6 +674,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -696,6 +723,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -745,6 +775,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -797,6 +830,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -1005,6 +1041,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -1082,6 +1121,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           },
           "404": {
             "$ref": "#/components/responses/notFound"
@@ -1372,6 +1414,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
+          },
           "404": {
             "$ref": "#/components/responses/notFound"
           }
@@ -1424,6 +1469,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
+          },
           "404": {
             "$ref": "#/components/responses/notFound"
           }
@@ -1475,6 +1523,9 @@
           "200": {
             "$ref": "#/components/responses/paramsRetrieved"
           },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
+          },
           "404": {
             "$ref": "#/components/responses/notFound"
           }
@@ -1520,6 +1571,9 @@
           "200": {
             "$ref": "#/components/responses/paramRetrieved"
           },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
+          },
           "404": {
             "$ref": "#/components/responses/notFound"
           }
@@ -1545,6 +1599,9 @@
           },
           "404": {
             "$ref": "#/components/responses/notFound"
+          },
+          "423": {
+            "$ref": "#/components/responses/locked"
           }
         }
       }
@@ -1596,6 +1653,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           },
           "404": {
             "$ref": "#/components/responses/notFound"
@@ -1666,6 +1726,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
+          },
           "404": {
             "$ref": "#/components/responses/notFound"
           }
@@ -1726,6 +1789,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
+          },
           "404": {
             "$ref": "#/components/responses/notFound"
           }
@@ -1774,6 +1840,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -1823,6 +1892,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -1875,6 +1947,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -2051,6 +2126,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -2103,6 +2181,9 @@
           "200": {
             "$ref": "#/components/responses/paramsRetrieved"
           },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
+          },
           "404": {
             "$ref": "#/components/responses/notFound"
           }
@@ -2151,6 +2232,9 @@
           "200": {
             "$ref": "#/components/responses/paramRetrieved"
           },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
+          },
           "404": {
             "$ref": "#/components/responses/notFound"
           }
@@ -2176,6 +2260,9 @@
           },
           "404": {
             "$ref": "#/components/responses/notFound"
+          },
+          "423": {
+            "$ref": "#/components/responses/locked"
           }
         }
       }
@@ -2225,6 +2312,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -2277,6 +2367,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -2332,6 +2425,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequest"
           }
         }
       }
@@ -2515,8 +2611,35 @@
       }
     },
     "responses": {
+      "badRequest": {
+        "description": "Bad Request",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/error"
+            }
+          }
+        }
+      },
+      "locked": {
+        "description": "Locked",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/error"
+            }
+          }
+        }
+      },
       "notFound": {
-        "description": "Entity not found."
+        "description": "Not Found",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/error"
+            }
+          }
+        }
       },
       "paramsRetrieved": {
         "description": "OK",
@@ -2671,6 +2794,53 @@
           "vblocks": {
             "type": "integer",
             "nullable": false
+          }
+        }
+      },
+      "error": {
+        "type": "object",
+        "description": "RFC7807-compliant error description",
+        "externalDocs": {
+          "url": "https://www.rfc-editor.org/rfc/rfc7807"
+        },
+        "nullable": false,
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Summary of the problem",
+            "nullable": false
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code",
+            "nullable": false
+          },
+          "detail": {
+            "type": "string",
+            "description": "Explanation specific to this occurrence of the problem",
+            "nullable": false
+          },
+          "origin": {
+            "type": "object",
+            "description": "Origin of where the error was generated",
+            "nullable": false,
+            "properties": {
+              "file": {
+                "type": "string",
+                "description": "File where the error was generated",
+                "nullable": false
+              },
+              "lineno": {
+                "type": "integer",
+                "description": "Line number where the error was generated",
+                "nullable": false
+              },
+              "errno": {
+                "type": "integer",
+                "description": "Errno value describing the error",
+                "nullable": false
+              }
+            }
           }
         }
       },

--- a/lib/config/param.c
+++ b/lib/config/param.c
@@ -1026,7 +1026,7 @@ param_get(
             ps = &pspecs[i];
 
     if (!ps)
-        return merr(EINVAL);
+        return merr(ENOENT);
 
     assert(ps->ps_stringify);
     return ps->ps_stringify(
@@ -1093,7 +1093,7 @@ param_set(
 
     if (!ps) {
         log_err("Unknown parameter %s", param);
-        err = merr(EINVAL);
+        err = merr(ENOENT);
         goto out;
     }
 

--- a/lib/rest/include/hse/rest/headers.h
+++ b/lib/rest/include/hse/rest/headers.h
@@ -14,6 +14,7 @@ struct rest_headers;
 
 #define REST_HEADER_CONTENT_TYPE "Content-Type"
 #define REST_APPLICATION_JSON "application/json"
+#define REST_APPLICATION_PROBLEM_JSON "application/problem+json"
 
 const char *
 rest_headers_get(const struct rest_headers *headers, const char *key);

--- a/lib/rest/include/hse/rest/response.h
+++ b/lib/rest/include/hse/rest/response.h
@@ -9,11 +9,19 @@
 #include <stdio.h>
 #include <stddef.h>
 
+#include <hse/error/merr.h>
 #include <hse/rest/forward.h>
 
 struct rest_response {
     struct rest_headers *rr_headers;
     FILE *rr_stream;
 };
+
+enum rest_status
+rest_response_perror(
+    struct rest_response *resp,
+    enum rest_status status,
+    const char *detail,
+    merr_t origin);
 
 #endif

--- a/lib/rest/lib/meson.build
+++ b/lib/rest/lib/meson.build
@@ -1,6 +1,7 @@
 rest_sources = files(
     'headers.c',
     'params.c',
+    'response.c',
     'server.c',
     'status.c'
 )

--- a/lib/rest/lib/response.c
+++ b/lib/rest/lib/response.c
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2022 Micron Technology, Inc.  All rights reserved.
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+
+#include <hse/error/merr.h>
+#include <hse/rest/headers.h>
+#include <hse/rest/response.h>
+#include <hse/rest/status.h>
+#include <hse/util/event_counter.h>
+#include <hse/util/err_ctx.h>
+
+#include "response.h"
+#include "status.h"
+
+enum rest_status
+rest_response_perror(
+    struct rest_response *const resp,
+    const enum rest_status status,
+    const char *const detail,
+    const merr_t origin)
+{
+    merr_t err;
+    const char *reason;
+
+    if (!resp || status < 400 || status > 500 || !detail || !origin) {
+        ev(1);
+        return status;
+    }
+
+    reason = status_to_reason(status);
+
+    err = rest_headers_set(resp->rr_headers, REST_HEADER_CONTENT_TYPE, REST_APPLICATION_PROBLEM_JSON);
+    ev(err);
+
+    fprintf(resp->rr_stream, RFC7807_FMT, reason, status, detail, merr_file(origin),
+        merr_lineno(origin), merr_errno(origin));
+
+    return status;
+}

--- a/lib/rest/lib/response.h
+++ b/lib/rest/lib/response.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2022 Micron Technology, Inc.  All rights reserved.
+ */
+
+#ifndef HSE_REST_PRIVATE_RESPONSE_H
+#define HSE_REST_PRIVATE_RESPONSE_H
+
+#define RFC7807_FMT \
+    "{\"title\": \"%s\", \"status\": %d, \"detail\": \"%s\", \"origin\": {\"file\": \"%s\", \"lineno\": %d, \"errno\": %d}}"
+
+#endif

--- a/lib/rest/lib/status.c
+++ b/lib/rest/lib/status.c
@@ -12,9 +12,9 @@
 #include "status.h"
 
 const char *
-status_to_reason(const enum rest_status code)
+status_to_reason(const enum rest_status status)
 {
-    switch (code) {
+    switch (status) {
     case REST_STATUS_OK:
         return "OK";
     case REST_STATUS_CREATED:

--- a/lib/rest/lib/status.h
+++ b/lib/rest/lib/status.h
@@ -10,6 +10,6 @@
 #include <hse/util/compiler.h>
 
 const char *
-status_to_reason(enum rest_status code) HSE_RETURNS_NONNULL;
+status_to_reason(enum rest_status status) HSE_RETURNS_NONNULL;
 
 #endif

--- a/tests/functional/api/hse_api_test.c
+++ b/tests/functional/api/hse_api_test.c
@@ -35,6 +35,16 @@ MTF_DEFINE_UTEST(hse_api_test, param_mismatched_buf_buf_sz)
     ASSERT_EQ(EINVAL, hse_err_to_errno(err));
 }
 
+MTF_DEFINE_UTEST(hse_api_test, param_dne)
+{
+    hse_err_t err;
+    size_t    needed_sz;
+    char      buf[16];
+
+    err = hse_param_get("does.not.exist", buf, sizeof(buf), &needed_sz);
+    ASSERT_EQ(ENOENT, hse_err_to_errno(err));
+}
+
 /* This works because we have previously initialized HSE which sets up the
  * global hse_gparams struct even though HSE is not currently initialized when
  * this test is run.

--- a/tests/functional/api/kvdb_api_test.c
+++ b/tests/functional/api/kvdb_api_test.c
@@ -387,6 +387,16 @@ MTF_DEFINE_UTEST(kvdb_api_test, mode)
     ASSERT_EQ(0, hse_err_to_errno(err));
 }
 
+MTF_DEFINE_UTEST(kvdb_api_test, param_dne)
+{
+    hse_err_t err;
+    size_t    needed_sz;
+    char      buf[16];
+
+    err = hse_kvdb_param_get(kvdb_handle, "does.not.exist", buf, sizeof(buf), &needed_sz);
+    ASSERT_EQ(ENOENT, hse_err_to_errno(err));
+}
+
 MTF_DEFINE_UTEST(kvdb_api_test, param_null_kvdb)
 {
     hse_err_t err;

--- a/tests/functional/api/kvs_api_test.c
+++ b/tests/functional/api/kvs_api_test.c
@@ -548,6 +548,16 @@ MTF_DEFINE_UTEST_PREPOST(kvs_api_test, name_success, kvs_setup, kvs_teardown)
     ASSERT_STREQ(kvs_name, name);
 }
 
+MTF_DEFINE_UTEST_PREPOST(kvs_api_test, param_dnem, kvs_setup, kvs_teardown)
+{
+    hse_err_t err;
+    size_t    needed_sz;
+    char      buf[16];
+
+    err = hse_kvs_param_get(kvs_handle, "does.not.exist", buf, sizeof(buf), &needed_sz);
+    ASSERT_EQ(ENOENT, hse_err_to_errno(err));
+}
+
 MTF_DEFINE_UTEST(kvs_api_test, param_null_kvs)
 {
     hse_err_t err;

--- a/tests/unit/config/hse_gparams_test.c
+++ b/tests/unit/config/hse_gparams_test.c
@@ -419,7 +419,7 @@ MTF_DEFINE_UTEST(hse_gparams_test, get)
     ASSERT_STREQ("true", buf);
 
     err = hse_gparams_get(&p, "does.not.exist", buf, sizeof(buf), &needed_sz);
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     err = hse_gparams_get(NULL, "rest.enabled", buf, sizeof(buf), NULL);
     ASSERT_EQ(EINVAL, merr_errno(err));
@@ -446,7 +446,7 @@ MTF_DEFINE_UTEST(hse_gparams_test, set)
     ASSERT_EQ(EINVAL, merr_errno(err));
 
     err = hse_gparams_set(&p, "does.not.exist", "5");
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 }
 
 MTF_DEFINE_UTEST(hse_gparams_test, to_json)

--- a/tests/unit/config/param_test.c
+++ b/tests/unit/config/param_test.c
@@ -1165,7 +1165,7 @@ MTF_DEFINE_UTEST_PRE(param_test, get, test_pre)
     ASSERT_STREQ("true", buf);
 
     err = param_get(&p, pspecs, NELEM(pspecs), "does.not.exist", buf, sizeof(buf), NULL);
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     err = param_get(NULL, pspecs, NELEM(pspecs), "test1", buf, sizeof(buf), NULL);
     ASSERT_EQ(EINVAL, merr_errno(err));

--- a/tests/unit/kvdb/ikvdb_test.c
+++ b/tests/unit/kvdb/ikvdb_test.c
@@ -1994,7 +1994,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, get_param, test_pre, test_post)
     ASSERT_STREQ("\"rdwr\"", buf);
 
     err = ikvdb_param_get(kvdb, "does.not.exist", buf, sizeof(buf), NULL);
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     err = ikvdb_param_get(kvdb, "mode", NULL, 0, &needed_sz);
     ASSERT_EQ(0, merr_errno(err));
@@ -2047,7 +2047,7 @@ MTF_DEFINE_UTEST_PREPOST(ikvdb_test, get_kvs_param, test_pre, test_post)
     ASSERT_STREQ("0", buf);
 
     err = ikvdb_kvs_param_get(kvs, "does.not.exist", buf, sizeof(buf), NULL);
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     err = ikvdb_kvs_param_get(kvs, "prefix.length", NULL, 0, &needed_sz);
     ASSERT_EQ(0, merr_errno(err));

--- a/tests/unit/kvdb/kvdb_cparams_test.c
+++ b/tests/unit/kvdb/kvdb_cparams_test.c
@@ -376,7 +376,7 @@ MTF_DEFINE_UTEST(kvdb_cparams_test, get)
     ASSERT_STREQ("null", buf);
 
     err = kvdb_cparams_get(&p, "does.not.exist", buf, sizeof(buf), NULL);
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     err = kvdb_cparams_get(NULL, "storage.capacity.path", buf, sizeof(buf), NULL);
     ASSERT_EQ(EINVAL, merr_errno(err));

--- a/tests/unit/kvdb/kvdb_rparams_test.c
+++ b/tests/unit/kvdb/kvdb_rparams_test.c
@@ -969,7 +969,7 @@ MTF_DEFINE_UTEST(kvdb_rparams_test, get)
     ASSERT_STREQ("\"rdwr\"", buf);
 
     err = kvdb_rparams_get(&p, "does.not.exist", buf, sizeof(buf), NULL);
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     err = kvdb_rparams_get(NULL, "mode", buf, sizeof(buf), NULL);
     ASSERT_EQ(EINVAL, merr_errno(err));
@@ -1000,7 +1000,7 @@ MTF_DEFINE_UTEST(kvdb_rparams_test, set)
     ASSERT_EQ(76, p.csched_hi_th_pct);
 
     err = kvdb_rparams_set(&p, "does.not.exist", "5");
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     /* Fail to parse */
     err = kvdb_rparams_set(&p, "csched_hi_th_pct", "invalid");

--- a/tests/unit/kvs/kvs_cparams_test.c
+++ b/tests/unit/kvs/kvs_cparams_test.c
@@ -96,7 +96,7 @@ MTF_DEFINE_UTEST(kvs_cparams_test, get)
     ASSERT_STREQ("0", buf);
 
     err = kvs_cparams_get(&p, "does.not.exist", buf, sizeof(buf), NULL);
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     err = kvs_cparams_get(NULL, "prefix.length", buf, sizeof(buf), NULL);
     ASSERT_EQ(EINVAL, merr_errno(err));

--- a/tests/unit/kvs/kvs_rparams_test.c
+++ b/tests/unit/kvs/kvs_rparams_test.c
@@ -664,7 +664,7 @@ MTF_DEFINE_UTEST(kvs_rparams_test, get)
     ASSERT_STREQ("false", buf);
 
     err = kvs_rparams_get(&p, "does.not.exist", buf, sizeof(buf), NULL);
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     err = kvs_rparams_get(NULL, "transactions.enabled", buf, sizeof(buf), NULL);
     ASSERT_EQ(EINVAL, merr_errno(err));
@@ -695,7 +695,7 @@ MTF_DEFINE_UTEST(kvs_rparams_test, set)
     ASSERT_EQ(32768, p.cn_compact_kblk_ra);
 
     err = kvs_rparams_set(&p, "does.not.exist", "5");
-    ASSERT_EQ(EINVAL, merr_errno(err));
+    ASSERT_EQ(ENOENT, merr_errno(err));
 
     /* Fail to parse */
     err = kvs_rparams_set(&p, "cn_compact_kblk_ra", "invalid");


### PR DESCRIPTION
Previously the REST implementation would send back uninformative HTML pages in the event of an error (libevent default). Using RFC7807[^0], the REST server and various endpoints now emit more detailed errors about why a request failed.

[^0]: https://www.rfc-editor.org/rfc/rfc7807

Signed-off-by: Tristan Partin <tpartin@micron.com>
