### PR TITLE
Cap mblk_madvise() length for errant callers

### DIFF
--- a/lib/cn/kvs_mblk_desc.c
+++ b/lib/cn/kvs_mblk_desc.c
@@ -74,12 +74,18 @@ merr_t
 mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice)
 {
     int rc;
+    const size_t wlen = md->wlen_pages * PAGE_SIZE;
+
+    assert(md->map_base);
 
     if (len == 0)
         return 0;
 
-    assert(off + len <= md->wlen_pages * PAGE_SIZE);
-    assert(md->map_base);
+    if (off >= wlen)
+        return merr(EINVAL);
+
+    if (off + len > wlen)
+        len = wlen - off;
 
     /* Cast away the const of map_base for madvise().
      */

--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -2730,7 +2730,7 @@ kvset_madvise_capped(struct kvset *ks, int advice)
         for (uint j = 0; j < v->mbs_mblkc; j++) {
             struct vblock_desc *vbd = mbset_get_udata(v, j);
 
-            vbr_madvise_async(vbd, 0, vra_len, advice, wq);
+            vbr_madvise_async(vbd, 0, min_t(uint, vbd->vbd_len, vra_len), advice, wq);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
