### PR TITLE
Seek to last key when klast is non-zero

### DIFF
--- a/tools/capput/capput.c
+++ b/tools/capput/capput.c
@@ -459,7 +459,7 @@ reader(void *arg)
         if (err)
             fatal(err, "hse_kvs_cursor_create failure");
 
-        if (klast[0]) {
+        if (klast[1]) {
             klen = 0;
 
             ti->state = 's';


### PR DESCRIPTION
Signed-off-by: Gaurav Ramdasi <10132364+gsramdasi@users.noreply.github.com>

## Description
The reader in capput should seek to the last key whenever there is a last key.

## Issue(s) Addressed
NFSE-5405