### PR TITLE
Track/report csched stats and fix node removal and madvise bugs

### DIFF
--- a/lib/cn/cn.c
+++ b/lib/cn/cn.c
@@ -1111,10 +1111,10 @@ cn_open(
 
     cn_tree_samp_init(cn->cn_tree);
 
-    /* Increase the split size of the rightmost node to allow small
-     * tree on monotonically increasing load to leverage zspill.
+    /* Increase the split size of the rightmost node to allow
+     * monotonically increasing loads to better leverage zspill.
      */
-    tn->tn_split_size = (tn->tn_split_size * 3) / 2;
+    tn->tn_split_size += (8ul << 30);
 
     /* Enable tree maintenance unless it's deliberately disabled
      * or we're in replay, diag, or read-only mode.

--- a/lib/cn/cn_tree.c
+++ b/lib/cn/cn_tree.c
@@ -1643,6 +1643,8 @@ cn_comp_update_split(
                 kvset_list_add_tail(kvsets[k], &left->tn_kvset_list);
         }
 
+        left->tn_split_ns = get_time_ns() + 60 * NSEC_PER_SEC;
+        left->tn_split_ns += (left->tn_split_ns % 1048576) * 32;
         w->cw_split.nodev[LEFT] = left;
     }
 
@@ -1668,6 +1670,8 @@ cn_comp_update_split(
 
             assert(route_node_keycmp(w->cw_split.key, w->cw_split.klen, right->tn_route_node) < 0);
 
+            right->tn_split_ns = get_time_ns() + 60 * NSEC_PER_SEC;
+            right->tn_split_ns += (right->tn_split_ns % 1048576) * 32;
             w->cw_split.nodev[RIGHT] = right;
         }
 

--- a/lib/cn/cn_tree_internal.h
+++ b/lib/cn/cn_tree_internal.h
@@ -151,6 +151,7 @@ struct cn_tree_node {
     struct route_node   *tn_route_node;
     struct list_head     tn_link;
     size_t               tn_split_size;
+    uint64_t             tn_split_ns;
 
     struct list_head     tn_kvset_list HSE_L1D_ALIGNED;
     u64                  tn_update_incr_dgen;

--- a/lib/cn/csched.c
+++ b/lib/cn/csched.c
@@ -33,9 +33,14 @@ csched_destroy(struct csched *handle)
 }
 
 void
-csched_notify_ingest(struct csched *handle, struct cn_tree *tree, size_t alen)
+csched_notify_ingest(
+    struct csched *handle,
+    struct cn_tree *tree,
+    size_t alen,
+    size_t kwlen,
+    size_t vwlen)
 {
-    sp3_notify_ingest(handle, tree, alen);
+    sp3_notify_ingest(handle, tree, alen, kwlen, vwlen);
 }
 
 void

--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -6,6 +6,7 @@
 #define MTF_MOCK_IMPL_csched_sp3
 
 #include <bsd/string.h>
+#include <sys/resource.h>
 
 #include <hse/experimental.h>
 #include <hse/rest/headers.h>
@@ -277,6 +278,9 @@ struct sp3 {
     atomic_int       sp_ingest_count;
     atomic_int       sp_trees_count;
 
+    struct cn_merge_stats sp_mstatsv[CN_RULE_MAX] HSE_L1D_ALIGNED;
+    struct rusage sp_rusage;
+
     /* The following fields are rarely touched.
      */
     struct workqueue_struct *mon_wq;
@@ -409,7 +413,6 @@ sp3_log_progress(struct cn_compaction_work *w, struct cn_merge_stats *ms, bool f
 
     if (final) {
         msg_type = "final";
-        progress = (double)w->cw_stats.ms_keys_in / max_t(uint64_t, 1, est->cwe_keys);
         qt = w->cw_t1_qtime ? (w->cw_t1_qtime - w->cw_t0_enqueue) / 1000 : 0;
         pt = w->cw_t2_prep ? (w->cw_t2_prep - w->cw_t1_qtime) / 1000 : 0;
         bt = w->cw_t3_build ? (w->cw_t3_build - w->cw_t2_prep) / 1000 : 0;
@@ -417,29 +420,29 @@ sp3_log_progress(struct cn_compaction_work *w, struct cn_merge_stats *ms, bool f
 
     } else {
         msg_type = "progress";
-        progress = (double)w->cw_stats.ms_keys_in / max_t(uint64_t, 1, est->cwe_keys);
         qt = pt = bt = ct = 0;
     }
 
+    progress = (double)w->cw_stats.ms_keys_in / max_t(uint64_t, 1, est->cwe_keys);
     sts_job_progress_set(&w->cw_job, progress * 100);
 
     vblk_read_efficiency =
         safe_div(1.0 * ms->ms_val_bytes_out, ms->ms_vblk_read1.op_size + ms->ms_vblk_read2.op_size);
 
     log_info(
-        "type=%s job=%u comp=%s rule=%s "
+        "type=%s job=%u action=%s rule=%s "
         "cnid=%lu nodeid=%lu leaf=%u pct=%3.1f "
         "vrd_eff=%.3f "
-        "kblk_alloc_ops=%ld kblk_alloc_sz=%ld "
-        "kblk_alloc_ns=%ld kblk_write_ops=%ld kblk_write_sz=%ld "
-        "kblk_write_ns=%ld vblk_alloc_ops=%ld vblk_alloc_sz=%ld "
-        "vblk_alloc_ns=%ld vblk_write_ops=%ld vblk_write_sz=%ld "
-        "vblk_write_ns=%ld vblk_read1_ops=%ld vblk_read1_sz=%ld "
-        "vblk_read1_ns=%ld vblk_read1wait_ops=%ld vblk_read1wait_ns=%ld "
-        "vblk_read2_ops=%ld vblk_read2_sz=%ld vblk_read2_ns=%ld "
-        "vblk_read2wait_ops=%ld vblk_read2wait_ns=%ld "
-        "kblk_write_ops=%ld kblk_write_sz=%ld kblk_write_ns=%ld "
-        "kblk_readwait_ops=%ld kblk_readwait_ns=%ld "
+        "kblk_alloc_ops=%u kblk_alloc_sz=%ld "
+        "kblk_alloc_ms=%u kblk_write_ops=%u kblk_write_sz=%ld "
+        "kblk_write_ms=%u vblk_alloc_ops=%u vblk_alloc_sz=%ld "
+        "vblk_alloc_ms=%u vblk_write_ops=%u vblk_write_sz=%ld "
+        "vblk_write_ms=%u vblk_read1_ops=%u vblk_read1_sz=%ld "
+        "vblk_read1_ms=%u vblk_read1wait_ops=%u vblk_read1wait_ms=%u "
+        "vblk_read2_ops=%u vblk_read2_sz=%ld vblk_read2_ms=%u "
+        "vblk_read2wait_ops=%u vblk_read2wait_ms=%u "
+        "kblk_write_ops=%u kblk_write_sz=%ld kblk_write_ms=%u "
+        "kblk_readwait_ops=%u kblk_readwait_ms=%u "
         "vblk_dbl_reads=%ld "
         "queue_us=%lu prep_us=%lu build_us=%lu commit_us=%lu",
         msg_type, w->cw_job.sj_id, cn_action2str(w->cw_action), cn_rule2str(w->cw_rule),
@@ -1055,6 +1058,8 @@ sp3_process_workitem(struct sp3 *sp, struct cn_compaction_work *w)
         tree->ct_rspill_dt = (tree->ct_rspill_dt + dt) / 2;
     }
 
+    cn_merge_stats_add(&sp->sp_mstatsv[w->cw_rule], &w->cw_stats);
+
     if (w->cw_debug & (CW_DEBUG_PROGRESS | CW_DEBUG_FINAL))
         sp3_log_progress(w, &w->cw_stats, true);
 
@@ -1516,6 +1521,9 @@ sp3_comp_thread_name(
     case CN_RULE_JOIN:
         r = "nj";
         break;
+    case CN_RULE_MAX:
+        r = "xx";
+        break;
     }
 
     snprintf(buf, bufsz, "hse_%s_%s_%lu", a, r, nodeid);
@@ -1717,6 +1725,9 @@ sp3_submit(struct sp3 *sp, struct cn_compaction_work *w, uint qnum)
     w->cw_prog_interval = nsecs_to_jiffies(NSEC_PER_SEC);
     w->cw_debug = csched_rp_dbg_comp(sp->rp);
     w->cw_qnum = qnum;
+
+    memset(&w->cw_stats, 0, sizeof(w->cw_stats));
+    w->cw_stats.ms_jobs = 1;
 
     cn_samp_add(&sp->samp_wip, &w->cw_est.cwe_samp);
 
@@ -2548,16 +2559,27 @@ sp3_compact_status_get(struct csched *handle, struct hse_kvdb_compact_status *st
  * sp3_notify_ingest() - External API: notify ingest job has completed
  */
 void
-sp3_notify_ingest(struct csched *handle, struct cn_tree *tree, size_t alen)
+sp3_notify_ingest(
+    struct csched *handle,
+    struct cn_tree *tree,
+    size_t alen,
+    size_t kwlen,
+    size_t vwlen)
 {
     struct sp3 *sp = (struct sp3 *)handle;
     struct sp3_tree *spt = tree2spt(tree);
+    struct cn_merge_stats *stats;
 
     if (!sp)
         return;
 
     if (alen == 0)
         abort();
+
+    stats = &sp->sp_mstatsv[CN_RULE_INGEST];
+    atomic_add((atomic_uint *)&stats->ms_jobs, 1);
+    atomic_add((atomic_ulong *)&stats->ms_kblk_write.op_size, kwlen);
+    atomic_add((atomic_ulong *)&stats->ms_vblk_write.op_size, vwlen);
 
     if (atomic_add_return(&spt->spt_ingest_alen, alen) == 0) {
         atomic_inc_rel(&sp->sp_ingest_count);
@@ -2673,6 +2695,44 @@ sp3_destroy(struct csched *handle)
 
     rest_server_remove_endpoint(ENDPOINT_FMT_KVDB_CSCED, sp->kvdb_alias);
 
+    if (1) {
+        struct rusage ru;
+
+        log_info("%8s %6s %12s %12s %7s %7s %7s %7s",
+                 "rule", "jobs",  "keysin", "keysout", "kbr", "kbw", "vbr", "vbw");
+
+        for (enum cn_rule r = CN_RULE_NONE; r < CN_RULE_MAX; ++r) {
+            const struct cn_merge_stats *stats = &sp->sp_mstatsv[CN_RULE_MAX - 1 - r];
+
+            if (stats->ms_jobs == 0)
+                continue;
+
+            log_info("%8s %6u %12lu %12lu %7lu %7lu %7lu %7lu",
+                     (stats == sp->sp_mstatsv) ? "total" : cn_rule2str(stats - sp->sp_mstatsv),
+                     stats->ms_jobs,
+                     stats->ms_keys_in, stats->ms_keys_out,
+                     stats->ms_kblk_read.op_size >> 20,
+                     stats->ms_kblk_write.op_size >> 20,
+                     (stats->ms_vblk_read1.op_size +
+                      stats->ms_vblk_read2.op_size) >> 20,
+                     stats->ms_vblk_write.op_size >> 20);
+
+            cn_merge_stats_add(&sp->sp_mstatsv[CN_RULE_NONE], stats);
+        }
+
+        getrusage(RUSAGE_SELF, &ru);
+
+        ru.ru_minflt -= sp->sp_rusage.ru_minflt;
+        ru.ru_majflt -= sp->sp_rusage.ru_majflt;
+        ru.ru_nswap -= sp->sp_rusage.ru_nswap;
+        ru.ru_inblock -= sp->sp_rusage.ru_inblock;
+        ru.ru_oublock -= sp->sp_rusage.ru_inblock;
+
+        log_info("minflt %lu, majflt %lu, nswap %lu, inbytes %lu, outbytes %lu",
+                 ru.ru_minflt, ru.ru_majflt,ru.ru_nswap,
+                 ru.ru_inblock * 512, ru.ru_oublock * 512);
+    }
+
     free(sp->wp);
     free(sp);
 }
@@ -2744,6 +2804,7 @@ sp3_create(
         goto err_exit;
     }
 
+    getrusage(RUSAGE_SELF, &sp->sp_rusage);
     sp->kvdb_alias = kvdb_alias;
 
     if (hse_gparams.gp_rest.enabled) {

--- a/lib/cn/csched_sp3.h
+++ b/lib/cn/csched_sp3.h
@@ -84,7 +84,12 @@ void
 sp3_compact_status_get(struct csched *handle, struct hse_kvdb_compact_status *status);
 
 void
-sp3_notify_ingest(struct csched *handle, struct cn_tree *tree, size_t alen);
+sp3_notify_ingest(
+    struct csched *handle,
+    struct cn_tree *tree,
+    size_t alen,
+    size_t kwlen,
+    size_t vmlen);
 
 void
 sp3_tree_add(struct csched *handle, struct cn_tree *tree);

--- a/lib/cn/csched_sp3_work.c
+++ b/lib/cn/csched_sp3_work.c
@@ -405,7 +405,7 @@ sp3_work_wtype_idle(
 bool
 sp3_work_splittable(struct cn_tree_node *tn, const struct sp3_thresholds *thresh)
 {
-    return !tn->tn_ss_joining && (cn_ns_kvsets(&tn->tn_ns) > 0) &&
+    return !tn->tn_ss_joining && (jclock_ns > tn->tn_split_ns) &&
         (cn_ns_wlen(&tn->tn_ns) >= tn->tn_split_size ||
          cn_ns_keys_uniq(&tn->tn_ns) >= thresh->lcomp_split_keys);
 }
@@ -859,7 +859,7 @@ sp3_work_wtype_length(
          * a small number of keys.
          */
         if (kvsets > runlen_max) {
-            uint64_t keys_max = 32ul << 20;
+            uint64_t keys_max = 16ul << 20;
 
             *action = CN_ACTION_COMPACT_K;
             *rule = CN_RULE_COMPC;
@@ -869,7 +869,7 @@ sp3_work_wtype_length(
             list_for_each_entry(le, head, le_link) {
                 const struct kvset_stats *stats = kvset_statsp(le->le_kvset);
 
-                if (stats->kst_keys > keys_max)
+                if (stats->kst_keys > keys_max / 2)
                     break;
 
                 keys_max -= stats->kst_keys;

--- a/lib/cn/csched_sp3_work.h
+++ b/lib/cn/csched_sp3_work.h
@@ -17,7 +17,7 @@
  */
 #define SP3_RSPILL_RUNLEN_MIN           (1u) /* root spill requires at least 1 kvset */
 #define SP3_RSPILL_RUNLEN_MAX           (UINT8_MAX)
-#define SP3_RSPILL_RUNLEN_MIN_DEFAULT   (5u)
+#define SP3_RSPILL_RUNLEN_MIN_DEFAULT   (7u)
 #define SP3_RSPILL_RUNLEN_MAX_DEFAULT   (9u)
 
 #define SP3_RSPILL_WLEN_MIN             (0u)

--- a/lib/cn/kvs_mblk_desc.h
+++ b/lib/cn/kvs_mblk_desc.h
@@ -26,6 +26,7 @@ struct kvs_mblk_desc {
     uint64_t mbid;          // mblock id
     uint16_t alen_pages;    // allocated length of mblock, in 4K pages
     uint16_t wlen_pages;    // written length of mblock, in 4K pages
+    uint16_t ra_pages;      // max readahead pages
     uint8_t  mclass;        // media class
 };
 
@@ -43,10 +44,6 @@ mblk_mmap(struct mpool *mp, uint64_t mbid, struct kvs_mblk_desc *md_out);
 /* MTF_MOCK */
 merr_t
 mblk_munmap(struct mpool *mp, struct kvs_mblk_desc *md);
-
-/* MTF_MOCK */
-merr_t
-mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice);
 
 /* MTF_MOCK */
 merr_t

--- a/lib/cn/vblock_reader.c
+++ b/lib/cn/vblock_reader.c
@@ -221,7 +221,7 @@ vbr_madvise_async(
 void
 vbr_madvise(struct vblock_desc *vbd, uint off, uint len, int advice)
 {
-    mblk_madvise(vbd->vbd_mblkdesc, off, len, advice);
+    mblk_madvise_pages(vbd->vbd_mblkdesc, off / PAGE_SIZE, len / PAGE_SIZE, advice);
 }
 
 /* off, len version */

--- a/lib/include/hse/ikvdb/csched.h
+++ b/lib/include/hse/ikvdb/csched.h
@@ -63,6 +63,7 @@ enum cn_rule {
     CN_RULE_LSPLIT,         /* left node kvset after a split */
     CN_RULE_RSPLIT,         /* right ndoe kvset after a split */
     CN_RULE_JOIN,           /* prev node is very small */
+    CN_RULE_MAX,
 };
 
 static inline const char *
@@ -113,10 +114,18 @@ cn_rule2str(enum cn_rule rule)
         return "right";
     case CN_RULE_JOIN:
         return "join";
+    case CN_RULE_MAX:
+        return "max";
     }
 
     return "invalid";
 }
+
+struct cn_rule_stats {
+    uint64_t read_bytes;
+    uint64_t write_bytes;
+    uint64_t jobs;
+};
 
 /* Default threads-per-queue for csched_qthreads kvdb rparam.
  */
@@ -151,7 +160,12 @@ csched_destroy(struct csched *csched);
 
 /* MTF_MOCK */
 void
-csched_notify_ingest(struct csched *handle, struct cn_tree *tree, size_t alen);
+csched_notify_ingest(
+    struct csched *handle,
+    struct cn_tree *tree,
+    size_t alen,
+    size_t kwlen,
+    size_t vwlen);
 
 /* MTF_MOCK */
 void

--- a/lib/include/hse/ikvdb/csched_rp.h
+++ b/lib/include/hse/ikvdb/csched_rp.h
@@ -20,6 +20,7 @@
 #define csched_rp_dbg_qos(_rp)        ((bool)((_rp)->csched_debug_mask & 0x0010))
 #define csched_rp_dbg_sched(_rp)      ((bool)((_rp)->csched_debug_mask & 0x0020))
 #define csched_rp_dbg_tree_shape(_rp) ((bool)((_rp)->csched_debug_mask & 0x0040))
+#define csched_rp_dbg_stats(_rp)      ((bool)((_rp)->csched_debug_mask & 0x0080))
 
 #define csched_rp_dbg_dirty_node(_rp) ((bool)((_rp)->csched_debug_mask & 0x0400))
 #define csched_rp_dbg_tree_life(_rp)  ((bool)((_rp)->csched_debug_mask & 0x0800))

--- a/lib/include/hse/ikvdb/kvdb_rparams.h
+++ b/lib/include/hse/ikvdb/kvdb_rparams.h
@@ -46,7 +46,6 @@
  * fields towards the end.
  */
 struct kvdb_rparams {
-    enum kvdb_open_mode mode;
     bool    throttle_disable;
     uint8_t perfc_level;
     uint8_t perfc_enable;
@@ -100,6 +99,7 @@ struct kvdb_rparams {
     uint32_t cndb_compact_hwm_pct;
 
     uint32_t keylock_tables;
+    enum kvdb_open_mode mode;
 
     bool   dio_enable[HSE_MCLASS_COUNT];
     struct mclass_policy mclass_policies[HSE_MPOLICY_COUNT];

--- a/lib/include/hse/ikvdb/limits.h
+++ b/lib/include/hse/ikvdb/limits.h
@@ -92,6 +92,11 @@
 #define HSE_LOWMEM_THRESHOLD_GB_DFLT   (32ul)
 #define HSE_LOWMEM_THRESHOLD_GB_MAX    (64ul)
 
+/* TODO: Get this from /sys/block/{device}/queue/read_ahead_kb
+ * and store in kvs_mblk_desc for calls to madvise().
+ */
+#define HSE_RA_PAGES_MAX               ((128 * 1024) / PAGE_SIZE)
+
 /* clang-format on */
 
 #endif

--- a/lib/kvdb/ikvdb.c
+++ b/lib/kvdb/ikvdb.c
@@ -1289,13 +1289,17 @@ ikvdb_lowmem_adjust(struct ikvdb_impl *self, ulong memgb)
         rp->dur_bufsz_mb =
             min_t(uint32_t, HSE_WAL_DUR_BUFSZ_MB_MIN * scale, HSE_WAL_DUR_BUFSZ_MB_MAX);
 
+    if (rp->c0_ingest_threads == rpdef.c0_ingest_threads)
+        rp->c0_ingest_threads = HSE_C0_INGEST_THREADS_MIN;
+
     if (rp->c0_ingest_width == rpdef.c0_ingest_width)
         rp->c0_ingest_width = HSE_C0_INGEST_WIDTH_MIN;
 
     log_debug("Low mem config settings for %s: c0kvs_cache %lu c0kvs_cheap %lu "
-              "c0_width %u dur_bufsz_mb %u vlb cache %lu",
+              "c0_ingest_threads %u c0_width %u dur_bufsz_mb %u vlb cache %lu",
               self->ikdb_home, hse_gparams.gp_c0kvs_ccache_sz_max, hse_gparams.gp_c0kvs_cheap_sz,
-              rp->c0_ingest_width, rp->dur_bufsz_mb, hse_gparams.gp_vlb_cache_sz);
+              rp->c0_ingest_threads, rp->c0_ingest_width,
+              rp->dur_bufsz_mb, hse_gparams.gp_vlb_cache_sz);
 }
 
 static void

--- a/lib/kvdb/kvdb_rparams.c
+++ b/lib/kvdb/kvdb_rparams.c
@@ -918,12 +918,12 @@ static const struct param_spec pspecs[] = {
         .ps_stringify = param_default_stringify,
         .ps_jsonify = param_default_jsonify,
         .ps_default_value = {
-            .as_uscalar = 64,
+            .as_uscalar = UINT8_MAX,
         },
         .ps_bounds = {
             .as_uscalar = {
                 .ps_min = 1,
-                .ps_max = 255,
+                .ps_max = UINT8_MAX,
             },
         },
     },

--- a/lib/kvs/kvs_rparams.c
+++ b/lib/kvs/kvs_rparams.c
@@ -208,7 +208,7 @@ static const struct param_spec pspecs[] = {
         .ps_stringify = param_default_stringify,
         .ps_jsonify = param_default_jsonify,
         .ps_default_value = {
-            .as_uscalar = 19,
+            .as_uscalar = 23,
         },
         .ps_bounds = {
             .as_uscalar = {

--- a/tests/unit/cn/hblock_reader_test.c
+++ b/tests/unit/cn/hblock_reader_test.c
@@ -112,15 +112,6 @@ init_hblock(struct hblock_hdr_omf *hbh)
 }
 
 merr_t
-mock_mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice)
-{
-    madvise_off = off;
-    madvise_len = len;
-    madvise_advice = advice;
-    return 0;
-}
-
-merr_t
 mock_mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg_off, size_t pg_cnt, int advice)
 {
     madvise_off = pg_off * PAGE_SIZE;
@@ -148,7 +139,6 @@ test_pre(struct mtf_test_info *info)
     madvise_len = 12345;
     madvise_advice = 12345;
 
-    MOCK_SET_FN(mblk_desc, mblk_madvise, mock_mblk_madvise);
     MOCK_SET_FN(mblk_desc, mblk_madvise_pages, mock_mblk_madvise_pages);
 
     return 0;

--- a/tests/unit/cn/kblock_reader_test.c
+++ b/tests/unit/cn/kblock_reader_test.c
@@ -143,15 +143,6 @@ init_kblock(struct kblock_hdr_omf *kbh)
 }
 
 merr_t
-mock_mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice)
-{
-    madvise_off = off;
-    madvise_len = len;
-    madvise_advice = advice;
-    return 0;
-}
-
-merr_t
 mock_mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg_off, size_t pg_cnt, int advice)
 {
     madvise_off = pg_off * PAGE_SIZE;
@@ -179,7 +170,6 @@ pre(struct mtf_test_info *info)
     madvise_len = 12345;
     madvise_advice = 12345;
 
-    MOCK_SET_FN(mblk_desc, mblk_madvise, mock_mblk_madvise);
     MOCK_SET_FN(mblk_desc, mblk_madvise_pages, mock_mblk_madvise_pages);
 
     return 0;

--- a/tests/unit/cn/mbset_test.c
+++ b/tests/unit/cn/mbset_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <sys/mman.h>
@@ -70,7 +70,6 @@ static int
 pre(struct mtf_test_info *mtf)
 {
     mapi_inject(mapi_idx_mpool_mblock_delete, 0);
-    mapi_inject(mapi_idx_mblk_madvise, 0);
     MOCK_SET_FN(mblk_desc, mblk_mmap, mocked_mblk_mmap);
     MOCK_SET_FN(mblk_desc, mblk_munmap, mocked_mblk_munmap);
 

--- a/tests/unit/kvdb/kvdb_rparams_test.c
+++ b/tests/unit/kvdb/kvdb_rparams_test.c
@@ -326,9 +326,9 @@ MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, csched_lscat_hwm, test_pre)
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
-    ASSERT_EQ(64, params.csched_lscat_hwm);
+    ASSERT_EQ(UINT8_MAX, params.csched_lscat_hwm);
     ASSERT_EQ(1, ps->ps_bounds.as_uscalar.ps_min);
-    ASSERT_EQ(255, ps->ps_bounds.as_uscalar.ps_max);
+    ASSERT_EQ(UINT8_MAX, ps->ps_bounds.as_uscalar.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, csched_lscat_runlen_max, test_pre)

--- a/tests/unit/kvs/kvs_rparams_test.c
+++ b/tests/unit/kvs/kvs_rparams_test.c
@@ -165,7 +165,7 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_split_size, test_pre)
     ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
     ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
     ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
-    ASSERT_EQ(19, params.cn_split_size);
+    ASSERT_EQ(23, params.cn_split_size);
     ASSERT_EQ(8, ps->ps_bounds.as_uscalar.ps_min);
     ASSERT_EQ(1024, ps->ps_bounds.as_uscalar.ps_max);
 
@@ -173,7 +173,7 @@ MTF_DEFINE_UTEST_PRE(kvs_rparams_test, cn_split_size, test_pre)
     err = check(
         "cn_split_size=7", false,
         "cn_split_size=8", true,
-        "cn_split_size=19", true,
+        "cn_split_size=23", true,
         "cn_split_size=1024", true,
         "cn_split_size=1025", false,
         NULL


### PR DESCRIPTION
- Track compaction stats by rule. Report compaction stats at kvdb close time (by rule and totals).
- Fix bug that leaves empty nodes in the tree, and errantly removes empty nodes still on either the active or stable dirty list.
