### PR TITLE
Query read-ahead size from sysfs (NFSE-5410)

### DIFF
--- a/lib/cn/kvs_mblk_desc.c
+++ b/lib/cn/kvs_mblk_desc.c
@@ -91,9 +91,10 @@ mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg, size_t pg_cnt, int
         return 0;
 
     ra_pages = (advice == MADV_WILLNEED) ? md->ra_pages : pg_cnt;
-    ev(!ra_pages);
+    if (ev(!ra_pages))
+        return 0;
 
-    for (size_t pg_end = pg + pg_cnt; ra_pages && (pg < pg_end); pg += chunk) {
+    for (size_t pg_end = pg + pg_cnt; pg < pg_end; pg += chunk) {
         int rc;
 
         chunk = min_t(size_t, pg_end - pg, ra_pages);

--- a/lib/cn/kvs_mblk_desc.c
+++ b/lib/cn/kvs_mblk_desc.c
@@ -43,7 +43,7 @@ mblk_mmap(struct mpool *mp, uint64_t mbid, struct kvs_mblk_desc *md)
     md->map_base = (void *)base;
     md->alen_pages = props.mpr_alloc_cap / PAGE_SIZE;
     md->wlen_pages = props.mpr_write_len / PAGE_SIZE;
-    md->ra_pages = HSE_RA_PAGES_MAX;
+    md->ra_pages = props.mpr_ra_pages;
     md->mclass = props.mpr_mclass;
     md->mbid = mbid;
 
@@ -91,8 +91,9 @@ mblk_madvise_pages(const struct kvs_mblk_desc *md, size_t pg, size_t pg_cnt, int
         return 0;
 
     ra_pages = (advice == MADV_WILLNEED) ? md->ra_pages : pg_cnt;
+    ev(!ra_pages);
 
-    for (size_t pg_end = pg + pg_cnt; pg < pg_end; pg += chunk) {
+    for (size_t pg_end = pg + pg_cnt; ra_pages && (pg < pg_end); pg += chunk) {
         int rc;
 
         chunk = min_t(size_t, pg_end - pg, ra_pages);

--- a/lib/include/hse/ikvdb/limits.h
+++ b/lib/include/hse/ikvdb/limits.h
@@ -92,11 +92,6 @@
 #define HSE_LOWMEM_THRESHOLD_GB_DFLT   (32ul)
 #define HSE_LOWMEM_THRESHOLD_GB_MAX    (64ul)
 
-/* TODO: Get this from /sys/block/{device}/queue/read_ahead_kb
- * and store in kvs_mblk_desc for calls to madvise().
- */
-#define HSE_RA_PAGES_MAX               ((128 * 1024) / PAGE_SIZE)
-
 /* clang-format on */
 
 #endif

--- a/lib/mpool/include/hse/mpool/mpool_structs.h
+++ b/lib/mpool/include/hse/mpool/mpool_structs.h
@@ -34,10 +34,6 @@
 #define MPOOL_MBLOCK_PREALLOC   (1u << 0)   /* advisory */
 #define MPOOL_MBLOCK_PUNCH_HOLE (1u << 1)
 
-#define MPOOL_RA_PAGES_MIN      0
-#define MPOOL_RA_PAGES_MAX      ((1024 * 1024) / PAGE_SIZE)
-#define MPOOL_RA_PAGES_DFLT     ((128 * 1024) / PAGE_SIZE)
-
 /**
  * struct mpool_cparams - mpool create params
  *

--- a/lib/mpool/include/hse/mpool/mpool_structs.h
+++ b/lib/mpool/include/hse/mpool/mpool_structs.h
@@ -14,6 +14,7 @@
 #include <hse/types.h>
 
 #include <hse/util/storage.h>
+#include <hse/util/page.h>
 
 #define WAL_FILE_PFX           "wal"
 #define WAL_FILE_PFX_LEN       (sizeof(WAL_FILE_PFX) - 1)
@@ -32,6 +33,10 @@
 /* Both prealloc and punch hole flags are mutually exclusive */
 #define MPOOL_MBLOCK_PREALLOC   (1u << 0)   /* advisory */
 #define MPOOL_MBLOCK_PUNCH_HOLE (1u << 1)
+
+#define MPOOL_RA_PAGES_MIN      0
+#define MPOOL_RA_PAGES_MAX      ((1024 * 1024) / PAGE_SIZE)
+#define MPOOL_RA_PAGES_DFLT     ((128 * 1024) / PAGE_SIZE)
 
 /**
  * struct mpool_cparams - mpool create params
@@ -90,6 +95,7 @@ struct mpool_info {
 struct mpool_mclass_props {
     uint64_t mc_fmaxsz;
     uint32_t mc_mblocksz;
+    uint16_t mc_ra_pages;
     uint8_t  mc_filecnt;
     char     mc_path[PATH_MAX];
 };
@@ -110,12 +116,14 @@ struct mpool_props {
  * @mpr_alloc_cap:    allocated capacity in bytes
  * @mpr_write_len:    written user-data in bytes
  * @mpr_mclass:       media class
+ * @mpr_ra_pages:     read-ahead size in pages
  */
 struct mblock_props {
     uint64_t mpr_objid;
     uint32_t mpr_alloc_cap;
     uint32_t mpr_write_len;
     uint32_t mpr_mclass;
+    uint16_t mpr_ra_pages;
 };
 
 struct mpool_file_cb {

--- a/lib/mpool/lib/mblock.c
+++ b/lib/mpool/lib/mblock.c
@@ -85,6 +85,7 @@ merr_t
 mpool_mblock_props_get(struct mpool *mp, uint64_t mbid, struct mblock_props *props)
 {
     struct media_class *mc;
+    merr_t err;
 
     if (!mp)
         return merr(EINVAL);
@@ -93,7 +94,14 @@ mpool_mblock_props_get(struct mpool *mp, uint64_t mbid, struct mblock_props *pro
     if (!mc)
         return merr(ENOENT);
 
-    return mblock_fset_find(mclass_fset(mc), &mbid, 1, props);
+    err = mblock_fset_find(mclass_fset(mc), &mbid, 1, props);
+    if (err)
+        return err;
+
+    if (props)
+        props->mpr_ra_pages = mclass_ra_pages(mc);
+
+    return 0;
 }
 
 merr_t

--- a/lib/mpool/lib/mclass.c
+++ b/lib/mpool/lib/mclass.c
@@ -4,6 +4,7 @@
  */
 
 #include <ftw.h>
+#include <sys/sysmacros.h>
 
 #include <bsd/string.h>
 
@@ -11,6 +12,8 @@
 #include <hse/logging/logging.h>
 #include <hse/util/workqueue.h>
 #include <hse/util/assert.h>
+#include <hse/util/log2.h>
+#include <hse/util/minmax.h>
 
 #include <hse/mpool/mpool_structs.h>
 
@@ -38,9 +41,58 @@ struct media_class {
     enum mclass_id      mcid;
     bool                gclose;
     bool                directio;
+    uint16_t            ra_pages;
     char *              dpath;
     char *              upath;
 };
+
+static merr_t
+get_read_ahead_pages(DIR *dirp, uint16_t *ra_pages)
+{
+    struct stat sbuf;
+    unsigned int major, minor;
+    char buf[PATH_MAX];
+    char line[16];
+    int fd, rc, n;
+    FILE *fp;
+
+    fd = dirfd(dirp);
+    if (fd == -1)
+        return merr(errno);
+
+    rc = fstat(fd, &sbuf);
+    if (rc == -1)
+        return merr(errno);
+
+    *ra_pages = MPOOL_RA_PAGES_DFLT;
+
+    major = major(sbuf.st_dev);
+    minor = minor(sbuf.st_dev);
+
+    n = snprintf(buf, sizeof(buf), "/sys/dev/block/%u:%u/queue/read_ahead_kb", major, minor);
+    if (ev(n < 0 || n >= sizeof(buf)))
+        return 0;
+
+    fp = fopen(buf, "r");
+    if (ev(!fp))
+        return 0;
+
+    if (fgets(line, sizeof(line), fp)) {
+        uint32_t val;
+
+        n = sscanf(line, "%u", &val);
+        if (n == 1) {
+            val >>= (ilog2(PAGE_SIZE) - 10);
+            *ra_pages = clamp_t(uint32_t, val, MPOOL_RA_PAGES_MIN, MPOOL_RA_PAGES_MAX);
+        } else {
+            ev(1);
+        }
+    }
+
+    fclose(fp);
+
+    return 0;
+}
 
 merr_t
 mclass_open(
@@ -50,8 +102,8 @@ mclass_open(
     struct media_class **       handle)
 {
     struct media_class *mc;
-    DIR *               dirp;
-    merr_t              err;
+    merr_t err;
+    DIR *dirp;
 
     if (!params || !handle || mclass >= HSE_MCLASS_COUNT)
         return merr(EINVAL);
@@ -71,6 +123,10 @@ mclass_open(
 
     mc->dirp = dirp;
     mc->mcid = mclass_to_mcid(mclass);
+
+    err = get_read_ahead_pages(dirp, &mc->ra_pages);
+    if (err)
+        goto err_exit1;
 
     mc->mblocksz = powerof2(params->mblocksz) ? params->mblocksz : MPOOL_MBLOCK_SIZE_DEFAULT;
 
@@ -291,19 +347,19 @@ mclass_destroy(const char *path, struct workqueue_struct *wq)
 }
 
 int
-mclass_id(struct media_class *mc)
+mclass_id(const struct media_class *mc)
 {
     return mc ? mc->mcid : MCID_INVALID;
 }
 
 int
-mclass_dirfd(struct media_class *mc)
+mclass_dirfd(const struct media_class *mc)
 {
     return mc ? dirfd(mc->dirp) : -1;
 }
 
 const char *
-mclass_dpath(struct media_class *mc)
+mclass_dpath(const struct media_class *mc)
 {
     return mc ? mc->dpath : NULL;
 }
@@ -315,19 +371,25 @@ mclass_upath(const struct media_class *const mc)
 }
 
 struct mblock_fset *
-mclass_fset(struct media_class *mc)
+mclass_fset(const struct media_class *mc)
 {
     return mc ? mc->mbfsp : NULL;
 }
 
+uint16_t
+mclass_ra_pages(const struct media_class *mc)
+{
+    return mc ? mc->ra_pages : MPOOL_RA_PAGES_DFLT;
+}
+
 bool
-mclass_supports_directio(struct media_class *mc)
+mclass_supports_directio(const struct media_class *mc)
 {
     return mc ? mc->directio : true;
 }
 
 size_t
-mclass_mblocksz_get(struct media_class *mc)
+mclass_mblocksz_get(const struct media_class *mc)
 {
     return mc ? mc->mblocksz : 0;
 }
@@ -351,7 +413,7 @@ mclass_gclose_set(struct media_class *mc)
 }
 
 bool
-mclass_gclose_get(struct media_class *mc)
+mclass_gclose_get(const struct media_class *mc)
 {
     return mc ? mc->gclose : false;
 }
@@ -406,7 +468,7 @@ mclass_io_ops_set(enum hse_mclass mclass, struct io_ops *io)
 }
 
 merr_t
-mclass_info_get(struct media_class *mc, struct hse_mclass_info *info)
+mclass_info_get(const struct media_class *mc, struct hse_mclass_info *info)
 {
     size_t n;
     merr_t err;
@@ -426,11 +488,12 @@ mclass_info_get(struct media_class *mc, struct hse_mclass_info *info)
 }
 
 void
-mclass_props_get(struct media_class *const mc, struct mpool_mclass_props *const props)
+mclass_props_get(const struct media_class *const mc, struct mpool_mclass_props *const props)
 {
     props->mc_fmaxsz = mblock_fset_fmaxsz_get(mc->mbfsp);
     props->mc_mblocksz = mc->mblocksz;
     props->mc_filecnt = mblock_fset_filecnt_get(mc->mbfsp);
+    props->mc_ra_pages = mc->ra_pages;
     strlcpy(props->mc_path, mc->upath, sizeof(props->mc_path));
 }
 

--- a/lib/mpool/lib/mclass.h
+++ b/lib/mpool/lib/mclass.h
@@ -120,9 +120,11 @@ struct mblock_fset *
 mclass_fset(const struct media_class *mc);
 
 /**
- * mclass_ra_pages() - get read-ahead size in pages
+ * @brief Get the read-ahead size in pages.
  *
- * @mc: mclass handle
+ * @param mc: Media class handle
+ *
+ * @returns read-ahead size in pages
  */
 uint16_t
 mclass_ra_pages(const struct media_class *mc);

--- a/lib/mpool/lib/mclass.h
+++ b/lib/mpool/lib/mclass.h
@@ -84,7 +84,7 @@ mclass_destroy(const char *path, struct workqueue_struct *wq);
  * @mc: mclass handle
  */
 int
-mclass_id(struct media_class *mc);
+mclass_id(const struct media_class *mc);
 
 /**
  * mclass_dpath() - get directory path
@@ -92,7 +92,7 @@ mclass_id(struct media_class *mc);
  * @mc: mclass handle
  */
 const char *
-mclass_dpath(struct media_class *mc);
+mclass_dpath(const struct media_class *mc);
 
 /** @brief Get the user-given path.
  *
@@ -109,7 +109,7 @@ mclass_upath(const struct media_class *mc);
  * @mc: mclass handle
  */
 int
-mclass_dirfd(struct media_class *mc);
+mclass_dirfd(const struct media_class *mc);
 
 /**
  * mclass_fset() - get mblock fileset handle
@@ -117,7 +117,15 @@ mclass_dirfd(struct media_class *mc);
  * @mc: mclass handle
  */
 struct mblock_fset *
-mclass_fset(struct media_class *mc);
+mclass_fset(const struct media_class *mc);
+
+/**
+ * mclass_ra_pages() - get read-ahead size in pages
+ *
+ * @mc: mclass handle
+ */
+uint16_t
+mclass_ra_pages(const struct media_class *mc);
 
 /**
  * mclass_supports_directio() - check directio support
@@ -125,7 +133,7 @@ mclass_fset(struct media_class *mc);
  * @mc: mclass handle
  */
 bool
-mclass_supports_directio(struct media_class *mc);
+mclass_supports_directio(const struct media_class *mc);
 
 /**
  * mclass_to_mcid() - convert mclass to mclass ID
@@ -149,7 +157,7 @@ mcid_to_mclass(enum mclass_id mcid);
  * @mc: mclass handle
  */
 size_t
-mclass_mblocksz_get(struct media_class *mc);
+mclass_mblocksz_get(const struct media_class *mc);
 
 /**
  * mclass_mblocksz_set() - set mblock size
@@ -174,7 +182,7 @@ mclass_gclose_set(struct media_class *mc);
  * @mc:       mclass handle
  */
 bool
-mclass_gclose_get(struct media_class *mc);
+mclass_gclose_get(const struct media_class *mc);
 
 /**
  * mclass_io_ops_set() -  set io ops for the specified mclass
@@ -192,7 +200,7 @@ mclass_io_ops_set(enum hse_mclass mclass, struct io_ops *io);
  * @info: mclass info (output)
  */
 merr_t
-mclass_info_get(struct media_class *mc, struct hse_mclass_info *info);
+mclass_info_get(const struct media_class *mc, struct hse_mclass_info *info);
 
 /** @brief Get properties of a media class.
  *
@@ -200,7 +208,7 @@ mclass_info_get(struct media_class *mc, struct hse_mclass_info *info);
  * @param props: Media class properties.
  */
 void
-mclass_props_get(struct media_class *mc, struct mpool_mclass_props *props);
+mclass_props_get(const struct media_class *mc, struct mpool_mclass_props *props);
 
 /**
  * mclass_ftw() - walk mclass files matching prefix and invoke callback for each file


### PR DESCRIPTION
Make read-ahead size a per media class property and query it from sysfs
at mpool open

Signed-off-by: Nabeel M Mohamed <50154757+nabeelmmd@users.noreply.github.com>