### PR TITLE
Fix madvise readahead and csched node removal bugs

### DIFF
--- a/lib/cn/csched_sp3.c
+++ b/lib/cn/csched_sp3.c
@@ -1146,7 +1146,7 @@ sp3_process_dirtylist(struct sp3 *sp)
                  * it until the next call to sp3_process_dirtylist().
                  */
                 mutex_lock(&sp->sp_dlist_lock);
-                busy = list_empty(&tn->tn_dnode_linkv[i]);
+                busy = !list_empty(&tn->tn_dnode_linkv[i]);
                 mutex_unlock(&sp->sp_dlist_lock);
 
                 if (busy) {

--- a/lib/cn/kvs_mblk_desc.h
+++ b/lib/cn/kvs_mblk_desc.h
@@ -26,6 +26,7 @@ struct kvs_mblk_desc {
     uint64_t mbid;          // mblock id
     uint16_t alen_pages;    // allocated length of mblock, in 4K pages
     uint16_t wlen_pages;    // written length of mblock, in 4K pages
+    uint16_t ra_pages;      // max readahead pages
     uint8_t  mclass;        // media class
 };
 
@@ -43,10 +44,6 @@ mblk_mmap(struct mpool *mp, uint64_t mbid, struct kvs_mblk_desc *md_out);
 /* MTF_MOCK */
 merr_t
 mblk_munmap(struct mpool *mp, struct kvs_mblk_desc *md);
-
-/* MTF_MOCK */
-merr_t
-mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice);
 
 /* MTF_MOCK */
 merr_t

--- a/lib/cn/vblock_reader.c
+++ b/lib/cn/vblock_reader.c
@@ -221,7 +221,7 @@ vbr_madvise_async(
 void
 vbr_madvise(struct vblock_desc *vbd, uint off, uint len, int advice)
 {
-    mblk_madvise(vbd->vbd_mblkdesc, off, len, advice);
+    mblk_madvise_pages(vbd->vbd_mblkdesc, off / PAGE_SIZE, len / PAGE_SIZE, advice);
 }
 
 /* off, len version */

--- a/lib/include/hse/ikvdb/limits.h
+++ b/lib/include/hse/ikvdb/limits.h
@@ -92,6 +92,11 @@
 #define HSE_LOWMEM_THRESHOLD_GB_DFLT   (32ul)
 #define HSE_LOWMEM_THRESHOLD_GB_MAX    (64ul)
 
+/* TODO: Get this from /sys/block/{device}/queue/read_ahead_kb
+ * and store in kvs_mblk_desc for calls to madvise().
+ */
+#define HSE_RA_PAGES_MAX               ((128 * 1024) / PAGE_SIZE)
+
 /* clang-format on */
 
 #endif

--- a/tests/unit/cn/hblock_reader_test.c
+++ b/tests/unit/cn/hblock_reader_test.c
@@ -112,15 +112,6 @@ init_hblock(struct hblock_hdr_omf *hbh)
 }
 
 merr_t
-mock_mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice)
-{
-    madvise_off = off;
-    madvise_len = len;
-    madvise_advice = advice;
-    return 0;
-}
-
-merr_t
 mock_mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg_off, size_t pg_cnt, int advice)
 {
     madvise_off = pg_off * PAGE_SIZE;
@@ -148,7 +139,6 @@ test_pre(struct mtf_test_info *info)
     madvise_len = 12345;
     madvise_advice = 12345;
 
-    MOCK_SET_FN(mblk_desc, mblk_madvise, mock_mblk_madvise);
     MOCK_SET_FN(mblk_desc, mblk_madvise_pages, mock_mblk_madvise_pages);
 
     return 0;

--- a/tests/unit/cn/kblock_reader_test.c
+++ b/tests/unit/cn/kblock_reader_test.c
@@ -143,15 +143,6 @@ init_kblock(struct kblock_hdr_omf *kbh)
 }
 
 merr_t
-mock_mblk_madvise(const struct kvs_mblk_desc *md, size_t off, size_t len, int advice)
-{
-    madvise_off = off;
-    madvise_len = len;
-    madvise_advice = advice;
-    return 0;
-}
-
-merr_t
 mock_mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg_off, size_t pg_cnt, int advice)
 {
     madvise_off = pg_off * PAGE_SIZE;
@@ -179,7 +170,6 @@ pre(struct mtf_test_info *info)
     madvise_len = 12345;
     madvise_advice = 12345;
 
-    MOCK_SET_FN(mblk_desc, mblk_madvise, mock_mblk_madvise);
     MOCK_SET_FN(mblk_desc, mblk_madvise_pages, mock_mblk_madvise_pages);
 
     return 0;

--- a/tests/unit/cn/mbset_test.c
+++ b/tests/unit/cn/mbset_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <sys/mman.h>
@@ -70,7 +70,6 @@ static int
 pre(struct mtf_test_info *mtf)
 {
     mapi_inject(mapi_idx_mpool_mblock_delete, 0);
-    mapi_inject(mapi_idx_mblk_madvise, 0);
     MOCK_SET_FN(mblk_desc, mblk_mmap, mocked_mblk_mmap);
     MOCK_SET_FN(mblk_desc, mblk_munmap, mocked_mblk_munmap);
 


### PR DESCRIPTION
Signed-off-by: Greg Becker <gbecker@micron.com>
