### PR TITLE
Change unstable_external_project to unstable-external_project

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -231,12 +231,21 @@ jobs:
         run: |
           echo "CFLAGS=-Wno-deprecated ${CFLAGS}" >> "$GITHUB_ENV"
 
+        # We use the `unstable-external_project` Meson module to enable certain
+        # subprojects. Meson generates a warning just for importing it, so we
+        # have to not use --fatal-meson-warnings in environments where we have
+        # to use some of these subprojects.
+      - name: Export --fatal-meson-warnings conditionally
+        if: ${{ matrix.image != 'ubuntu-18.04' && !startsWith(matrix.image, 'cross') }}
+        run: |
+          echo "FATAL_MESON_WARNINGS=--fatal-meson-warnings" >> "$GITHUB_ENV"
+
         # Tools are disabled due to deprecated support in Meson for CMake
         # versions this old.
       - name: Setup
         if: ${{ steps.to-skip.outputs.skip == 'false' }}
         run: |
-          meson setup builddir --fatal-meson-warnings $WERROR $CROSS_ARGS \
+          meson setup builddir $FATAL_MESON_WARNINGS $WERROR $CROSS_ARGS \
             --buildtype=${{ matrix.buildtype }} -Dtools=enabled \
             -Ddocs=disabled -Dbindings=all
 

--- a/subprojects/packagefiles/curl/meson.build
+++ b/subprojects/packagefiles/curl/meson.build
@@ -25,7 +25,7 @@ else
     error('Unable to translate "warning_level" for your compiler')
 endif
 
-extern = import('unstable_external_project')
+extern = import('unstable-external_project')
 
 run_command('buildconf', check: true)
 

--- a/subprojects/packagefiles/libbsd/meson.build
+++ b/subprojects/packagefiles/libbsd/meson.build
@@ -25,7 +25,7 @@ else
     error('Unable to translate "warning_level" for your compiler')
 endif
 
-extern = import('unstable_external_project')
+extern = import('unstable-external_project')
 
 run_command('autogen', check: true)
 

--- a/subprojects/packagefiles/userspace-rcu/meson.build
+++ b/subprojects/packagefiles/userspace-rcu/meson.build
@@ -25,7 +25,7 @@ else
     error('Unable to translate "warning_level" for your compiler')
 endif
 
-extern = import('unstable_external_project')
+extern = import('unstable-external_project')
 
 run_command('bootstrap', check: true)
 


### PR DESCRIPTION
Fixes a Meson 0.64.0 warning.

Signed-off-by: Tristan Partin <tpartin@micron.com>
