### PR TITLE
Add support for stashing the CLI program names in a common way

### DIFF
--- a/cli/hse_cli.c
+++ b/cli/hse_cli.c
@@ -19,13 +19,13 @@
 #include <bsd/string.h>
 
 #include <hse/cli/param.h>
+#include <hse/cli/program.h>
 #include <hse/hse.h>
 #include <hse/logging/logging.h>
 #include <hse/pidfile/pidfile.h>
-#include <hse/version.h>
-
 #include <hse/util/compiler.h>
 #include <hse/util/parse_num.h>
+#include <hse/version.h>
 
 #include "cli_util.h"
 #include "storage_profile.h"
@@ -1876,12 +1876,9 @@ int
 main(int argc, char **argv)
 {
     struct cli cli;
-    char *     prog;
     int        rc;
 
-    prog = strrchr(argv[0], '/');
-    if (prog)
-        argv[0] = prog + 1;
+    progname_set(argv[0]);
 
     cmd_tree_set_paths(&cli_root);
 

--- a/cli/include/hse/cli/program.h
+++ b/cli/include/hse/cli/program.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2022 Micron Technology, Inc. All rights reserved.
+ */
+
+extern const char *progname;
+
+void
+progname_set(const char *argv_0);

--- a/cli/lib/meson.build
+++ b/cli/lib/meson.build
@@ -18,6 +18,7 @@ libcurl_dep = dependency(
 
 libhse_cli_sources = files(
     'param.c',
+    'program.c',
     'rest/api.c',
     'rest/buffer.c',
     'rest/client.c',

--- a/cli/lib/program.c
+++ b/cli/lib/program.c
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2022 Micron Technology, Inc. All rights reserved.
+ */
+
+#include <string.h>
+
+#include <hse/cli/program.h>
+
+const char *progname;
+
+void
+progname_set(const char *const argv_0)
+{
+    const char *slash;
+
+    slash = strrchr(argv_0, '/');
+    if (slash) {
+        progname = slash + 1;
+    } else {
+        progname = argv_0;
+    }
+}

--- a/lib/binding/kvdb_interface.c
+++ b/lib/binding/kvdb_interface.c
@@ -381,8 +381,6 @@ hse_init(const char *const config, const size_t paramc, const char *const *const
     if (hse_initialized)
         goto out;
 
-    hse_progname = program_invocation_name ? program_invocation_name : __func__;
-
     hse_gparams = hse_gparams_defaults();
 
     err = argv_deserialize_to_hse_gparams(paramc, paramv, &hse_gparams);
@@ -411,7 +409,11 @@ hse_init(const char *const config, const size_t paramc, const char *const *const
     }
 
     /* First log message w/ HSE version - after deserializing global params */
-    log_info("version %s, program %s", HSE_VERSION_STRING, hse_progname);
+#ifdef _GNU_SOURCE
+    log_info("version %s, program %s", HSE_VERSION_STRING, program_invocation_name);
+#else
+    log_info("version %s", HSE_VERSION_STRING);
+#endif
 
     hse_lowmem_adjust(&memgb);
     log_info("Memory available: %lu GiB", memgb);

--- a/lib/cn/cn_metrics.h
+++ b/lib/cn/cn_metrics.h
@@ -6,6 +6,7 @@
 #ifndef HSE_KVDB_CN_METRICS_H
 #define HSE_KVDB_CN_METRICS_H
 
+#include <assert.h>
 #include <stdint.h>
 #include <sys/types.h>
 

--- a/samples/ex5_large_val.c
+++ b/samples/ex5_large_val.c
@@ -46,11 +46,10 @@
 #include <errno.h>
 #include <linux/limits.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
 
 #include "helper.h"
-
-char *progname;
 
 int
 extract_kv_to_files(struct hse_kvs *kvs, int file_cnt, char **files)
@@ -182,7 +181,7 @@ put_files_as_kv(struct hse_kvdb *kvdb, struct hse_kvs *kvs, int kv_cnt, char **k
 }
 
 int
-usage()
+usage(void)
 {
     printf(
         "usage: %s [options] <kvdb> <kvs> <file1> [<fileN> ...]\n"
@@ -205,7 +204,7 @@ main(int argc, char **argv)
                                   "rest.enabled=false" };
     const size_t     paramc = sizeof(paramv) / sizeof(paramv[0]);
 
-    progname = argv[0];
+    progname_set(argv[0]);
 
     while ((c = getopt(argc, argv, "xh")) != -1) {
         switch (c) {

--- a/samples/meson.build
+++ b/samples/meson.build
@@ -17,6 +17,7 @@ foreach s : samples
             ['@0@.c'.format(s)],
             dependencies: [
                 hse_dep,
+                libhse_cli_dep,
             ],
             gnu_symbol_visibility: 'hidden',
         )

--- a/tests/framework/lib/framework.c
+++ b/tests/framework/lib/framework.c
@@ -5,10 +5,6 @@
 
 #include <mtf/framework.h>
 
-#include <hse/util/base.h>
-#include <hse/util/err_ctx.h>
-#include <hse/ikvdb/hse_gparams.h>
-
 #include <errno.h>
 #include <getopt.h>
 #include <limits.h>
@@ -18,7 +14,11 @@
 #include <string.h>
 #include <sysexits.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
+#include <hse/ikvdb/hse_gparams.h>
+#include <hse/util/base.h>
+#include <hse/util/err_ctx.h>
 
 int         mtf_verify_flag;
 int         mtf_verify_line;
@@ -95,7 +95,6 @@ mtf_main(int argc, char **argv, struct mtf_test_coll_info *tci)
     char **paramv;
     char errbuf[1024];
     hse_err_t err;
-    const char *progname = program_invocation_short_name;
     char *logging_level, *config = NULL, *argv_home = NULL;
 
     static const struct option long_options[] = {
@@ -103,6 +102,8 @@ mtf_main(int argc, char **argv, struct mtf_test_coll_info *tci)
         { "one", required_argument, NULL, '1' },           { "home", required_argument, NULL, 'C' },
         { "config", required_argument, NULL, 'c' },        { 0, 0, 0, 0 },
     };
+
+    progname_set(argv[0]);
 
     tci->tci_named = NULL;
 

--- a/tests/framework/meson.build
+++ b/tests/framework/meson.build
@@ -5,7 +5,10 @@ hse_test_framework = static_library(
     '@0@-test-framework'.format(meson.project_name()),
     hse_test_framework_sources,
     include_directories: hse_test_framework_includes,
-    dependencies: hse_internal_dep,
+    dependencies: [
+        hse_internal_dep,
+        libhse_cli_dep,
+    ],
     gnu_symbol_visibility: 'hidden'
 )
 

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -111,7 +111,6 @@ components = {
         'kvdb_rest_test': {
             'dependencies': [
                 cjson_dep,
-                libcurl_dep,
                 libhse_cli_dep,
                 hse_fixtures_dep,
             ],
@@ -129,7 +128,6 @@ components = {
         'kvs_rest_test': {
             'dependencies': [
                 cjson_dep,
-                libcurl_dep,
                 libhse_cli_dep,
                 hse_fixtures_dep,
             ],
@@ -180,7 +178,6 @@ components = {
         'global_rest_test': {
             'dependencies': [
                 cjson_dep,
-                libcurl_dep,
                 libhse_cli_dep,
             ],
         },

--- a/tests/unit/mpool/mblock_test.c
+++ b/tests/unit/mpool/mblock_test.c
@@ -18,7 +18,6 @@
 #include <mblock_fset.h>
 #include <mpool_internal.h>
 
-#include <libgen.h>
 #include <limits.h>
 #include <fcntl.h>
 #include <ftw.h>

--- a/tools/attack/attack.c
+++ b/tools/attack/attack.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc. All rights reserved.
  */
 
 /*
@@ -18,7 +18,6 @@
 
 #include <arpa/inet.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -27,12 +26,10 @@
 #include <sysexits.h>
 #include <unistd.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/compiler.h>
 #include <hse/util/inttypes.h>
-
-const char *progname;
 
 void HSE_PRINTF(2, 3)
 fatal(hse_err_t err, char *fmt, ...)
@@ -92,7 +89,8 @@ main(int argc, char **argv)
     int              i, c, last;
     u64              rc;
 
-    progname = basename(argv[0]);
+    progname_set(argv[0]);
+
     keylen = 4;
     cnt = 1000;
     start = 1;

--- a/tools/bnt/bnt.c
+++ b/tools/bnt/bnt.c
@@ -34,15 +34,15 @@
 #include <term.h>
 #include <sys/sysinfo.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-#include <hse/version.h>
-
 #include <hse/util/platform.h>
 #include <hse/util/compiler.h>
 #include <hse/util/page.h>
 #include <hse/util/timer.h>
 #include <hse/util/mutex.h>
 #include <hse/util/bonsai_tree.h>
+#include <hse/version.h>
 
 #include <xoroshiro.h>
 
@@ -155,7 +155,6 @@ u_long testsecs = 60;
 
 u_int tjobsmax, cjobsmax;
 
-char *progname;
 char *tgs_clrtoeol;
 int verbosity;
 u_long mark;
@@ -790,11 +789,10 @@ main(int argc, char **argv)
     tsi_t tstart;
     int rc;
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
-
     version = help = false;
     human = true;
+
+    progname_set(argv[0]);
 
     setvbuf(stdout, NULL, _IONBF, 0);
     xrand64_init(0);

--- a/tools/boundcur/boundcur.c
+++ b/tools/boundcur/boundcur.c
@@ -1,11 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2020 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc. All rights reserved.
  */
 #include <assert.h>
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -16,13 +15,12 @@
 #include <sysexits.h>
 #include <unistd.h>
 
-#include <hse/hse.h>
+#include <hse/cli/param.h>
+#include <hse/cli/program.h>
 #include <hse/flags.h>
-
+#include <hse/hse.h>
 #include <hse/util/arch.h>
 #include <hse/util/compiler.h>
-
-#include <hse/cli/param.h>
 
 #include "kvs_helper.h"
 
@@ -133,8 +131,6 @@ do_work(void *arg)
     rc = hse_kvs_cursor_destroy(c);
 }
 
-char *progname;
-
 void HSE_PRINTF(1, 2)
 syntax(const char *fmt, ...)
 {
@@ -186,7 +182,7 @@ main(
     int                 i;
     int                 rc;
 
-    progname = basename(argv[0]);
+    progname_set(argv[0]);
 
     while ((c = getopt(argc, argv, "c:hj:rZ:")) != -1) {
         char *errmsg, *end;

--- a/tools/capput/capput.c
+++ b/tools/capput/capput.c
@@ -32,7 +32,6 @@
 
 #include <endian.h>
 #include <errno.h>
-#include <libgen.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -42,15 +41,14 @@
 #include <sys/resource.h>
 #include <sysexits.h>
 
+#include <hse/cli/param.h>
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/arch.h>
 #include <hse/util/atomic.h>
 #include <hse/util/compiler.h>
 #include <hse/util/inttypes.h>
 #include <hse/util/time.h>
-
-#include <hse/cli/param.h>
 
 #include "kvs_helper.h"
 
@@ -61,7 +59,6 @@ static uint64_t next_del HSE_ACP_ALIGNED;
 pthread_barrier_t   put_barrier1;
 pthread_barrier_t   put_barrier2;
 
-char *progname;
 int exrc;
 
 static volatile bool killthreads;
@@ -596,7 +593,7 @@ main(int argc, char **argv)
     int                 c;
     int                 rc;
 
-    progname = basename(argv[0]);
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
     if (rc)

--- a/tools/cn_metrics/cn_metrics.c
+++ b/tools/cn_metrics/cn_metrics.c
@@ -5,19 +5,18 @@
 
 #include <stdio.h>
 
-#include <hse/ikvdb/cn.h>
-#include <hse/ikvdb/limits.h>
-#include <hse/ikvdb/ikvdb.h>
-#include <hse/ikvdb/csched.h>
-
 #include <cn/cn_metrics.h>
 #include <cn/cn_tree.h>
 #include <cn/cn_tree_internal.h>
 #include <cn/cn_tree_iter.h>
 #include <cn/kvset.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
+#include <hse/ikvdb/cn.h>
+#include <hse/ikvdb/limits.h>
+#include <hse/ikvdb/ikvdb.h>
+#include <hse/ikvdb/csched.h>
 #include <hse/util/parse_num.h>
 
 #include <tools/parm_groups.h>
@@ -26,8 +25,6 @@
 #include <hse/mpool/mpool.h>
 
 #include <sysexits.h>
-
-const char *progname;
 
 void
 usage(void)
@@ -574,8 +571,7 @@ main(int argc, char **argv)
     struct svec         db_oparm = { 0 };
     struct svec         kv_oparm = { 0 };
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, NULL);
     if (rc)

--- a/tools/cndump/cndb_dump.c
+++ b/tools/cndump/cndb_dump.c
@@ -9,8 +9,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/ikvdb/diag_kvdb.h>
 
 #include "cndb_reader.h"

--- a/tools/cndump/cndump.c
+++ b/tools/cndump/cndump.c
@@ -5,13 +5,11 @@
 
 #include <stdio.h>
 #include <stdarg.h>
-#include <libgen.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/ikvdb/cndb.h>
 #include <hse/ikvdb/diag_kvdb.h>
-
 #include <hse/mpool/mpool.h>
 
 #include <cndb/omf.h>
@@ -23,7 +21,6 @@
 #include "commands.h"
 
 /* globals */
-const char *progname;
 struct global_opts global_opts;
 
 static void
@@ -76,7 +73,7 @@ main(int argc, char **argv)
 {
     const char *cmd;
 
-    progname = basename(argv[0]);
+    progname_set(argv[0]);
 
     parse_args(argc, argv);
 

--- a/tools/cndump/fatal.c
+++ b/tools/cndump/fatal.c
@@ -7,6 +7,7 @@
 #include <sysexits.h>
 #include <stdarg.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
 
 #include "fatal.h"

--- a/tools/cndump/globals.h
+++ b/tools/cndump/globals.h
@@ -14,6 +14,5 @@ struct global_opts {
 };
 
 extern struct global_opts global_opts;
-extern const char *progname;
 
 #endif

--- a/tools/cndump/kvset_dump.c
+++ b/tools/cndump/kvset_dump.c
@@ -9,17 +9,15 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/ikvdb/diag_kvdb.h>
 #include <hse/ikvdb/ikvdb.h>
 #include <hse/ikvdb/omf_kmd.h>
-
-#include <hse/util/parse_num.h>
-#include <hse/util/fmt.h>
-
 #include <hse/mpool/mpool_structs.h>
 #include <hse/mpool/mpool.h>
+#include <hse/util/parse_num.h>
+#include <hse/util/fmt.h>
 
 #include <cn/omf.h>
 #include <cn/wbt_internal.h>

--- a/tools/ctxn_validation/ctxn_validation.c
+++ b/tools/ctxn_validation/ctxn_validation.c
@@ -1,10 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2019,2021-2022 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <errno.h>
-#include <libgen.h>
 #include <pthread.h>
 #include <stdalign.h>
 #include <stdarg.h>
@@ -15,9 +14,10 @@
 #include <sysexits.h>
 #include <signal.h>
 
-#include <hse/hse.h>
 #include <xoroshiro.h>
 
+#include <hse/cli/program.h>
+#include <hse/hse.h>
 #include <hse/util/arch.h>
 #include <hse/util/compiler.h>
 #include <hse/util/inttypes.h>
@@ -25,7 +25,7 @@
 
 #include <tools/parm_groups.h>
 
-const char *progname, *mp_name, *kvs_name;
+const char *mp_name, *kvs_name;
 sig_atomic_t done;
 ulong       secmax = 0;
 ulong       itermax = 1;
@@ -939,8 +939,7 @@ main(int argc, char **argv)
     ulong       i;
     int         rc;
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
+    progname_set(argv[0]);
 
     seed = time(NULL);
 

--- a/tools/curcache/curcache.c
+++ b/tools/curcache/curcache.c
@@ -1,10 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc. All rights reserved.
  */
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <poll.h>
 #include <pthread.h>
 #include <stdarg.h>
@@ -12,8 +11,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/compiler.h>
 
 int              verbose = 0;
@@ -234,7 +233,7 @@ stress(char *mp, char *kv)
 }
 
 void
-usage(char *prog)
+usage(void)
 {
     fprintf(
         stderr,
@@ -245,7 +244,7 @@ usage(char *prog)
         "-Z config  path to global config file\n"
         "stress test of kvs cursor caching:\n"
         "runs nthreads, each doing niter create/seek/read/destroy\n\n",
-        prog);
+        progname);
     exit(1);
 }
 
@@ -253,9 +252,10 @@ int
 main(int argc, char **argv)
 {
     const char *config = NULL;
-    char *      prog = basename(argv[0]);
     char *      parts[3];
     int         c, err;
+
+    progname_set(argv[0]);
 
     while ((c = getopt(argc, argv, "?vt:i:Z:")) != -1) {
         switch (c) {
@@ -273,7 +273,7 @@ main(int argc, char **argv)
                 break;
             case '?': /* fallthrough */
             default:
-                usage(prog);
+                usage();
         }
     }
 
@@ -284,7 +284,7 @@ main(int argc, char **argv)
     parts[1] = strsep(&argv[0], "/");
 
     if (!parts[0] || !parts[1])
-        usage(prog);
+        usage();
 
     err = hse_init(config, 0, NULL);
     if (err)

--- a/tools/hsettp/hsettp.c
+++ b/tools/hsettp/hsettp.c
@@ -21,12 +21,13 @@
 #include <cjson/cJSON_Utils.h>
 #include <curl/curl.h>
 
-#include <hse/error/merr.h>
+#include <hse/cli/program.h>
 #include <hse/cli/rest/client.h>
 #include <hse/cli/tprint.h>
+#include <hse/error/merr.h>
+#include <hse/pidfile/pidfile.h>
 #include <hse/util/assert.h>
 #include <hse/util/compiler.h>
-#include <hse/pidfile/pidfile.h>
 
 #include "buffer.h"
 #include "format.h"
@@ -50,7 +51,6 @@ cJSON *openapi;
 struct options_map *options_map;
 
 const char *fspath;
-const char *progname;
 int verbosity;
 
 struct {
@@ -1653,8 +1653,7 @@ main(const int argc, char **const argv)
     struct curl_slist *headers = NULL;
     cJSON *path = NULL, *method = NULL;
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
+    progname_set(argv[0]);
 
     openapi = cJSON_ParseWithLength((char *)openapi_json, sizeof(openapi_json));
     if (!openapi) {

--- a/tools/ksync/ksync.c
+++ b/tools/ksync/ksync.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2017 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2017-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <stdarg.h>
@@ -11,14 +11,14 @@
 #include <sysexits.h>
 #include <sys/time.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/inttypes.h>
 #include <hse/util/arch.h>
 
 #include <tools/parm_groups.h>
 
-const char *progname, *mp_name, *kvs_name;
+const char *mp_name, *kvs_name;
 ulong       kwrite, kflush, ksync, ktxn;
 ulong       keymax;
 size_t      vlenmin = 0;
@@ -250,8 +250,7 @@ main(int argc, char **argv)
     bool        help = false;
     int         rc;
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, NULL);
     if (rc) {

--- a/tools/longtest/longtest.c
+++ b/tools/longtest/longtest.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2017,2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <getopt.h>
@@ -12,12 +12,12 @@
 #include <sysexits.h>
 #include <sys/time.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-#include <hse/version.h>
-
 #include <hse/util/atomic.h>
 #include <hse/util/inttypes.h>
 #include <hse/util/parse_num.h>
+#include <hse/version.h>
 
 #include <tools/parm_groups.h>
 
@@ -146,89 +146,89 @@ static void syntax(const char *fmt, ...);
 static void usage(void);
 
 enum opt_enum {
-	opt_config = 'Z',
-	opt_keys	= 'c',
-	opt_help	= 'h',
-	opt_num_iters	= 'i',
-	opt_dryrun	= 'n',
-	opt_duration	= 's',
-	opt_threads	= 't',
-	opt_version	= 'V',
-	opt_verbose	= 'v',
-	opt_errcnt      = 'e',
-	opt_verify      = 'p',
-	opt_log_stdout  = 'l',
-	opt_cursor      = 'C',
-	opt_sync	= 'S',
+    opt_config = 'Z',
+    opt_keys	= 'c',
+    opt_help	= 'h',
+    opt_num_iters	= 'i',
+    opt_dryrun	= 'n',
+    opt_duration	= 's',
+    opt_threads	= 't',
+    opt_version	= 'V',
+    opt_verbose	= 'v',
+    opt_errcnt      = 'e',
+    opt_verify      = 'p',
+    opt_log_stdout  = 'l',
+    opt_cursor      = 'C',
+    opt_sync	= 'S',
 
-	opt_seed = 1024,
-	opt_once,
-	opt_show,
-	opt_nostats,
-	opt_interactive,
+    opt_seed = 1024,
+    opt_once,
+    opt_show,
+    opt_nostats,
+    opt_interactive,
 
-	opt_exp,
-	opt_poly,
+    opt_exp,
+    opt_poly,
 
-	opt_mthread,
-	opt_mphase,
+    opt_mthread,
+    opt_mphase,
 
-	opt_seqnum_pfx,
+    opt_seqnum_pfx,
 
-	opt_klen, opt_kmin, opt_kmax,
-	opt_vlen, opt_vmin, opt_vmax,
+    opt_klen, opt_kmin, opt_kmax,
+    opt_vlen, opt_vmin, opt_vmax,
 };
 
 enum phase {
-	PHASE_PUT_P    = 1 << 0,
-	PHASE_PUT_PU   = 1 << 1,
-	PHASE_DEL_P    = 1 << 2,
-	PHASE_DEL_PU   = 1 << 3,
-	PHASE_VER_P    = 1 << 4,
-	PHASE_VER_PU   = 1 << 5,
-	PHASE_VER_PD   = 1 << 6,
-	PHASE_VER_PUD  = 1 << 7,
-	PHASE_DEL_REM  = 1 << 8,
-	PHASE_VER_REM  = 1 << 9,
+    PHASE_PUT_P    = 1 << 0,
+    PHASE_PUT_PU   = 1 << 1,
+    PHASE_DEL_P    = 1 << 2,
+    PHASE_DEL_PU   = 1 << 3,
+    PHASE_VER_P    = 1 << 4,
+    PHASE_VER_PU   = 1 << 5,
+    PHASE_VER_PD   = 1 << 6,
+    PHASE_VER_PUD  = 1 << 7,
+    PHASE_DEL_REM  = 1 << 8,
+    PHASE_VER_REM  = 1 << 9,
 
-	PHASE_ALL      = -1,
-	PHASE_PUD_MASK = 15,
+    PHASE_ALL      = -1,
+    PHASE_PUD_MASK = 15,
 };
 
 struct opts {
-	const char *config;
-	const char *mpool;
-	const char *kvs;
+    const char *config;
+    const char *mpool;
+    const char *kvs;
 
-	u64 keys;
-	u64 duration;
-	u64 num_iters;
+    u64 keys;
+    u64 duration;
+    u64 num_iters;
 
-	u32 kmin, kmax, vmin, vmax;
+    u32 kmin, kmax, vmin, vmax;
 
-	u32 verify;
-	u32 seed;
-	u32 test_threads;
+    u32 verify;
+    u32 seed;
+    u32 test_threads;
 
-	u32 verbose;
-	u32 sync;
-	int mthread;
-	enum phase mphase;
-	bool cursor;
-	bool   distr_is_exp;
-	double distr_param;
+    u32 verbose;
+    u32 sync;
+    int mthread;
+    enum phase mphase;
+    bool cursor;
+    bool   distr_is_exp;
+    double distr_param;
 
-	s32  max_errors;
-	u32  seqnum_pfx;
+    s32  max_errors;
+    u32  seqnum_pfx;
 
-	bool version;
-	bool help;
-	bool dryrun;
-	bool stats;
-	bool once;
-	bool show;
-	bool log_stdout;
-	bool interactive;
+    bool version;
+    bool help;
+    bool dryrun;
+    bool stats;
+    bool once;
+    bool show;
+    bool log_stdout;
+    bool interactive;
 };
 
 struct parm_groups *pg;
@@ -239,473 +239,472 @@ struct svec         kv_oparms = { 0 };
 /* per-thread state */
 struct tstate {
 
-	/* constant for duration of test */
-	u32     id;
-	u64     key_space_offset;
-	u64     num_keys;
-	u64     num_iters;
+    /* constant for duration of test */
+    u32     id;
+    u64     key_space_offset;
+    u64     num_keys;
+    u64     num_iters;
 
-	/* if using cursors, there is a prefix of the thread id */
-	char    pfxbuf[2];
-	void   *pfx;
-	size_t  pfxlen;
+    /* if using cursors, there is a prefix of the thread id */
+    char    pfxbuf[2];
+    void   *pfx;
+    size_t  pfxlen;
 
-	/* current iteration */
-	u64     iter_cnt;
+    /* current iteration */
+    u64     iter_cnt;
 
-	/* stats */
-	u64     put_cnt;
-	u64     upd_cnt;
-	u64     get_cnt;
-	u64     del_cnt;
+    /* stats */
+    u64     put_cnt;
+    u64     upd_cnt;
+    u64     get_cnt;
+    u64     del_cnt;
 
-	/* thread management */
-	pthread_t   thread;
-	bool        running;
-	bool        joined;
+    /* thread management */
+    pthread_t   thread;
+    bool        running;
+    bool        joined;
 
-	/* work buffers */
-	char    genkey[MAX_VMAX];  /* generated key */
-	char    exp_val[MAX_VMAX]; /* expected value */
-	char    act_val[MAX_VMAX]; /* actual retrieved value */
-	char    msgbuf[MAX_VMAX * 2 + 256];
-	char    msgbuf1[MAX_VMAX * 2 + 256];
+    /* work buffers */
+    char    genkey[MAX_VMAX];  /* generated key */
+    char    exp_val[MAX_VMAX]; /* expected value */
+    char    act_val[MAX_VMAX]; /* actual retrieved value */
+    char    msgbuf[MAX_VMAX * 2 + 256];
+    char    msgbuf1[MAX_VMAX * 2 + 256];
 };
 
 
 struct test_stats {
-	u64 puts;
-	u64 upds;
-	u64 gets;
-	u64 dels;
-	u64 iters;
-	u64 ops;
+    u64 puts;
+    u64 upds;
+    u64 gets;
+    u64 dels;
+    u64 iters;
+    u64 ops;
 };
 
 struct test {
-	void               *kvdb_h;
-	void               *kvs_h;
-	struct rsgen        kgen;
-	struct rsgen        vgen;
-	u64                 start_time;
-	u32                 stat_rows_no_hdr;
-	u32                 running_threads;
-	pthread_barrier_t   bar_sync;
-	atomic_int          errors;
-	atomic_int          test_complete;
-	atomic_int          hard_stop;
-	u8                 *seqnum_pfx_key;
-	struct test_stats   tot;
-	struct test_stats   stats[MAX_THREADS];
-	struct tstate       ts[MAX_THREADS];
+    void               *kvdb_h;
+    void               *kvs_h;
+    struct rsgen        kgen;
+    struct rsgen        vgen;
+    u64                 start_time;
+    u32                 stat_rows_no_hdr;
+    u32                 running_threads;
+    pthread_barrier_t   bar_sync;
+    atomic_int          errors;
+    atomic_int          test_complete;
+    atomic_int          hard_stop;
+    u8                 *seqnum_pfx_key;
+    struct test_stats   tot;
+    struct test_stats   stats[MAX_THREADS];
+    struct tstate       ts[MAX_THREADS];
 
 };
 
 struct keystat {
-	int ks_puts;
-	int ks_dels;
-	int ks_upds;
+    int ks_puts;
+    int ks_dels;
+    int ks_upds;
 };
 
 struct keystat  *keystats = NULL;
 
 
-const char *progname = NULL;
 struct opts opt;
 struct test test;
 
 struct option longopts[] = {
-	{ "config",         required_argument,  NULL,  opt_config },
-	{ "dryrun",         no_argument,        NULL,  opt_dryrun   },
-	{ "duration",       required_argument,  NULL,  opt_duration },
-	{ "exp",            required_argument,  NULL,  opt_exp   },
-	{ "help",           no_argument,        NULL,  opt_help     },
-	{ "num_iters",      required_argument,  NULL,  opt_num_iters },
-	{ "keys",           required_argument,  NULL,  opt_keys     },
+    { "config",         required_argument,  NULL,  opt_config },
+    { "dryrun",         no_argument,        NULL,  opt_dryrun   },
+    { "duration",       required_argument,  NULL,  opt_duration },
+    { "exp",            required_argument,  NULL,  opt_exp   },
+    { "help",           no_argument,        NULL,  opt_help     },
+    { "num_iters",      required_argument,  NULL,  opt_num_iters },
+    { "keys",           required_argument,  NULL,  opt_keys     },
 
-	{ "klen",           required_argument,  NULL,  opt_klen },
-	{ "kmin",           required_argument,  NULL,  opt_kmin },
-	{ "kmax",           required_argument,  NULL,  opt_kmax },
+    { "klen",           required_argument,  NULL,  opt_klen },
+    { "kmin",           required_argument,  NULL,  opt_kmin },
+    { "kmax",           required_argument,  NULL,  opt_kmax },
 
-	{ "vlen",           required_argument,  NULL,  opt_vlen },
-	{ "vmin",           required_argument,  NULL,  opt_vmin },
-	{ "vmax",           required_argument,  NULL,  opt_vmax },
-
-
-	{ "poly",           required_argument,  NULL,  opt_poly  },
-	{ "seed",           required_argument,  NULL,  opt_seed     },
-	{ "once",           no_argument,        NULL,  opt_once },
-	{ "threads",        required_argument,  NULL,  opt_threads  },
-	{ "verbose",        optional_argument,  NULL,  opt_verbose  },
-	{ "show",           no_argument,        NULL,  opt_show },
-	{ "logs",           no_argument,        NULL,  opt_log_stdout  },
-	{ "version",        no_argument,        NULL,  opt_version  },
-	{ "errcnt",         required_argument,  NULL,  opt_errcnt  },
-	{ "verify",         required_argument,  NULL,  opt_verify  },
-	{ "cursor",         no_argument,        NULL,  opt_cursor },
-	{ "sync",           optional_argument,  NULL,  opt_sync },
-	{ "nostats",        no_argument,        NULL,  opt_nostats },
-	{ "interactive",    no_argument,        NULL,  opt_interactive },
-
-	{ "mthread",        required_argument,  NULL,  opt_mthread  },
-	{ "mphase",         required_argument,  NULL,  opt_mphase  },
-
-	{ "seqnum-pfx",     required_argument,  NULL,  opt_seqnum_pfx  },
+    { "vlen",           required_argument,  NULL,  opt_vlen },
+    { "vmin",           required_argument,  NULL,  opt_vmin },
+    { "vmax",           required_argument,  NULL,  opt_vmax },
 
 
-	{ 0, 0, 0, 0 }
+    { "poly",           required_argument,  NULL,  opt_poly  },
+    { "seed",           required_argument,  NULL,  opt_seed     },
+    { "once",           no_argument,        NULL,  opt_once },
+    { "threads",        required_argument,  NULL,  opt_threads  },
+    { "verbose",        optional_argument,  NULL,  opt_verbose  },
+    { "show",           no_argument,        NULL,  opt_show },
+    { "logs",           no_argument,        NULL,  opt_log_stdout  },
+    { "version",        no_argument,        NULL,  opt_version  },
+    { "errcnt",         required_argument,  NULL,  opt_errcnt  },
+    { "verify",         required_argument,  NULL,  opt_verify  },
+    { "cursor",         no_argument,        NULL,  opt_cursor },
+    { "sync",           optional_argument,  NULL,  opt_sync },
+    { "nostats",        no_argument,        NULL,  opt_nostats },
+    { "interactive",    no_argument,        NULL,  opt_interactive },
+
+    { "mthread",        required_argument,  NULL,  opt_mthread  },
+    { "mphase",         required_argument,  NULL,  opt_mphase  },
+
+    { "seqnum-pfx",     required_argument,  NULL,  opt_seqnum_pfx  },
+
+
+    { 0, 0, 0, 0 }
 };
 
 static
 void
 opts_set_default(
-	struct opts *opt)
+    struct opts *opt)
 {
-	memset(opt, 0, sizeof(*opt));
+    memset(opt, 0, sizeof(*opt));
 
-	opt->keys = 32*1000*1000;
-	opt->test_threads = 32;
-	opt->seed = 0;
+    opt->keys = 32*1000*1000;
+    opt->test_threads = 32;
+    opt->seed = 0;
 
-	opt->distr_is_exp = true;
-	opt->distr_param = 1.0;
+    opt->distr_is_exp = true;
+    opt->distr_param = 1.0;
 
-	opt->kmin = 20;
-	opt->kmax = 30;
-	opt->vmin = 80;
-	opt->vmax = 120;
+    opt->kmin = 20;
+    opt->kmax = 30;
+    opt->vmin = 80;
+    opt->vmax = 120;
 
-	opt->cursor = 0;
-	opt->verify = 25;
-	opt->verbose = 0;
-	opt->log_stdout = false;
-	opt->dryrun = false;
+    opt->cursor = 0;
+    opt->verify = 25;
+    opt->verbose = 0;
+    opt->log_stdout = false;
+    opt->dryrun = false;
 
-	opt->mthread = -1;
-	opt->mphase = PHASE_ALL;
+    opt->mthread = -1;
+    opt->mphase = PHASE_ALL;
 
-	opt->mpool = NULL;
+    opt->mpool = NULL;
 
-	opt->duration = 0;
-	opt->num_iters = 0;
-	opt->max_errors = 1;
+    opt->duration = 0;
+    opt->num_iters = 0;
+    opt->max_errors = 1;
 
-	opt->stats = 1;
+    opt->stats = 1;
 }
 
 void
 opts_show(
-	struct opts *opt)
+    struct opts *opt)
 {
-	printf("  mpool          =  %s\n", opt->mpool ?: "<none>");
-	printf("  kvs            =  %s\n", opt->kvs ?: "<none>");
-	printf("  num keys       =  %lu\n", opt->keys);
-	printf("  duration       =  %lu\n", opt->duration);
-	printf("  iterations     =  %lu\n", opt->num_iters);
-	printf("  min key len    =  %u\n",  opt->kmin);
-	printf("  max key len    =  %u\n",  opt->kmax);
-	printf("  min value len  =  %u\n",  opt->vmin);
-	printf("  max value len  =  %u\n",  opt->vmax);
-	printf("  seed           =  %u\n",  opt->seed);
-	printf("  distr          =  %s:%g\n",
-	       (opt->distr_is_exp ? "exponential" : "polynomial"),
-	       opt->distr_param);
-	printf("  threads        =  %u\n",  opt->test_threads);
-	printf("  verbose        =  %d\n",  opt->verbose);
-	printf("  logs           =  %d\n",  opt->log_stdout);
-	printf("  dryrun         =  %d\n",  opt->dryrun);
-	printf("  errcnt         =  %u\n",  opt->max_errors);
-	printf("  verify         =  %u\n",  opt->verify);
-	printf("  mphase         =  0x%x\n", opt->mphase);
-	printf("  mthread        =  %d\n",  opt->mthread);
-	printf("  cursor         =  %d\n",  opt->cursor);
-	printf("  sync           =  %d\n",  opt->sync);
-	printf("  stats          =  %d\n",  opt->stats);
+    printf("  mpool          =  %s\n", opt->mpool ?: "<none>");
+    printf("  kvs            =  %s\n", opt->kvs ?: "<none>");
+    printf("  num keys       =  %lu\n", opt->keys);
+    printf("  duration       =  %lu\n", opt->duration);
+    printf("  iterations     =  %lu\n", opt->num_iters);
+    printf("  min key len    =  %u\n",  opt->kmin);
+    printf("  max key len    =  %u\n",  opt->kmax);
+    printf("  min value len  =  %u\n",  opt->vmin);
+    printf("  max value len  =  %u\n",  opt->vmax);
+    printf("  seed           =  %u\n",  opt->seed);
+    printf("  distr          =  %s:%g\n",
+           (opt->distr_is_exp ? "exponential" : "polynomial"),
+           opt->distr_param);
+    printf("  threads        =  %u\n",  opt->test_threads);
+    printf("  verbose        =  %d\n",  opt->verbose);
+    printf("  logs           =  %d\n",  opt->log_stdout);
+    printf("  dryrun         =  %d\n",  opt->dryrun);
+    printf("  errcnt         =  %u\n",  opt->max_errors);
+    printf("  verify         =  %u\n",  opt->verify);
+    printf("  mphase         =  0x%x\n", opt->mphase);
+    printf("  mthread        =  %d\n",  opt->mthread);
+    printf("  cursor         =  %d\n",  opt->cursor);
+    printf("  sync           =  %d\n",  opt->sync);
+    printf("  stats          =  %d\n",  opt->stats);
 
 }
 
 #define GET_VALUE(TYPE, OPTARG, VALUE)					\
-	do {								\
-		if (parse_##TYPE(OPTARG, VALUE)) {			\
-			syntax((char *)"Unable to parse"		\
-			       " "#TYPE" number: "			\
-			       "'%s'", OPTARG);				\
-		}							\
-	} while (0)
+    do {								\
+        if (parse_##TYPE(OPTARG, VALUE)) {			\
+            syntax((char *)"Unable to parse"		\
+                   " "#TYPE" number: "			\
+                   "'%s'", OPTARG);				\
+        }							\
+    } while (0)
 
 #define GET_DOUBLE(OPTARG, VALUE)					\
-	do {								\
-		if (1 != sscanf(OPTARG, "%lg", VALUE)) {		\
-			syntax((char *)"Unable to parse"		\
-			       " floating point number: "		\
-			       "'%s'", OPTARG);				\
-		}							\
-	} while (0)
+    do {								\
+        if (1 != sscanf(OPTARG, "%lg", VALUE)) {		\
+            syntax((char *)"Unable to parse"		\
+                   " floating point number: "		\
+                   "'%s'", OPTARG);				\
+        }							\
+    } while (0)
 
 
 
 void
 opts_parse(
-	int argc,
-	char **argv,
-	struct opts *opt)
+    int argc,
+    char **argv,
+    struct opts *opt)
 {
-	int done;
+    int done;
 
-	/* Dynamically build option string from longopts[] for getopt_long(). */
-	const size_t opstrsz = (sizeof(longopts) / sizeof(longopts[0])) * 3 + 3;
-	char opstr[opstrsz + 1];
-	const struct option *longopt;
-	char *pc = opstr;
+    /* Dynamically build option string from longopts[] for getopt_long(). */
+    const size_t opstrsz = (sizeof(longopts) / sizeof(longopts[0])) * 3 + 3;
+    char opstr[opstrsz + 1];
+    const struct option *longopt;
+    char *pc = opstr;
 
-	*pc++ = ':';    /* Disable getopt error messages */
+    *pc++ = ':';    /* Disable getopt error messages */
 
-	for (longopt = longopts; longopt->name; ++longopt) {
-		if (!longopt->flag && isprint(longopt->val)) {
-			*pc++ = longopt->val;
-			if (longopt->has_arg == required_argument) {
-				*pc++ = ':';
-			} else if (longopt->has_arg == optional_argument) {
-				*pc++ = ':';
-				*pc++ = ':';
-			}
-		}
-	}
-	*pc = '\000';
+    for (longopt = longopts; longopt->name; ++longopt) {
+        if (!longopt->flag && isprint(longopt->val)) {
+            *pc++ = longopt->val;
+            if (longopt->has_arg == required_argument) {
+                *pc++ = ':';
+            } else if (longopt->has_arg == optional_argument) {
+                *pc++ = ':';
+                *pc++ = ':';
+            }
+        }
+    }
+    *pc = '\000';
 
-	done = 0;
-	while (!done) {
-		int curind = optind;
-		int longidx = 0;
-		int c;
+    done = 0;
+    while (!done) {
+        int curind = optind;
+        int longidx = 0;
+        int c;
 
-		c = getopt_long(argc, argv, opstr, longopts, &longidx);
-		if (-1 == c)
-			break; /* got '--' or end of arg list */
-		switch (c) {
+        c = getopt_long(argc, argv, opstr, longopts, &longidx);
+        if (-1 == c)
+            break; /* got '--' or end of arg list */
+        switch (c) {
 
-		case opt_verbose:
-			if (optarg)
-				GET_VALUE(u32, optarg, &opt->verbose);
-			else
-				++opt->verbose;
-			break;
+        case opt_verbose:
+            if (optarg)
+                GET_VALUE(u32, optarg, &opt->verbose);
+            else
+                ++opt->verbose;
+            break;
 
-		case opt_sync:
-			if (optarg)
-				GET_VALUE(u32, optarg, &opt->sync);
-			else
-				opt->sync = -1;
-			break;
+        case opt_sync:
+            if (optarg)
+                GET_VALUE(u32, optarg, &opt->sync);
+            else
+                opt->sync = -1;
+            break;
 
-		case opt_help:         opt->help = true; break;
-		case opt_config:       opt->config = optarg; break;
-		case opt_dryrun:       opt->dryrun = true; break;
-		case opt_once:         opt->once = true; break;
-		case opt_show:         opt->show = true; break;
-		case opt_nostats:      opt->stats = false; break;
-		case opt_interactive:  opt->interactive = true; break;
-		case opt_log_stdout:   opt->log_stdout = true; break;
-		case opt_version:      opt->version = true; break;
+        case opt_help:         opt->help = true; break;
+        case opt_config:       opt->config = optarg; break;
+        case opt_dryrun:       opt->dryrun = true; break;
+        case opt_once:         opt->once = true; break;
+        case opt_show:         opt->show = true; break;
+        case opt_nostats:      opt->stats = false; break;
+        case opt_interactive:  opt->interactive = true; break;
+        case opt_log_stdout:   opt->log_stdout = true; break;
+        case opt_version:      opt->version = true; break;
 
-		case opt_kmin:    GET_VALUE(u32, optarg, &opt->kmin);    break;
-		case opt_kmax:    GET_VALUE(u32, optarg, &opt->kmax);    break;
-		case opt_klen:
-			GET_VALUE(u32, optarg, &opt->kmax);
-			opt->kmin = opt->kmax;
-			break;
+        case opt_kmin:    GET_VALUE(u32, optarg, &opt->kmin);    break;
+        case opt_kmax:    GET_VALUE(u32, optarg, &opt->kmax);    break;
+        case opt_klen:
+            GET_VALUE(u32, optarg, &opt->kmax);
+            opt->kmin = opt->kmax;
+            break;
 
-		case opt_vmin:    GET_VALUE(u32, optarg, &opt->vmin);    break;
-		case opt_vmax:    GET_VALUE(u32, optarg, &opt->vmax);    break;
-		case opt_vlen:
-			GET_VALUE(u32, optarg, &opt->vmax);
-			opt->vmin = opt->vmax;
-			break;
+        case opt_vmin:    GET_VALUE(u32, optarg, &opt->vmin);    break;
+        case opt_vmax:    GET_VALUE(u32, optarg, &opt->vmax);    break;
+        case opt_vlen:
+            GET_VALUE(u32, optarg, &opt->vmax);
+            opt->vmin = opt->vmax;
+            break;
 
-		case opt_threads:
-			GET_VALUE(u32, optarg, &opt->test_threads);
-			break;
+        case opt_threads:
+            GET_VALUE(u32, optarg, &opt->test_threads);
+            break;
 
-		case opt_keys:    GET_VALUE(u64, optarg, &opt->keys);    break;
-		case opt_seed:    GET_VALUE(u32, optarg, &opt->seed);    break;
+        case opt_keys:    GET_VALUE(u64, optarg, &opt->keys);    break;
+        case opt_seed:    GET_VALUE(u32, optarg, &opt->seed);    break;
 
-		case opt_mphase:  GET_VALUE(s32, optarg, &opt->mphase);  break;
-		case opt_mthread: GET_VALUE(s32, optarg, &opt->mthread); break;
+        case opt_mphase:  GET_VALUE(s32, optarg, &opt->mphase);  break;
+        case opt_mthread: GET_VALUE(s32, optarg, &opt->mthread); break;
 
-		case opt_seqnum_pfx:
-			GET_VALUE(u32, optarg, &opt->seqnum_pfx);
-			break;
+        case opt_seqnum_pfx:
+            GET_VALUE(u32, optarg, &opt->seqnum_pfx);
+            break;
 
-		case opt_errcnt:
-			GET_VALUE(s32, optarg, &opt->max_errors);
-			break;
+        case opt_errcnt:
+            GET_VALUE(s32, optarg, &opt->max_errors);
+            break;
 
-		case opt_verify:
-			GET_VALUE(u32, optarg, &opt->verify);
-			break;
+        case opt_verify:
+            GET_VALUE(u32, optarg, &opt->verify);
+            break;
 
-		case opt_cursor:
-			opt->cursor = true;
-			break;
+        case opt_cursor:
+            opt->cursor = true;
+            break;
 
-		case opt_exp:
-			opt->distr_is_exp = true;
-			GET_DOUBLE(optarg, &opt->distr_param);
-			break;
+        case opt_exp:
+            opt->distr_is_exp = true;
+            GET_DOUBLE(optarg, &opt->distr_param);
+            break;
 
-		case opt_poly:
-			opt->distr_is_exp = false;
-			GET_DOUBLE(optarg, &opt->distr_param);
-			break;
+        case opt_poly:
+            opt->distr_is_exp = false;
+            GET_DOUBLE(optarg, &opt->distr_param);
+            break;
 
-		case opt_duration:
-			GET_VALUE(u64, optarg, &opt->duration);
-			break;
+        case opt_duration:
+            GET_VALUE(u64, optarg, &opt->duration);
+            break;
 
-		case opt_num_iters:
-			GET_VALUE(u64, optarg, &opt->num_iters);
-			break;
+        case opt_num_iters:
+            GET_VALUE(u64, optarg, &opt->num_iters);
+            break;
 
-		case ':':
-			syntax("missing argument for option '%s'",
-			       argv[curind]);
-			break;
+        case ':':
+            syntax("missing argument for option '%s'",
+                   argv[curind]);
+            break;
 
-		case '?':
-			if (!strcmp(argv[optind-1], "-m") ||
-			    !strcmp(argv[optind-1], "-k")) {
-				/* Accept for backward compatibility. */
-				break;
-			}
-			/* If the uknown arg starts with '-', then error.
-			 * Otherwise assume it is a positional paramater that
-			 * will be handled by the caller. */
-			if (*argv[optind-1] == '-')
-				syntax("invalid option '%s'", argv[optind-1]);
-			break;
+        case '?':
+            if (!strcmp(argv[optind-1], "-m") ||
+                !strcmp(argv[optind-1], "-k")) {
+                /* Accept for backward compatibility. */
+                break;
+            }
+            /* If the uknown arg starts with '-', then error.
+             * Otherwise assume it is a positional paramater that
+             * will be handled by the caller. */
+            if (*argv[optind-1] == '-')
+                syntax("invalid option '%s'", argv[optind-1]);
+            break;
 
-		default:
-			if (c == 0) {
-				if (!longopt[longidx].flag) {
-					syntax("unhandled option '--%s'",
-					       longopts[longidx].name);
-				}
-			} else {
-				syntax("unhandled option '%s'", argv[curind]);
-			}
-			break;
-		}
-	}
+        default:
+            if (c == 0) {
+                if (!longopt[longidx].flag) {
+                    syntax("unhandled option '--%s'",
+                           longopts[longidx].name);
+                }
+            } else {
+                syntax("unhandled option '%s'", argv[curind]);
+            }
+            break;
+        }
+    }
 
-	if (opt->help)
-		usage();
-	else if (opt->version) {
-		printf("HSE KVDB Lib:   %s\n", HSE_VERSION_STRING);
-	}
+    if (opt->help)
+        usage();
+    else if (opt->version) {
+        printf("HSE KVDB Lib:   %s\n", HSE_VERSION_STRING);
+    }
 }
 
 static void
 usage(void)
 {
-	printf("usage: %s [options] <kvdb> <kvs> [param=value ...]",
-	       progname);
-	printf("%s\n",
-	       "  -h, --help             show help (use -hv for more help)\n"
-	       "  -t, --threads THREADS  specify the number of threads\n"
-	       "  -c, --keys COUNT       put/get COUNT keys\n"
-	       "  -i, --iterations ITER  run for given number of iterations\n"
-	       "  -s, --duration SECS    specify the test duration in seconds\n"
-	       "  -n, --dryrun           show operations w/o touching kvs\n"
-	       "  -V, --version          print build version\n"
-	       "  -v, --verbose[=LVL]    increase[or set] verbosity (0=quiet)\n"
-	       "  -e, --errcnt N         stop after N errors, 0=infinite\n"
-	       "  -l, --logs             mirror logs stdout\n"
-	       "  -C, --cursor           use a cursor to verify\n"
-	       "  -S, --sync[=THREAD]    given thread calls sync once/iter\n"
-	       "                         use -S or -sync=-1 for all threads)\n"
-	       "      --verify[=PCT]     set verify percentage\n"
-	       "      --once             run each thread through 1 iteration\n"
-	       "      --exp M            M > 0.0\n"
-	       "      --poly DEGREE      DEGREE >= 0.0\n"
-	       "      --klen LEN         fixed key length\n"
-	       "      --kmin LEN         min key length\n"
-	       "      --kmax LEN         max key length\n"
-	       "      --vlen LEN         fixed value length\n"
-	       "      --vmin LEN         min value length\n"
-	       "      --vmax LEN         max value length\n"
-	       "      --seed SEED\n"
-	       "      --show             show test parameters and exit\n"
-	       "      --nostats          do not show periodic stats\n"
-	       "      --interactive      run interactively (use with -t 1)\n"
-	       "      --seqnum-pfx LEN   issue frequent pfx delete operations\n"
-	       "                         for the side-effect of increasing\n"
-	       "                         KVDB sequnce number\n");
-	if (!opt.verbose)
-		return;
+    printf("usage: %s [options] <kvdb> <kvs> [param=value ...]",
+           progname);
+    printf("%s\n",
+           "  -h, --help             show help (use -hv for more help)\n"
+           "  -t, --threads THREADS  specify the number of threads\n"
+           "  -c, --keys COUNT       put/get COUNT keys\n"
+           "  -i, --iterations ITER  run for given number of iterations\n"
+           "  -s, --duration SECS    specify the test duration in seconds\n"
+           "  -n, --dryrun           show operations w/o touching kvs\n"
+           "  -V, --version          print build version\n"
+           "  -v, --verbose[=LVL]    increase[or set] verbosity (0=quiet)\n"
+           "  -e, --errcnt N         stop after N errors, 0=infinite\n"
+           "  -l, --logs             mirror logs stdout\n"
+           "  -C, --cursor           use a cursor to verify\n"
+           "  -S, --sync[=THREAD]    given thread calls sync once/iter\n"
+           "                         use -S or -sync=-1 for all threads)\n"
+           "      --verify[=PCT]     set verify percentage\n"
+           "      --once             run each thread through 1 iteration\n"
+           "      --exp M            M > 0.0\n"
+           "      --poly DEGREE      DEGREE >= 0.0\n"
+           "      --klen LEN         fixed key length\n"
+           "      --kmin LEN         min key length\n"
+           "      --kmax LEN         max key length\n"
+           "      --vlen LEN         fixed value length\n"
+           "      --vmin LEN         min value length\n"
+           "      --vmax LEN         max value length\n"
+           "      --seed SEED\n"
+           "      --show             show test parameters and exit\n"
+           "      --nostats          do not show periodic stats\n"
+           "      --interactive      run interactively (use with -t 1)\n"
+           "      --seqnum-pfx LEN   issue frequent pfx delete operations\n"
+           "                         for the side-effect of increasing\n"
+           "                         KVDB sequnce number\n");
+    if (!opt.verbose)
+        return;
 
-	printf("%s\n",
-	       "Set #threads, #keys, etc:\n"
-	       "    --threads THREADS    // set number of threads\n"
-	       "    --keys KEYS          // number of keys\n"
-	       "\n"
-	       "Set how to distribute keys among threads:\n"
-	       "    --exp M              // M > 0.0\n"
-	       "    --poly DEGREE        // DEGREE >= 0.0\n"
-	       "\n"
-	       "Define how long to run the test:\n"
-	       "    If ITER is zero or not set, then run test for DURATION\n"
-	       "    seconds, otherwise stop after thread 0 (which always\n"
-	       "    has the most keys) has completed ITER iterations.\n"
-	       "      --duration DURATION\n"
-	       "      --iterations ITER\n"
-	       "\n"
-	       "Key and value sizes:\n"
-	       "    These settings define the amount of random data used in\n"
-	       "    keys and values.  The actual sizes will be a bit\n"
-	       "    larger due to embedded 'magic' data used by the test.\n"
-	       "      --kmin LEN, --kmax LEN // min/max key length\n"
-	       "      --vmin LEN, --vmax LEN // min/max value length\n"
-	       "\n"
-	       "PRNG seed:\n"
-	       "    --seed SEED\n"
-	       "\n"
-	       "Phases (for --mphase):\n"
-	       "    PUT_P    = 1 << 0\n"
-	       "    PUT_PU   = 1 << 1\n"
-	       "    DEL_P    = 1 << 2\n"
-	       "    DEL_PU   = 1 << 3\n"
-	       "    VER_P    = 1 << 4\n"
-	       "    VER_PU   = 1 << 5\n"
-	       "    VER_PUD  = 1 << 6\n"
-	       "    VER_PD   = 1 << 7\n"
-	       "    DEL_REM  = 1 << 8\n"
-	       "    VER_VREM = 1 << 9\n"
-	       "\n");
+    printf("%s\n",
+           "Set #threads, #keys, etc:\n"
+           "    --threads THREADS    // set number of threads\n"
+           "    --keys KEYS          // number of keys\n"
+           "\n"
+           "Set how to distribute keys among threads:\n"
+           "    --exp M              // M > 0.0\n"
+           "    --poly DEGREE        // DEGREE >= 0.0\n"
+           "\n"
+           "Define how long to run the test:\n"
+           "    If ITER is zero or not set, then run test for DURATION\n"
+           "    seconds, otherwise stop after thread 0 (which always\n"
+           "    has the most keys) has completed ITER iterations.\n"
+           "      --duration DURATION\n"
+           "      --iterations ITER\n"
+           "\n"
+           "Key and value sizes:\n"
+           "    These settings define the amount of random data used in\n"
+           "    keys and values.  The actual sizes will be a bit\n"
+           "    larger due to embedded 'magic' data used by the test.\n"
+           "      --kmin LEN, --kmax LEN // min/max key length\n"
+           "      --vmin LEN, --vmax LEN // min/max value length\n"
+           "\n"
+           "PRNG seed:\n"
+           "    --seed SEED\n"
+           "\n"
+           "Phases (for --mphase):\n"
+           "    PUT_P    = 1 << 0\n"
+           "    PUT_PU   = 1 << 1\n"
+           "    DEL_P    = 1 << 2\n"
+           "    DEL_PU   = 1 << 3\n"
+           "    VER_P    = 1 << 4\n"
+           "    VER_PU   = 1 << 5\n"
+           "    VER_PUD  = 1 << 6\n"
+           "    VER_PD   = 1 << 7\n"
+           "    DEL_REM  = 1 << 8\n"
+           "    VER_VREM = 1 << 9\n"
+           "\n");
 }
 
 static void
 syntax(const char *fmt, ...)
 {
-	char msg[256];
-	va_list ap;
+    char msg[256];
+    va_list ap;
 
-	va_start(ap, fmt);
-	vsnprintf(msg, sizeof(msg), fmt, ap);
-	va_end(ap);
+    va_start(ap, fmt);
+    vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
 
-	fprintf(stderr, "%s: %s, use -h for help\n", progname, msg);
-	exit(EX_USAGE);
+    fprintf(stderr, "%s: %s, use -h for help\n", progname, msg);
+    exit(EX_USAGE);
 }
 
 
 /* get time of day as a count of micro seconds */
 u64 gtod_usec(void)
 {
-	struct timeval ctime;
+    struct timeval ctime;
 
-	gettimeofday(&ctime, 0);
-	return (u64)ctime.tv_sec * (u64)1000000
-		+ (u64)ctime.tv_usec;
+    gettimeofday(&ctime, 0);
+    return (u64)ctime.tv_sec * (u64)1000000
+        + (u64)ctime.tv_usec;
 }
 
 /**
@@ -725,27 +724,27 @@ u64 gtod_usec(void)
 int
 poly_dist(double degree, u32 len, double *results)
 {
-	u32 i;
-	double total;
+    u32 i;
+    double total;
 
-	if (degree < 0.0) {
-		fprintf(stderr,
-			"Error: invalid --poly value: %g (must be >= 0.0)\n",
-			degree);
-		return -1;
-	}
+    if (degree < 0.0) {
+        fprintf(stderr,
+            "Error: invalid --poly value: %g (must be >= 0.0)\n",
+            degree);
+        return -1;
+    }
 
-	total = 0.0;
-	for (i = 0; i < len; i++) {
-		results[i] = pow((double)(i+1) / (double)len, degree);
-		total += results[i];
-	}
+    total = 0.0;
+    for (i = 0; i < len; i++) {
+        results[i] = pow((double)(i+1) / (double)len, degree);
+        total += results[i];
+    }
 
-	/* normalized */
-	for (i = 0; i < len; i++)
-		results[i] = results[i] / total;
+    /* normalized */
+    for (i = 0; i < len; i++)
+        results[i] = results[i] / total;
 
-	return 0;
+    return 0;
 }
 
 
@@ -766,223 +765,223 @@ poly_dist(double degree, u32 len, double *results)
 int
 exp_dist(double m, u32 len, double *dist)
 {
-	u32 i;
-	double total;
+    u32 i;
+    double total;
 
-	if (m <= 0.0) {
-		fprintf(stderr,
-			"Error: invalid --exp value: %g (must be > 0.0)\n",
-			m);
-		return -1;
-	}
+    if (m <= 0.0) {
+        fprintf(stderr,
+            "Error: invalid --exp value: %g (must be > 0.0)\n",
+            m);
+        return -1;
+    }
 
-	total = 0.0;
-	for (i = 0; i < len; i++) {
-		dist[i] = exp((m * (i+1)) / (double)len) - 1.0;
-		total += dist[i];
-	}
+    total = 0.0;
+    for (i = 0; i < len; i++) {
+        dist[i] = exp((m * (i+1)) / (double)len) - 1.0;
+        total += dist[i];
+    }
 
-	/* normalize */
-	for (i = 0; i < len; i++)
-		dist[i] = dist[i] / total;
+    /* normalize */
+    for (i = 0; i < len; i++)
+        dist[i] = dist[i] / total;
 
-	return 0;
+    return 0;
 }
 
 int
 normalize_dist(double *distr, u32 len, u64 scale, u64 *results)
 {
-	u64 tot = 0;
-	int i;
+    u64 tot = 0;
+    int i;
 
-	for (i = 0; i < len; i++) {
-		double val = round(distr[i] * scale);
+    for (i = 0; i < len; i++) {
+        double val = round(distr[i] * scale);
 
-		if (val > (double)(U64_MAX)) {
-			fprintf(stderr, "Error: overflow: "
-				"try a more uniform distribution\n");
-			return -1;
-		}
-		results[i] = (u64)val;
-		tot += results[i];
-	}
+        if (val > (double)(U64_MAX)) {
+            fprintf(stderr, "Error: overflow: "
+                "try a more uniform distribution\n");
+            return -1;
+        }
+        results[i] = (u64)val;
+        tot += results[i];
+    }
 
-	if (tot != scale) {
-		double adjust = (double)scale - (double)tot;
-		double val = (double)results[len-1] + adjust;
+    if (tot != scale) {
+        double adjust = (double)scale - (double)tot;
+        double val = (double)results[len-1] + adjust;
 
-		if (val > (double)(U64_MAX)) {
-			fprintf(stderr, "Error: overflow: "
-				"try a more uniform distribution\n");
-			return -1;
-		}
-		results[len-1] = (u64)val;
-	}
+        if (val > (double)(U64_MAX)) {
+            fprintf(stderr, "Error: overflow: "
+                "try a more uniform distribution\n");
+            return -1;
+        }
+        results[len-1] = (u64)val;
+    }
 
-	return 0;
+    return 0;
 
 }
 
 u64
 xkvdb_kvs_open(
-	struct test        *t,
-	unsigned int       *idxv,
-	const char         *mp,
-	const char         *kvs)
+    struct test        *t,
+    unsigned int       *idxv,
+    const char         *mp,
+    const char         *kvs)
 {
-	struct hse_kvdb    *kvdb_h;
-	struct hse_kvs     *kvs_h;
-	u64                 err;
+    struct hse_kvdb    *kvdb_h;
+    struct hse_kvs     *kvs_h;
+    u64                 err;
 
-	if (opt.dryrun)
-		return 0;
+    if (opt.dryrun)
+        return 0;
 
-	err = hse_kvdb_open(mp, db_oparms.strc, db_oparms.strv, &kvdb_h);
-	if (err) {
-		fprintf(stderr, "%s: Unable to open kvdb %s",
-			progname, mp);
-		exit(1);
-	}
+    err = hse_kvdb_open(mp, db_oparms.strc, db_oparms.strv, &kvdb_h);
+    if (err) {
+        fprintf(stderr, "%s: Unable to open kvdb %s",
+            progname, mp);
+        exit(1);
+    }
 
-	err = hse_kvdb_kvs_open(kvdb_h, kvs, kv_oparms.strc, kv_oparms.strv, &kvs_h);
-	if (err) {
-		fprintf(stderr, "%s: Unable to open kvs %s",
-			progname, mp);
-		exit(1);
-	}
+    err = hse_kvdb_kvs_open(kvdb_h, kvs, kv_oparms.strc, kv_oparms.strv, &kvs_h);
+    if (err) {
+        fprintf(stderr, "%s: Unable to open kvs %s",
+            progname, mp);
+        exit(1);
+    }
 
-	t->kvdb_h = kvdb_h;
-	t->kvs_h = kvs_h;
+    t->kvdb_h = kvdb_h;
+    t->kvs_h = kvs_h;
 
-	return err;
+    return err;
 }
 
 u64
 xkvdb_kvs_close(struct test *t)
 {
-	return opt.dryrun ? 0 : hse_kvdb_close(t->kvdb_h);
+    return opt.dryrun ? 0 : hse_kvdb_close(t->kvdb_h);
 }
 
 u64
 xkvs_put(
-	struct test  *t,
-	void         *key,
-	size_t        klen,
-	void         *val,
-	size_t        vlen)
+    struct test  *t,
+    void         *key,
+    size_t        klen,
+    void         *val,
+    size_t        vlen)
 {
-	if (opt.dryrun)
-		return 0UL;
+    if (opt.dryrun)
+        return 0UL;
 
-	return hse_kvs_put(t->kvs_h, 0, NULL, key, klen, val, vlen);
+    return hse_kvs_put(t->kvs_h, 0, NULL, key, klen, val, vlen);
 }
 
 u64
 xkvs_get(
-	struct test  *t,
-	void         *key,
-	size_t        klen,
-	bool         *found,
-	void         *val,
-	size_t       *vlen)
+    struct test  *t,
+    void         *key,
+    size_t        klen,
+    bool         *found,
+    void         *val,
+    size_t       *vlen)
 {
-	*found = false;
+    *found = false;
 
-	if (opt.dryrun)
-		return 0UL;
+    if (opt.dryrun)
+        return 0UL;
 
-	*vlen = MAX_VMAX; /* assign here so valgrind knows it's initialized */
-	return hse_kvs_get(t->kvs_h, 0, NULL, key, klen, found,
-			   val, *vlen, vlen);
+    *vlen = MAX_VMAX; /* assign here so valgrind knows it's initialized */
+    return hse_kvs_get(t->kvs_h, 0, NULL, key, klen, found,
+               val, *vlen, vlen);
 }
 
 u64
 xkvs_del(
-	struct test  *t,
-	void         *key,
-	size_t        klen)
+    struct test  *t,
+    void         *key,
+    size_t        klen)
 {
-	return opt.dryrun ? 0UL : hse_kvs_delete(t->kvs_h, 0, NULL, key, klen);
+    return opt.dryrun ? 0UL : hse_kvs_delete(t->kvs_h, 0, NULL, key, klen);
 }
 
 u64
 xkvs_prefix_delete(
-	struct test  *t,
-	void         *key,
-	size_t        klen)
+    struct test  *t,
+    void         *key,
+    size_t        klen)
 {
-	return opt.dryrun ? 0UL : hse_kvs_prefix_delete(t->kvs_h, 0, NULL,
-							key, klen);
+    return opt.dryrun ? 0UL : hse_kvs_prefix_delete(t->kvs_h, 0, NULL,
+                            key, klen);
 }
 
 u64
 xkvdb_scan_begin(
-	struct test    *t,
-	void           *pfx,
-	size_t          plen,
-	void          **cur)
+    struct test    *t,
+    void           *pfx,
+    size_t          plen,
+    void          **cur)
 {
-	void       *pfxkey = pfx ?: 0;
-	int         pfxlen = pfx ? plen : 0;
+    void       *pfxkey = pfx ?: 0;
+    int         pfxlen = pfx ? plen : 0;
 
-	if (opt.dryrun)
-		return 0UL;
-	else
-		return hse_kvs_cursor_create(t->kvs_h, 0, NULL, pfxkey, pfxlen,
-					     (struct hse_kvs_cursor **)cur);
+    if (opt.dryrun)
+        return 0UL;
+    else
+        return hse_kvs_cursor_create(t->kvs_h, 0, NULL, pfxkey, pfxlen,
+                         (struct hse_kvs_cursor **)cur);
 }
 
 u64
 xkvdb_scan_read(
-	void       *cur,
-	void      **key,
-	size_t     *klen,
-	void      **val,
-	size_t     *vlen)
+    void       *cur,
+    void      **key,
+    size_t     *klen,
+    void      **val,
+    size_t     *vlen)
 {
-	u64         err;
-	bool        eof;
+    u64         err;
+    bool        eof;
 
-	if (opt.dryrun)
-		return 0;
+    if (opt.dryrun)
+        return 0;
 
-	err = hse_kvs_cursor_read(cur, 0, (const void **)key, klen,
-				  (const void **)val, vlen, &eof);
-	if (err)
-		return err;
+    err = hse_kvs_cursor_read(cur, 0, (const void **)key, klen,
+                  (const void **)val, vlen, &eof);
+    if (err)
+        return err;
 
-	if (eof)
-		*klen = 0;
+    if (eof)
+        *klen = 0;
 
-	return err;
+    return err;
 }
 
 u64
 xkvdb_scan_end(
-	void                    *cur)
+    void                    *cur)
 {
-	return opt.dryrun ? 0UL : hse_kvs_cursor_destroy(cur);
+    return opt.dryrun ? 0UL : hse_kvs_cursor_destroy(cur);
 }
 
 void bar_sync(void)
 {
-	int rc;
+    int rc;
 
-	rc = pthread_barrier_wait(&test.bar_sync);
-	if (rc && rc != PTHREAD_BARRIER_SERIAL_THREAD) {
-		perror("Error: pthread_barrier_wait");
-		exit(-1);
-	}
+    rc = pthread_barrier_wait(&test.bar_sync);
+    if (rc && rc != PTHREAD_BARRIER_SERIAL_THREAD) {
+        perror("Error: pthread_barrier_wait");
+        exit(-1);
+    }
 }
 
 
 
 char *
 hexstr(
-	char   *data,
-	size_t  data_len,
-	char   *out,
-	size_t  out_len)
+    char   *data,
+    size_t  data_len,
+    char   *out,
+    size_t  out_len)
 {
     if (data_len * 2 + 1 < out_len) {
         const char nybble2xdigit[] = "0123456789abcdef";
@@ -1004,7 +1003,7 @@ hexstr(
 void
 hard_stop(void)
 {
-	atomic_set(&test.hard_stop, 1);
+    atomic_set(&test.hard_stop, 1);
 }
 
 void *test_main(void *rock);
@@ -1014,283 +1013,283 @@ void *seqnum_pfx_thread(void *rock);
 void
 start_threads(void)
 {
-	struct tstate  *ts = test.ts;
+    struct tstate  *ts = test.ts;
 
-	int rc;
-	int i;
+    int rc;
+    int i;
 
-	for (i = 0; i < opt.test_threads; i++) {
+    for (i = 0; i < opt.test_threads; i++) {
 
-		ts->running = true;
-		rc = pthread_create(&ts->thread, NULL, test_main, ts);
-		if (rc) {
-			perror("pthread_create");
-			exit(1);
-		}
-		ts++;
-	}
+        ts->running = true;
+        rc = pthread_create(&ts->thread, NULL, test_main, ts);
+        if (rc) {
+            perror("pthread_create");
+            exit(1);
+        }
+        ts++;
+    }
 
-	if (opt.seqnum_pfx) {
+    if (opt.seqnum_pfx) {
 
-		size_t pfx_key_len = opt.seqnum_pfx;
+        size_t pfx_key_len = opt.seqnum_pfx;
 
-		test.seqnum_pfx_key = malloc(pfx_key_len);
-		if (!test.seqnum_pfx_key)
-			exit(1);
+        test.seqnum_pfx_key = malloc(pfx_key_len);
+        if (!test.seqnum_pfx_key)
+            exit(1);
 
-		memset(test.seqnum_pfx_key, 'X', pfx_key_len);
-		test.seqnum_pfx_key[pfx_key_len-1] = 0;
+        memset(test.seqnum_pfx_key, 'X', pfx_key_len);
+        test.seqnum_pfx_key[pfx_key_len-1] = 0;
 
-		ts->running = true;
-		rc = pthread_create(&ts->thread, NULL, seqnum_pfx_thread, ts);
-		if (rc) {
-			perror("pthread_create");
-			exit(1);
-		}
-		ts++;
-	}
+        ts->running = true;
+        rc = pthread_create(&ts->thread, NULL, seqnum_pfx_thread, ts);
+        if (rc) {
+            perror("pthread_create");
+            exit(1);
+        }
+        ts++;
+    }
 }
 
 void
 join_threads(void)
 {
-	u64         last_report = gtod_usec();
-	unsigned    joined = 0;
-	u64         now;
-	int         i;
+    u64         last_report = gtod_usec();
+    unsigned    joined = 0;
+    u64         now;
+    int         i;
 
-	while (joined != test.running_threads) {
+    while (joined != test.running_threads) {
 
-		for (i = 0; i < test.running_threads; i++) {
-			struct tstate *ts = test.ts + i;
+        for (i = 0; i < test.running_threads; i++) {
+            struct tstate *ts = test.ts + i;
 
-			if (!ts->joined) {
-				if (ts->running) {
-					void *retval;
-					long one_sec = 1000*1000*1000;
-					long tenth_sec = one_sec / 10;
-					struct timespec time;
+            if (!ts->joined) {
+                if (ts->running) {
+                    void *retval;
+                    long one_sec = 1000*1000*1000;
+                    long tenth_sec = one_sec / 10;
+                    struct timespec time;
 
-					clock_gettime(CLOCK_REALTIME, &time);
-					time.tv_nsec += tenth_sec;
-					while (time.tv_nsec > one_sec) {
-						time.tv_nsec -= one_sec;
-						time.tv_sec += 1;
-					}
-					if (0 == pthread_timedjoin_np(
-						    ts->thread,
-						    &retval,
-						    &time)) {
-						ts->joined = true;
-						joined++;
-					}
-				} else {
-					/* this thread never even ran */
-					ts->joined = true;
-					joined++;
-				}
-			}
-		}
+                    clock_gettime(CLOCK_REALTIME, &time);
+                    time.tv_nsec += tenth_sec;
+                    while (time.tv_nsec > one_sec) {
+                        time.tv_nsec -= one_sec;
+                        time.tv_sec += 1;
+                    }
+                    if (0 == pthread_timedjoin_np(
+                            ts->thread,
+                            &retval,
+                            &time)) {
+                        ts->joined = true;
+                        joined++;
+                    }
+                } else {
+                    /* this thread never even ran */
+                    ts->joined = true;
+                    joined++;
+                }
+            }
+        }
 
-		now = gtod_usec();
-		if (now - last_report > 1000000) {
-			fprintf(stderr,
-				"Waiting for threads:"
-				" %u of %u threads have finished\n",
-				joined, test.running_threads);
-			last_report = now;
-		}
-		usleep(1000);
-	}
+        now = gtod_usec();
+        if (now - last_report > 1000000) {
+            fprintf(stderr,
+                "Waiting for threads:"
+                " %u of %u threads have finished\n",
+                joined, test.running_threads);
+            last_report = now;
+        }
+        usleep(1000);
+    }
 }
 
 void
 interact(
-	const char *action)
+    const char *action)
 {
-	char input[64];
+    char input[64];
 
-	if (!opt.interactive)
-		return;
+    if (!opt.interactive)
+        return;
 
-	if (!action)
-		printf("Press CR to continue:");
-	else
-		printf("Press CR to continue with %s:", action);
+    if (!action)
+        printf("Press CR to continue:");
+    else
+        printf("Press CR to continue with %s:", action);
 
-	fflush(stdout);
-	while (true) {
-		uint len;
+    fflush(stdout);
+    while (true) {
+        uint len;
 
-		if (!fgets(input, sizeof(input), stdin))
-			break;
-		len = strlen(input);
-		if (len == 0 || input[len-1] == '\n')
-			break;
-	}
+        if (!fgets(input, sizeof(input), stdin))
+            break;
+        len = strlen(input);
+        if (len == 0 || input[len-1] == '\n')
+            break;
+    }
 }
 
 void
 do_puts(
-	struct tstate  *ts,
-	u64             first_key,
-	u64             num_keys,
-	char           *key_range_name,
-	char            tag)
+    struct tstate  *ts,
+    u64             first_key,
+    u64             num_keys,
+    char           *key_range_name,
+    char            tag)
 {
-	u64     keynum;
-	u32     vlen;
-	u32     klen;
-	u64     rc;
-	int     i;
+    u64     keynum;
+    u32     vlen;
+    u32     klen;
+    u64     rc;
+    int     i;
 
-	if (opt.verbose > 2 || opt.interactive)
-		printf("T%03u I%lu: insert(%s) %lu keys\n",
-		       ts->id, ts->iter_cnt,
-		       key_range_name, num_keys);
-	interact(0);
+    if (opt.verbose > 2 || opt.interactive)
+        printf("T%03u I%lu: insert(%s) %lu keys\n",
+               ts->id, ts->iter_cnt,
+               key_range_name, num_keys);
+    interact(0);
 
-	for (i = 0; i < num_keys; i++) {
+    for (i = 0; i < num_keys; i++) {
 
-		if (atomic_read(&test.hard_stop))
-			break;
+        if (atomic_read(&test.hard_stop))
+            break;
 
-		keynum = i + ts->key_space_offset + first_key;
+        keynum = i + ts->key_space_offset + first_key;
 
-		rsgen_str(&test.kgen, ts->id, keynum, ts->iter_cnt, 0,
-			  ts->genkey, &klen);
+        rsgen_str(&test.kgen, ts->id, keynum, ts->iter_cnt, 0,
+              ts->genkey, &klen);
 
-		if (opt.vmax)
-			rsgen_str(&test.vgen, ts->id, keynum, ts->iter_cnt, tag,
-				  ts->exp_val, &vlen);
-		else
-			vlen = 0;
+        if (opt.vmax)
+            rsgen_str(&test.vgen, ts->id, keynum, ts->iter_cnt, tag,
+                  ts->exp_val, &vlen);
+        else
+            vlen = 0;
 
-		if (opt.verbose > 3)
-			printf("T%03d I%lu: hse_kvs_put(%s) "
-			       "key#%lu len=%u key=%s%s%s\n",
-			       ts->id, ts->iter_cnt, key_range_name,
-			       keynum, klen,
-			       hexstr(ts->genkey, klen, ts->msgbuf,
-				      sizeof(ts->msgbuf)),
-			       (opt.verbose <= 4 ? "" : " val="),
-			       (opt.verbose <= 4
-				? "" :
-				hexstr(ts->exp_val, vlen, ts->msgbuf1,
-				       sizeof(ts->msgbuf1))));
+        if (opt.verbose > 3)
+            printf("T%03d I%lu: hse_kvs_put(%s) "
+                   "key#%lu len=%u key=%s%s%s\n",
+                   ts->id, ts->iter_cnt, key_range_name,
+                   keynum, klen,
+                   hexstr(ts->genkey, klen, ts->msgbuf,
+                      sizeof(ts->msgbuf)),
+                   (opt.verbose <= 4 ? "" : " val="),
+                   (opt.verbose <= 4
+                ? "" :
+                hexstr(ts->exp_val, vlen, ts->msgbuf1,
+                       sizeof(ts->msgbuf1))));
 
-		rc = xkvs_put(&test, ts->genkey, klen, ts->exp_val, vlen);
-		if (rc) {
-			fprintf(stderr, "%s: T%03d I%lu: %s %s %lu: "
-				"hse_kvs_put failed\n",
-				progname, ts->id, ts->iter_cnt, "put",
-				key_range_name, keynum);
-			return;
-		}
+        rc = xkvs_put(&test, ts->genkey, klen, ts->exp_val, vlen);
+        if (rc) {
+            fprintf(stderr, "%s: T%03d I%lu: %s %s %lu: "
+                "hse_kvs_put failed\n",
+                progname, ts->id, ts->iter_cnt, "put",
+                key_range_name, keynum);
+            return;
+        }
 
-		if (tag == 'P') {
-			if (keystats)
-				keystats[keynum].ks_puts++;
-			ts->put_cnt += 1;
-		} else {
-			ts->upd_cnt += 1;
-			if (keystats)
-				keystats[keynum].ks_upds++;
-		}
-	}
+        if (tag == 'P') {
+            if (keystats)
+                keystats[keynum].ks_puts++;
+            ts->put_cnt += 1;
+        } else {
+            ts->upd_cnt += 1;
+            if (keystats)
+                keystats[keynum].ks_upds++;
+        }
+    }
 }
 
 void
 do_deletes(
-	struct tstate  *ts,
-	u64             first_key,
-	u64             num_keys,
-	char           *key_range_name)
+    struct tstate  *ts,
+    u64             first_key,
+    u64             num_keys,
+    char           *key_range_name)
 {
-	u64     i;
-	u64     keynum;
-	u32     klen;
-	u64     rc;
+    u64     i;
+    u64     keynum;
+    u32     klen;
+    u64     rc;
 
-	if (opt.verbose > 2 || opt.interactive)
-		printf("T%03u I%lu: delete(%s) %lu keys\n",
-		       ts->id, ts->iter_cnt,
-		       key_range_name, num_keys);
-	interact(0);
+    if (opt.verbose > 2 || opt.interactive)
+        printf("T%03u I%lu: delete(%s) %lu keys\n",
+               ts->id, ts->iter_cnt,
+               key_range_name, num_keys);
+    interact(0);
 
-	for (i = 0; i < num_keys; i++) {
-		if (atomic_read(&test.hard_stop))
-			return;
+    for (i = 0; i < num_keys; i++) {
+        if (atomic_read(&test.hard_stop))
+            return;
 
-		keynum = i + ts->key_space_offset + first_key;
+        keynum = i + ts->key_space_offset + first_key;
 
-		rsgen_str(&test.kgen, ts->id, keynum, ts->iter_cnt, 0,
-			  ts->genkey, &klen);
+        rsgen_str(&test.kgen, ts->id, keynum, ts->iter_cnt, 0,
+              ts->genkey, &klen);
 
-		if (opt.verbose > 3)
-			printf("T%03d I%lu: kvs_del(%s) "
-			       "key#%lu len=%u key=%s\n",
-			       ts->id, ts->iter_cnt, key_range_name,
-			       keynum, klen,
-			       hexstr(ts->genkey, klen,
-				      ts->msgbuf, sizeof(ts->msgbuf)));
+        if (opt.verbose > 3)
+            printf("T%03d I%lu: kvs_del(%s) "
+                   "key#%lu len=%u key=%s\n",
+                   ts->id, ts->iter_cnt, key_range_name,
+                   keynum, klen,
+                   hexstr(ts->genkey, klen,
+                      ts->msgbuf, sizeof(ts->msgbuf)));
 
-		rc = xkvs_del(&test, ts->genkey, klen);
-		if (rc) {
-			fprintf(stderr, "%s: T%03d I%lu: delete %s %lu: "
-				"kvs_del failed\n",
-				progname, ts->id, ts->iter_cnt,
-				key_range_name, keynum);
-			hard_stop();
-			return;
-		}
+        rc = xkvs_del(&test, ts->genkey, klen);
+        if (rc) {
+            fprintf(stderr, "%s: T%03d I%lu: delete %s %lu: "
+                "kvs_del failed\n",
+                progname, ts->id, ts->iter_cnt,
+                key_range_name, keynum);
+            hard_stop();
+            return;
+        }
 
-		ts->del_cnt += 1;
-		if (keystats)
-			keystats[keynum].ks_dels++;
-	}
+        ts->del_cnt += 1;
+        if (keystats)
+            keystats[keynum].ks_dels++;
+    }
 }
 
 bool
 do_error(
-	struct tstate    *ts,
-	u64               keynum,
-	char             *key_range_name,
-	const char       *errmsg,
-	void             *key,
-	u32               klen,
-	void             *val,
-	u32               vlen,
-	void             *exp,
-	u32               explen,
-	int               verify_delete,
-	int               found)
+    struct tstate    *ts,
+    u64               keynum,
+    char             *key_range_name,
+    const char       *errmsg,
+    void             *key,
+    u32               klen,
+    void             *val,
+    u32               vlen,
+    void             *exp,
+    u32               explen,
+    int               verify_delete,
+    int               found)
 {
-	int errors = atomic_fetch_add(&test.errors, 1) + 1;
+    int errors = atomic_fetch_add(&test.errors, 1) + 1;
 
-	fprintf(stderr, "Error #%d: T%03d I%lu: verify %s: %s\n",
-		errors, ts->id, ts->iter_cnt, key_range_name, errmsg);
+    fprintf(stderr, "Error #%d: T%03d I%lu: verify %s: %s\n",
+        errors, ts->id, ts->iter_cnt, key_range_name, errmsg);
 
-	fprintf(stderr, "Error #%d: key#%lu len=%u: %s\n",
-		errors, keynum, klen, hexstr(key, klen,
-					     ts->msgbuf, sizeof(ts->msgbuf)));
+    fprintf(stderr, "Error #%d: key#%lu len=%u: %s\n",
+        errors, keynum, klen, hexstr(key, klen,
+                         ts->msgbuf, sizeof(ts->msgbuf)));
 
-	if (!verify_delete)
-		fprintf(stderr, "Error #%d: expected %u byte value: %s\n",
-			errors, explen, hexstr(exp, explen,
-			ts->msgbuf, sizeof(ts->msgbuf)));
-	else if (keystats)
-		fprintf(stderr, "keynum %lu puts %d upds %d dels %d\n", keynum,
-			keystats[keynum].ks_puts, keystats[keynum].ks_upds,
-			keystats[keynum].ks_dels);
+    if (!verify_delete)
+        fprintf(stderr, "Error #%d: expected %u byte value: %s\n",
+            errors, explen, hexstr(exp, explen,
+            ts->msgbuf, sizeof(ts->msgbuf)));
+    else if (keystats)
+        fprintf(stderr, "keynum %lu puts %d upds %d dels %d\n", keynum,
+            keystats[keynum].ks_puts, keystats[keynum].ks_upds,
+            keystats[keynum].ks_dels);
 
-	if (found)
-		fprintf(stderr, "Error #%d: retrieved %u byte value: %s\n",
-			errors, vlen, hexstr(val, vlen,
-					     ts->msgbuf, sizeof(ts->msgbuf)));
+    if (found)
+        fprintf(stderr, "Error #%d: retrieved %u byte value: %s\n",
+            errors, vlen, hexstr(val, vlen,
+                         ts->msgbuf, sizeof(ts->msgbuf)));
 
 
-	return opt.max_errors > 0 && errors >= opt.max_errors;
+    return opt.max_errors > 0 && errors >= opt.max_errors;
 }
 
 /*
@@ -1328,666 +1327,666 @@ do_error(
 
 void
 do_cursor_verify(
-	struct tstate  *ts,
-	u64             d1_len,
-	u64             u_len,
-	u64             p_len)
+    struct tstate  *ts,
+    u64             d1_len,
+    u64             u_len,
+    u64             p_len)
 {
-	int        err;
-	void         *key = 0, *val = 0, *exp = 0;
-	size_t        klen, vlen;
-	uint          explen;
-	void         *cur;
-	const char   *errmsg;
-	u64           keynum, iter, count;
-	u32           phase;
+    int        err;
+    void         *key = 0, *val = 0, *exp = 0;
+    size_t        klen, vlen;
+    uint          explen;
+    void         *cur;
+    const char   *errmsg;
+    u64           keynum, iter, count;
+    u32           phase;
 
-	/*
-	 * keys < key_first or > key_last are found deleted keys
-	 * keys < key_upd have a value tag U, else value tag P
-	 */
-	u64 key_first = ts->key_space_offset + d1_len;
-	u64 key_last  = ts->key_space_offset + p_len - d1_len;
-	u64 key_upd   = ts->key_space_offset + u_len;
+    /*
+     * keys < key_first or > key_last are found deleted keys
+     * keys < key_upd have a value tag U, else value tag P
+     */
+    u64 key_first = ts->key_space_offset + d1_len;
+    u64 key_last  = ts->key_space_offset + p_len - d1_len;
+    u64 key_upd   = ts->key_space_offset + u_len;
 
-	/*
-	 * phases can alter this key map:
-	 * if P, then no u or d
-	 * if PU, then no d
-	 * if PD, then no d1 offset from first
-	 * else full range
-	 *
-	 * phases MUST run in order: P PU PD PUD
-	 */
+    /*
+     * phases can alter this key map:
+     * if P, then no u or d
+     * if PU, then no d
+     * if PD, then no d1 offset from first
+     * else full range
+     *
+     * phases MUST run in order: P PU PD PUD
+     */
 
-	phase = opt.mphase & PHASE_PUD_MASK;
-	if (phase <= PHASE_DEL_P)
-		key_first -= d1_len;
-	if (phase <= PHASE_PUT_PU)
-		key_last += d1_len;
-	if (phase <= PHASE_PUT_P)
-		key_upd = 0;
+    phase = opt.mphase & PHASE_PUD_MASK;
+    if (phase <= PHASE_DEL_P)
+        key_first -= d1_len;
+    if (phase <= PHASE_PUT_PU)
+        key_last += d1_len;
+    if (phase <= PHASE_PUT_P)
+        key_upd = 0;
 
-	if (opt.verbose > 2 || opt.interactive)
-		printf("T%03u I%lu: verify with cursor\n",
-		       ts->id, ts->iter_cnt);
-	interact(0);
+    if (opt.verbose > 2 || opt.interactive)
+        printf("T%03u I%lu: verify with cursor\n",
+               ts->id, ts->iter_cnt);
+    interact(0);
 
-	/*
-	 * In order to allow multiple threads, limit the cursor
-	 * to the data for this thread, as a prefix.
-	 */
+    /*
+     * In order to allow multiple threads, limit the cursor
+     * to the data for this thread, as a prefix.
+     */
 
-	err = xkvdb_scan_begin(&test, ts->pfx, ts->pfxlen, &cur);
-	if (err) {
-		fprintf(stderr, "T%03d I%lu: Error: verify %s %lu: "
-			"cannot begin scan: %d\n",
-			ts->id, ts->iter_cnt, "cursor", key_first,
-			err);
-		/* allow a scan to fail because all resources changing */
-		if (err != EAGAIN)
-			hard_stop();
-		return;
-	}
+    err = xkvdb_scan_begin(&test, ts->pfx, ts->pfxlen, &cur);
+    if (err) {
+        fprintf(stderr, "T%03d I%lu: Error: verify %s %lu: "
+            "cannot begin scan: %d\n",
+            ts->id, ts->iter_cnt, "cursor", key_first,
+            err);
+        /* allow a scan to fail because all resources changing */
+        if (err != EAGAIN)
+            hard_stop();
+        return;
+    }
 
-	count = 0;
-	for (;;) {
-		u16     tid;
-		bool    vd = false;
+    count = 0;
+    for (;;) {
+        u16     tid;
+        bool    vd = false;
 
-		err = xkvdb_scan_read(cur, &key, &klen, &val, &vlen);
-		if (err || klen == 0)
-			break;
+        err = xkvdb_scan_read(cur, &key, &klen, &val, &vlen);
+        if (err || klen == 0)
+            break;
 
-		errmsg = 0;
-		++count;
+        errmsg = 0;
+        ++count;
 
-		/*
-		 * extract iter and keynum (id) from key
-		 * keys always have a tag of 0
-		 * values always have a tag P,U
-		 */
-		/* [MU_REVISIT] this algorithm assumes incorrectly that
-		 * rsgen_decode() can reverse map keys >= 8 bytes to
-		 * keynums.  However, it cannot.
-		 */
-		tid = rsgen_decode(key, klen, &keynum, &iter, 0);
+        /*
+         * extract iter and keynum (id) from key
+         * keys always have a tag of 0
+         * values always have a tag P,U
+         */
+        /* [MU_REVISIT] this algorithm assumes incorrectly that
+         * rsgen_decode() can reverse map keys >= 8 bytes to
+         * keynums.  However, it cannot.
+         */
+        tid = rsgen_decode(key, klen, &keynum, &iter, 0);
 
-		if (tid != ts->id) {
-			errmsg = "found key from wrong tid";
-		} else if (keynum < key_first || keynum > key_last) {
-			errmsg = "found deleted key";
-			vd = true;
-		} else  {
-			char tag = keynum < key_upd ? 'U' : 'P';
+        if (tid != ts->id) {
+            errmsg = "found key from wrong tid";
+        } else if (keynum < key_first || keynum > key_last) {
+            errmsg = "found deleted key";
+            vd = true;
+        } else  {
+            char tag = keynum < key_upd ? 'U' : 'P';
 
-			exp = ts->exp_val;
-			rsgen_str(&test.vgen, ts->id, keynum, iter, tag,
-				  exp, &explen);
-		}
+            exp = ts->exp_val;
+            rsgen_str(&test.vgen, ts->id, keynum, iter, tag,
+                  exp, &explen);
+        }
 
-		if (!errmsg && iter != ts->iter_cnt)
-			errmsg = "found key with wrong iter_cnt";
-		else if (!errmsg) {
-			if (vlen != explen)
-				errmsg = "key found, but value length is wrong";
-			else if (memcmp(val, exp, explen))
-				errmsg = "key found, but value is wrong";
-		}
+        if (!errmsg && iter != ts->iter_cnt)
+            errmsg = "found key with wrong iter_cnt";
+        else if (!errmsg) {
+            if (vlen != explen)
+                errmsg = "key found, but value length is wrong";
+            else if (memcmp(val, exp, explen))
+                errmsg = "key found, but value is wrong";
+        }
 
-		if (errmsg && !opt.dryrun &&
-		    do_error(ts, keynum, "cursor", errmsg,
-						key, klen, val, vlen,
-						exp, explen, vd, 1)) {
-			hard_stop();
-			break;
-		}
-	}
+        if (errmsg && !opt.dryrun &&
+            do_error(ts, keynum, "cursor", errmsg,
+                        key, klen, val, vlen,
+                        exp, explen, vd, 1)) {
+            hard_stop();
+            break;
+        }
+    }
 
-	if (err) {
-		fprintf(stderr, "T%03d I%lu: Error: verify %s %lu: "
-			"error during scan: %d\n",
-			ts->id, ts->iter_cnt, "cursor", keynum, err);
-		hard_stop();
-	}
+    if (err) {
+        fprintf(stderr, "T%03d I%lu: Error: verify %s %lu: "
+            "error during scan: %d\n",
+            ts->id, ts->iter_cnt, "cursor", keynum, err);
+        hard_stop();
+    }
 
-	xkvdb_scan_end(cur);
+    xkvdb_scan_end(cur);
 
-	if (!atomic_read(&test.hard_stop)
-	    && count != key_last - key_first)
-		fprintf(stderr, "T%03d I%lu: Error: verify %s %lu: "
-			"found %ld keys, expected %ld\n",
-			ts->id, ts->iter_cnt, "cursor", key_first,
-			count, p_len - d1_len * 2);
+    if (!atomic_read(&test.hard_stop)
+        && count != key_last - key_first)
+        fprintf(stderr, "T%03d I%lu: Error: verify %s %lu: "
+            "found %ld keys, expected %ld\n",
+            ts->id, ts->iter_cnt, "cursor", key_first,
+            count, p_len - d1_len * 2);
 }
 
 void
 do_verifies(
-	struct tstate  *ts,
-	u64             first_key,
-	u64             num_keys,
-	char           *key_range_name,
-	char            tag)
+    struct tstate  *ts,
+    u64             first_key,
+    u64             num_keys,
+    char           *key_range_name,
+    char            tag)
 {
-	u64         rc;
-	void       *key, *exp;
-	size_t      klen, vlen;
-	uint        gen_klen;
-	uint        explen;
-	bool        found;
-	bool        verify_delete = (tag == 'D');
-	u64         i, stop_at, keynum;
-	const char *errmsg;
+    u64         rc;
+    void       *key, *exp;
+    size_t      klen, vlen;
+    uint        gen_klen;
+    uint        explen;
+    bool        found;
+    bool        verify_delete = (tag == 'D');
+    u64         i, stop_at, keynum;
+    const char *errmsg;
 
-	if (opt.verify == 0)
-		return;
+    if (opt.verify == 0)
+        return;
 
-	if (opt.verify < 100) {
-		/* TODO: select a random sample to verify
-		 * instead of stopping after the first N
-		 * entries */
-		stop_at = (u64)(num_keys * (opt.verify/100.0));
-		if (stop_at < 5)
-			stop_at = 5;
-		if (stop_at > num_keys)
-			stop_at = num_keys;
-	} else {
-		stop_at = num_keys;
-	}
+    if (opt.verify < 100) {
+        /* TODO: select a random sample to verify
+         * instead of stopping after the first N
+         * entries */
+        stop_at = (u64)(num_keys * (opt.verify/100.0));
+        if (stop_at < 5)
+            stop_at = 5;
+        if (stop_at > num_keys)
+            stop_at = num_keys;
+    } else {
+        stop_at = num_keys;
+    }
 
-	if (opt.verbose > 2 || opt.interactive)
-		printf("T%03u I%lu: verify(%s) %lu of %lu keys\n",
-		       ts->id, ts->iter_cnt,
-		       key_range_name, stop_at, num_keys);
-	interact(0);
+    if (opt.verbose > 2 || opt.interactive)
+        printf("T%03u I%lu: verify(%s) %lu of %lu keys\n",
+               ts->id, ts->iter_cnt,
+               key_range_name, stop_at, num_keys);
+    interact(0);
 
-	for (i = 0; i < stop_at; i++) {
+    for (i = 0; i < stop_at; i++) {
 
-		if (atomic_read(&test.hard_stop))
-			break;
+        if (atomic_read(&test.hard_stop))
+            break;
 
-		keynum = i + ts->key_space_offset + first_key;
+        keynum = i + ts->key_space_offset + first_key;
 
-		rsgen_str(&test.kgen, ts->id, keynum, ts->iter_cnt, 0,
-			  ts->genkey, &gen_klen);
+        rsgen_str(&test.kgen, ts->id, keynum, ts->iter_cnt, 0,
+              ts->genkey, &gen_klen);
 
-		klen = gen_klen;
-		key = ts->genkey;
+        klen = gen_klen;
+        key = ts->genkey;
 
-		if (opt.verbose > 3)
-			printf("T%03d I%lu: hse_kvs_get(%s) "
-			       "key#%lu len=%lu key=%s\n",
-			       ts->id, ts->iter_cnt, key_range_name,
-			       keynum, (size_t)klen,
-			       hexstr(ts->genkey, klen,
-				      ts->msgbuf, sizeof(ts->msgbuf)));
+        if (opt.verbose > 3)
+            printf("T%03d I%lu: hse_kvs_get(%s) "
+                   "key#%lu len=%lu key=%s\n",
+                   ts->id, ts->iter_cnt, key_range_name,
+                   keynum, (size_t)klen,
+                   hexstr(ts->genkey, klen,
+                      ts->msgbuf, sizeof(ts->msgbuf)));
 
-		found = false;
-		rc = xkvs_get(&test, ts->genkey, klen, &found,
-			      ts->act_val, &vlen);
-		if (rc) {
-			fprintf(stderr, "T%03d I%lu: Error: verify %s %lu: "
-				"hse_kvs_get failed\n",
-				ts->id, ts->iter_cnt,
-				key_range_name, keynum);
-			hard_stop();
-			return;
-		}
+        found = false;
+        rc = xkvs_get(&test, ts->genkey, klen, &found,
+                  ts->act_val, &vlen);
+        if (rc) {
+            fprintf(stderr, "T%03d I%lu: Error: verify %s %lu: "
+                "hse_kvs_get failed\n",
+                ts->id, ts->iter_cnt,
+                key_range_name, keynum);
+            hard_stop();
+            return;
+        }
 
-		ts->get_cnt += 1;
+        ts->get_cnt += 1;
 
-		explen = 0;
-		exp    = 0;
-		errmsg = 0;
+        explen = 0;
+        exp    = 0;
+        errmsg = 0;
 
-		if (verify_delete) {
-			if (found)
-				errmsg = "found deleted key";
-		} else {
-			rsgen_str(&test.vgen, ts->id, keynum, ts->iter_cnt, tag,
-				  ts->exp_val, &explen);
-			exp = ts->exp_val;
+        if (verify_delete) {
+            if (found)
+                errmsg = "found deleted key";
+        } else {
+            rsgen_str(&test.vgen, ts->id, keynum, ts->iter_cnt, tag,
+                  ts->exp_val, &explen);
+            exp = ts->exp_val;
 
-			if (!found)
-				errmsg = "key not found";
-			else if (vlen != explen)
-				errmsg = "key found, but value length is wrong";
-			else if (memcmp(ts->act_val, exp, explen))
-				errmsg = "key found, but value is wrong";
-		}
+            if (!found)
+                errmsg = "key not found";
+            else if (vlen != explen)
+                errmsg = "key found, but value length is wrong";
+            else if (memcmp(ts->act_val, exp, explen))
+                errmsg = "key found, but value is wrong";
+        }
 
-		if (errmsg && !opt.dryrun &&
-		    do_error(ts, keynum, key_range_name, errmsg,
-					key, klen, ts->act_val, vlen,
-					exp, explen, verify_delete, found))
-			hard_stop();
-	}
+        if (errmsg && !opt.dryrun &&
+            do_error(ts, keynum, key_range_name, errmsg,
+                    key, klen, ts->act_val, vlen,
+                    exp, explen, verify_delete, found))
+            hard_stop();
+    }
 }
 
 
 void
 do_one_iteration(
-	struct tstate  *ts)
+    struct tstate  *ts)
 {
-	u64     u_len, d1_len, d2_len;
+    u64     u_len, d1_len, d2_len;
 
-	/* Setup ranges for this iteration as follows:
-	 *
-	 *   Put:      PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP
-	 *   Update:   UUUUUUUUUUUUUUUU................
-	 *   Delete_1: ........................DDDDDDDD
-	 *   Delete_2: DDDDDDDD........................
-	 *
-	 * Final state after 4 modify ops:
-	 *
-	 *   final:    DDDDDDDDUUUUUUUUPPPPPPPPDDDDDDDD
-	 *
-	 * Set U and D1 range sizes to 10% and 5% of total respectively,
-	 * unless 5% of total is 0, then bump to 50% and 25%.  Might
-	 * still end up with U and/or D1 range sizes being zero -- if
-	 * that's true there just aren't enough keys to populate each
-	 * range.  Set D2 range to be the same size as D1.
-	 */
-	u_len    = ts->num_keys / 10;
-	d1_len   = ts->num_keys / 20;
-	if (d1_len == 0) {
-		u_len  = ts->num_keys / 2;
-		d1_len = ts->num_keys / 4;
-	}
-	d2_len = d1_len;
+    /* Setup ranges for this iteration as follows:
+     *
+     *   Put:      PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP
+     *   Update:   UUUUUUUUUUUUUUUU................
+     *   Delete_1: ........................DDDDDDDD
+     *   Delete_2: DDDDDDDD........................
+     *
+     * Final state after 4 modify ops:
+     *
+     *   final:    DDDDDDDDUUUUUUUUPPPPPPPPDDDDDDDD
+     *
+     * Set U and D1 range sizes to 10% and 5% of total respectively,
+     * unless 5% of total is 0, then bump to 50% and 25%.  Might
+     * still end up with U and/or D1 range sizes being zero -- if
+     * that's true there just aren't enough keys to populate each
+     * range.  Set D2 range to be the same size as D1.
+     */
+    u_len    = ts->num_keys / 10;
+    d1_len   = ts->num_keys / 20;
+    if (d1_len == 0) {
+        u_len  = ts->num_keys / 2;
+        d1_len = ts->num_keys / 4;
+    }
+    d2_len = d1_len;
 
-	/* KVS State:  <empty> */
-	if (opt.mphase & PHASE_PUT_P)
-		do_puts(ts, 0, ts->num_keys, "P", 'P');
+    /* KVS State:  <empty> */
+    if (opt.mphase & PHASE_PUT_P)
+        do_puts(ts, 0, ts->num_keys, "P", 'P');
 
-	if (opt.sync == -1 || opt.sync == ts->id) {
-		interact("hse_kvdb_sync");
-		hse_kvdb_sync(test.kvdb_h, 0);
-	}
+    if (opt.sync == -1 || opt.sync == ts->id) {
+        interact("hse_kvdb_sync");
+        hse_kvdb_sync(test.kvdb_h, 0);
+    }
 
-	/* KVS State:  PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP */
+    /* KVS State:  PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP */
 
-	if (opt.mphase & PHASE_PUT_PU)
-		do_puts(ts, 0, u_len, "PU", 'U');
+    if (opt.mphase & PHASE_PUT_PU)
+        do_puts(ts, 0, u_len, "PU", 'U');
 
-	/* KVS State:  UUUUUUUUUUUUUUUUPPPPPPPPPPPPPPPP */
+    /* KVS State:  UUUUUUUUUUUUUUUUPPPPPPPPPPPPPPPP */
 
-	if (opt.mphase & PHASE_DEL_P)
-		do_deletes(ts, ts->num_keys - d2_len, d2_len, "PD");
+    if (opt.mphase & PHASE_DEL_P)
+        do_deletes(ts, ts->num_keys - d2_len, d2_len, "PD");
 
-	/* KVS State:  UUUUUUUUUUUUUUUUPPPPPPPPDDDDDDDD */
+    /* KVS State:  UUUUUUUUUUUUUUUUPPPPPPPPDDDDDDDD */
 
-	if (opt.mphase & PHASE_DEL_PU)
-		do_deletes(ts, 0, d1_len, "PUD");
+    if (opt.mphase & PHASE_DEL_PU)
+        do_deletes(ts, 0, d1_len, "PUD");
 
-	/* KVS State:  DDDDDDDDUUUUUUUUPPPPPPPPDDDDDDDD */
+    /* KVS State:  DDDDDDDDUUUUUUUUPPPPPPPPDDDDDDDD */
 
-	if (opt.cursor) {
-		do_cursor_verify(ts, d1_len, u_len, ts->num_keys);
-		goto del_rem;
-	}
+    if (opt.cursor) {
+        do_cursor_verify(ts, d1_len, u_len, ts->num_keys);
+        goto del_rem;
+    }
 
-	if (opt.mphase & PHASE_VER_P)
-		do_verifies(ts, u_len, ts->num_keys - d2_len - u_len, "P", 'P');
-	if (opt.mphase & PHASE_VER_PU)
-		do_verifies(ts, d1_len, u_len - d1_len, "PU", 'U');
-	if (opt.mphase & PHASE_VER_PUD)
-		do_verifies(ts, 0, d1_len, "PUD", 'D');
-	if (opt.mphase & PHASE_VER_PD)
-		do_verifies(ts, ts->num_keys - d2_len, d2_len, "PD", 'D');
+    if (opt.mphase & PHASE_VER_P)
+        do_verifies(ts, u_len, ts->num_keys - d2_len - u_len, "P", 'P');
+    if (opt.mphase & PHASE_VER_PU)
+        do_verifies(ts, d1_len, u_len - d1_len, "PU", 'U');
+    if (opt.mphase & PHASE_VER_PUD)
+        do_verifies(ts, 0, d1_len, "PUD", 'D');
+    if (opt.mphase & PHASE_VER_PD)
+        do_verifies(ts, ts->num_keys - d2_len, d2_len, "PD", 'D');
 
 del_rem:
 
-	/* Delete remaining keys */
-	if (opt.mphase & PHASE_DEL_REM)
-		do_deletes(ts, d1_len, ts->num_keys - d1_len - d2_len, "REM");
+    /* Delete remaining keys */
+    if (opt.mphase & PHASE_DEL_REM)
+        do_deletes(ts, d1_len, ts->num_keys - d1_len - d2_len, "REM");
 
-	/* Verify remaining keys deleted */
-	if (opt.mphase & PHASE_VER_REM) {
-		if (opt.cursor)
-			do_cursor_verify(ts, 0, 0, 0);
-		else
-			do_verifies(ts, d1_len, ts->num_keys - d1_len - d2_len,
-			    "REM", 'D');
-	}
+    /* Verify remaining keys deleted */
+    if (opt.mphase & PHASE_VER_REM) {
+        if (opt.cursor)
+            do_cursor_verify(ts, 0, 0, 0);
+        else
+            do_verifies(ts, d1_len, ts->num_keys - d1_len - d2_len,
+                "REM", 'D');
+    }
 }
 
 bool
 test_done(
-	void)
+    void)
 {
-	return atomic_read(&test.test_complete) ||
-		atomic_read(&test.hard_stop);
+    return atomic_read(&test.test_complete) ||
+        atomic_read(&test.hard_stop);
 }
 
 
 void *
 seqnum_pfx_thread(
-	void *rock)
+    void *rock)
 {
-	struct tstate      *ts = (struct tstate *)rock;
-	u64                 rc;
+    struct tstate      *ts = (struct tstate *)rock;
+    u64                 rc;
 
-	bar_sync();
+    bar_sync();
 
-	while (!test_done()) {
-		usleep(10*1000);
-		rc = xkvs_prefix_delete(&test, test.seqnum_pfx_key,
-					opt.seqnum_pfx);
-		if (rc) {
-			fprintf(stderr,
-				"%s: hse_kvs_prefix_delete failed\n",
-				progname);
-			hard_stop();
-		}
-	}
+    while (!test_done()) {
+        usleep(10*1000);
+        rc = xkvs_prefix_delete(&test, test.seqnum_pfx_key,
+                    opt.seqnum_pfx);
+        if (rc) {
+            fprintf(stderr,
+                "%s: hse_kvs_prefix_delete failed\n",
+                progname);
+            hard_stop();
+        }
+    }
 
-	ts->running = false;
-	return NULL;
+    ts->running = false;
+    return NULL;
 }
 
 
 void *
 test_main(
-	void *rock)
+    void *rock)
 {
-	int                 err = 0;
-	struct tstate      *ts = (struct tstate *)rock;
+    int                 err = 0;
+    struct tstate      *ts = (struct tstate *)rock;
 
-	if (ts->num_keys == 0) {
-		fprintf(stderr,
-			"Error: thread %d has no keys!\n"
-			"Try one or more of the following:\n"
-			"  1. more keys\n"
-			"  2. fewer threads\n"
-			"  3. smaller value with --poly or --exp\n",
-			ts->id);
-		err = 1;
-	}
+    if (ts->num_keys == 0) {
+        fprintf(stderr,
+            "Error: thread %d has no keys!\n"
+            "Try one or more of the following:\n"
+            "  1. more keys\n"
+            "  2. fewer threads\n"
+            "  3. smaller value with --poly or --exp\n",
+            ts->id);
+        err = 1;
+    }
 
-	if (err)
-		hard_stop();
+    if (err)
+        hard_stop();
 
-	bar_sync();
+    bar_sync();
 
-	do {
-		if (opt.mthread == -1 || opt.mthread == (int)ts->id) {
-			do_one_iteration(ts);
-			ts->iter_cnt += 1;
-		}
+    do {
+        if (opt.mthread == -1 || opt.mthread == (int)ts->id) {
+            do_one_iteration(ts);
+            ts->iter_cnt += 1;
+        }
 
-		if (opt.once ||
-		    (ts->num_iters > 0 && ts->iter_cnt == ts->num_iters))
-			atomic_set(&test.test_complete, 1);
+        if (opt.once ||
+            (ts->num_iters > 0 && ts->iter_cnt == ts->num_iters))
+            atomic_set(&test.test_complete, 1);
 
-	} while (!test_done());
+    } while (!test_done());
 
-	ts->running = false;
-	return NULL;
+    ts->running = false;
+    return NULL;
 }
 
 
 int
 test_init(
-	void)
+    void)
 {
-	double *dist = 0;
-	u64    *keys = 0;
-	u64     assigned_keys = 0;
-	u32     i;
-	u32     max_iter = 0;
+    double *dist = 0;
+    u64    *keys = 0;
+    u64     assigned_keys = 0;
+    u32     i;
+    u32     max_iter = 0;
 
-	memset(&test, 0, sizeof(test));
+    memset(&test, 0, sizeof(test));
 
-	dist = (double *)malloc(sizeof(double) * opt.test_threads);
-	keys = (u64 *)malloc(sizeof(u64) * opt.test_threads);
-	if (!dist || !keys) {
-		fprintf(stderr, "Error: out of memory\n");
-		goto error;
-	}
+    dist = (double *)malloc(sizeof(double) * opt.test_threads);
+    keys = (u64 *)malloc(sizeof(u64) * opt.test_threads);
+    if (!dist || !keys) {
+        fprintf(stderr, "Error: out of memory\n");
+        goto error;
+    }
 
-	test.running_threads = opt.test_threads;
-	if (opt.seqnum_pfx)
-		++test.running_threads;
-	if (pthread_barrier_init(&test.bar_sync, NULL,
-				 (unsigned)test.running_threads+1)) {
-		perror("Error: pthread_barrier_init");
-		goto error;
-	}
+    test.running_threads = opt.test_threads;
+    if (opt.seqnum_pfx)
+        ++test.running_threads;
+    if (pthread_barrier_init(&test.bar_sync, NULL,
+                 (unsigned)test.running_threads+1)) {
+        perror("Error: pthread_barrier_init");
+        goto error;
+    }
 
-	for (i = 0; i < test.running_threads; i++)
-		test.ts[i].id = i;
+    for (i = 0; i < test.running_threads; i++)
+        test.ts[i].id = i;
 
-	/* Determine how many keys each thread will manage. */
-	if (opt.distr_is_exp) {
-		if (exp_dist(opt.distr_param, opt.test_threads, dist))
-			goto error;
-	} else {
-		if (poly_dist(opt.distr_param, opt.test_threads, dist))
-			goto error;
-	}
+    /* Determine how many keys each thread will manage. */
+    if (opt.distr_is_exp) {
+        if (exp_dist(opt.distr_param, opt.test_threads, dist))
+            goto error;
+    } else {
+        if (poly_dist(opt.distr_param, opt.test_threads, dist))
+            goto error;
+    }
 
-	if (normalize_dist(dist, opt.test_threads, opt.keys, keys))
-		goto error;
+    if (normalize_dist(dist, opt.test_threads, opt.keys, keys))
+        goto error;
 
-	/* flip the distribution so thread 0 has the most keys */
-	for (i = 0; i < opt.test_threads; i++) {
-		struct tstate *ts = test.ts + i;
-		u64 nkeys = keys[opt.test_threads-1-i];
+    /* flip the distribution so thread 0 has the most keys */
+    for (i = 0; i < opt.test_threads; i++) {
+        struct tstate *ts = test.ts + i;
+        u64 nkeys = keys[opt.test_threads-1-i];
 
-		ts->key_space_offset = assigned_keys;
-		ts->num_keys  = nkeys;
-		assigned_keys += nkeys;
-	}
-	if (opt.keys != assigned_keys) {
-		fprintf(stderr,
-			"Error: opt.keys (%lu) != assigned_keys (%lu)\n"
-			"Bad logic in longtest!\n",
-			opt.keys, assigned_keys);
-		goto error;
-	}
+        ts->key_space_offset = assigned_keys;
+        ts->num_keys  = nkeys;
+        assigned_keys += nkeys;
+    }
+    if (opt.keys != assigned_keys) {
+        fprintf(stderr,
+            "Error: opt.keys (%lu) != assigned_keys (%lu)\n"
+            "Bad logic in longtest!\n",
+            opt.keys, assigned_keys);
+        goto error;
+    }
 
-	/*
-	 * There are multiple iterations for every use case except
-	 *	-i1 --once or -i1 -t1 or -s1 -t100 -c1 (silly);
-	 * every other case has at least 2 iterations possible.
-	 *
-	 * With a min iteration elapsed time of 100ms (of interest),
-	 * there cannot be more than 86400 / .1 = 864,000 iterations / day.
-	 * Assuming constant iteration elapsed time, the thread with
-	 * least keys will run max / min + 1 times for each max thread.
-	 */
+    /*
+     * There are multiple iterations for every use case except
+     *	-i1 --once or -i1 -t1 or -s1 -t100 -c1 (silly);
+     * every other case has at least 2 iterations possible.
+     *
+     * With a min iteration elapsed time of 100ms (of interest),
+     * there cannot be more than 86400 / .1 = 864,000 iterations / day.
+     * Assuming constant iteration elapsed time, the thread with
+     * least keys will run max / min + 1 times for each max thread.
+     */
 
-	max_iter = opt.duration ? opt.duration * 10 : opt.num_iters;
-	max_iter *= 1 + keys[0] / keys[opt.test_threads - 1];
+    max_iter = opt.duration ? opt.duration * 10 : opt.num_iters;
+    max_iter *= 1 + keys[0] / keys[opt.test_threads - 1];
 
-	/* initialize key and value generators */
-	if (rsgen_init(&test.kgen, opt.keys, max_iter,
-		       false, opt.kmin, opt.kmax, opt.test_threads, opt.seed)) {
-		fprintf(stderr,
-			"Error: Invalid key length: %s\n",
-			test.kgen.rs_errmsg);
-		goto error;
-	}
-	if (rsgen_init(&test.vgen, opt.keys, max_iter,
-		       true, opt.vmin, opt.vmax, 0, opt.seed ^ 0x01010101)) {
-		fprintf(stderr,
-			"Error: Invalid value length: %s\n",
-			test.vgen.rs_errmsg);
-		goto error;
-	}
+    /* initialize key and value generators */
+    if (rsgen_init(&test.kgen, opt.keys, max_iter,
+               false, opt.kmin, opt.kmax, opt.test_threads, opt.seed)) {
+        fprintf(stderr,
+            "Error: Invalid key length: %s\n",
+            test.kgen.rs_errmsg);
+        goto error;
+    }
+    if (rsgen_init(&test.vgen, opt.keys, max_iter,
+               true, opt.vmin, opt.vmax, 0, opt.seed ^ 0x01010101)) {
+        fprintf(stderr,
+            "Error: Invalid value length: %s\n",
+            test.vgen.rs_errmsg);
+        goto error;
+    }
 
-	/* if there are to be thread ids as prefixes, init them here */
-	if (opt.cursor && opt.test_threads > 1) {
-		for (i = 0; i < opt.test_threads; i++) {
-			test.ts[i].pfx = test.ts[i].pfxbuf;
-			test.ts[i].pfxlen = test.kgen.rs_prefix_tid_bytes;
-			rsgen_set_tid(&test.kgen, test.ts[i].pfxbuf, i);
-		}
-	}
+    /* if there are to be thread ids as prefixes, init them here */
+    if (opt.cursor && opt.test_threads > 1) {
+        for (i = 0; i < opt.test_threads; i++) {
+            test.ts[i].pfx = test.ts[i].pfxbuf;
+            test.ts[i].pfxlen = test.kgen.rs_prefix_tid_bytes;
+            rsgen_set_tid(&test.kgen, test.ts[i].pfxbuf, i);
+        }
+    }
 
-	/* set thread 0's iter count (or mthread if running a single thread) */
-	if (opt.num_iters) {
-		if (opt.mthread == -1)
-			test.ts[0].num_iters = opt.num_iters;
-		else
-			test.ts[opt.mthread].num_iters = opt.num_iters;
-	}
+    /* set thread 0's iter count (or mthread if running a single thread) */
+    if (opt.num_iters) {
+        if (opt.mthread == -1)
+            test.ts[0].num_iters = opt.num_iters;
+        else
+            test.ts[opt.mthread].num_iters = opt.num_iters;
+    }
 
-	free(dist);
-	free(keys);
-	return 0;
+    free(dist);
+    free(keys);
+    return 0;
 
 error:
-	free(dist);
-	free(keys);
-	rsgen_fini(&test.kgen);
-	if (opt.vmax)
-		rsgen_fini(&test.vgen);
-	return -1;
+    free(dist);
+    free(keys);
+    rsgen_fini(&test.kgen);
+    if (opt.vmax)
+        rsgen_fini(&test.vgen);
+    return -1;
 }
 
 void
 test_fini(
-	void)
+    void)
 {
-	rsgen_fini(&test.kgen);
-	if (opt.vmax)
-		rsgen_fini(&test.vgen);
+    rsgen_fini(&test.kgen);
+    if (opt.vmax)
+        rsgen_fini(&test.vgen);
 
-	free(keystats);
-	keystats = NULL;
+    free(keystats);
+    keystats = NULL;
 }
 
 
 void
 test_stats_header(
-	void)
+    void)
 {
-	printf("stats: %8s %8s %8s %8s %8s %8s %8s\n",
-	       "seconds", "put_ins", "put_upd", "put_del",
-	       "puts", "gets", "ops");
+    printf("stats: %8s %8s %8s %8s %8s %8s %8s\n",
+           "seconds", "put_ins", "put_upd", "put_del",
+           "puts", "gets", "ops");
 }
 
 void
 get_stats(
-	struct test_stats   curr[MAX_THREADS],
-	struct test_stats  *tot,
-	u64                *elapsed_time)
+    struct test_stats   curr[MAX_THREADS],
+    struct test_stats  *tot,
+    u64                *elapsed_time)
 {
-	u32 i;
+    u32 i;
 
-	/* get "snapshot" of thread counters */
-	for (i = 0; i < opt.test_threads; i++) {
-		curr[i].puts = test.ts[i].put_cnt;
-		curr[i].upds = test.ts[i].upd_cnt;
-		curr[i].dels = test.ts[i].del_cnt;
-		curr[i].gets = test.ts[i].get_cnt;
-		curr[i].iters = test.ts[i].iter_cnt;
-		curr[i].ops = (curr[i].puts +
-			       curr[i].upds +
-			       curr[i].gets +
-			       curr[i].dels);
-	}
+    /* get "snapshot" of thread counters */
+    for (i = 0; i < opt.test_threads; i++) {
+        curr[i].puts = test.ts[i].put_cnt;
+        curr[i].upds = test.ts[i].upd_cnt;
+        curr[i].dels = test.ts[i].del_cnt;
+        curr[i].gets = test.ts[i].get_cnt;
+        curr[i].iters = test.ts[i].iter_cnt;
+        curr[i].ops = (curr[i].puts +
+                   curr[i].upds +
+                   curr[i].gets +
+                   curr[i].dels);
+    }
 
-	*elapsed_time = gtod_usec() - test.start_time;
+    *elapsed_time = gtod_usec() - test.start_time;
 
-	/* compute totals */
-	memset(tot, 0, sizeof(*tot));
-	for (i = 0; i < opt.test_threads; i++) {
-		tot->puts  += curr[i].puts;
-		tot->upds  += curr[i].upds;
-		tot->dels  += curr[i].dels;
-		tot->gets  += curr[i].gets;
-		tot->iters += curr[i].iters;
-		tot->ops   += curr[i].ops;
-	}
+    /* compute totals */
+    memset(tot, 0, sizeof(*tot));
+    for (i = 0; i < opt.test_threads; i++) {
+        tot->puts  += curr[i].puts;
+        tot->upds  += curr[i].upds;
+        tot->dels  += curr[i].dels;
+        tot->gets  += curr[i].gets;
+        tot->iters += curr[i].iters;
+        tot->ops   += curr[i].ops;
+    }
 }
 
 
 void
 test_stats(
-	void)
+    void)
 {
-	u64 elapsed_time;
+    u64 elapsed_time;
 
-	struct test_stats curr[MAX_THREADS];
-	struct test_stats tot;
-	struct test_stats delta;
+    struct test_stats curr[MAX_THREADS];
+    struct test_stats tot;
+    struct test_stats delta;
 
-	get_stats(curr, &tot, &elapsed_time);
+    get_stats(curr, &tot, &elapsed_time);
 
-	/* compute delta */
-	delta.puts  = tot.puts  - test.tot.puts;
-	delta.upds  = tot.upds  - test.tot.upds;
-	delta.dels  = tot.dels  - test.tot.dels;
-	delta.gets  = tot.gets  - test.tot.gets;
-	delta.iters = tot.iters - test.tot.iters;
-	delta.ops   = tot.ops   - test.tot.ops;
+    /* compute delta */
+    delta.puts  = tot.puts  - test.tot.puts;
+    delta.upds  = tot.upds  - test.tot.upds;
+    delta.dels  = tot.dels  - test.tot.dels;
+    delta.gets  = tot.gets  - test.tot.gets;
+    delta.iters = tot.iters - test.tot.iters;
+    delta.ops   = tot.ops   - test.tot.ops;
 
-	/* update totals for next time */
-	test.tot.puts  = tot.puts;
-	test.tot.upds  = tot.upds;
-	test.tot.dels  = tot.dels;
-	test.tot.gets  = tot.gets;
-	test.tot.iters = tot.iters;
-	test.tot.ops   = tot.ops;
+    /* update totals for next time */
+    test.tot.puts  = tot.puts;
+    test.tot.upds  = tot.upds;
+    test.tot.dels  = tot.dels;
+    test.tot.gets  = tot.gets;
+    test.tot.iters = tot.iters;
+    test.tot.ops   = tot.ops;
 
-	/* report */
-	if (test.stat_rows_no_hdr > 20)
-		test.stat_rows_no_hdr = 0;
+    /* report */
+    if (test.stat_rows_no_hdr > 20)
+        test.stat_rows_no_hdr = 0;
 
-	if (test.stat_rows_no_hdr == 0)
-		test_stats_header();
+    if (test.stat_rows_no_hdr == 0)
+        test_stats_header();
 
-	test.stat_rows_no_hdr++;
+    test.stat_rows_no_hdr++;
 
-	printf("stats: %8.3f %8lu %8lu %8lu %8lu %8lu %8lu\n",
-	       elapsed_time * 1e-6,
-	       delta.puts, delta.upds, delta.dels,
-	       delta.puts + delta.upds + delta.dels,
-	       delta.gets,
-	       delta.ops);
+    printf("stats: %8.3f %8lu %8lu %8lu %8lu %8lu %8lu\n",
+           elapsed_time * 1e-6,
+           delta.puts, delta.upds, delta.dels,
+           delta.puts + delta.upds + delta.dels,
+           delta.gets,
+           delta.ops);
 }
 
 void
 test_summary(
-	void)
+    void)
 {
-	int     i;
-	u64     elapsed_time;
+    int     i;
+    u64     elapsed_time;
 
-	struct test_stats   curr[MAX_THREADS];
-	struct test_stats   tot;
-	struct test_stats  *s;
+    struct test_stats   curr[MAX_THREADS];
+    struct test_stats   tot;
+    struct test_stats  *s;
 
-	get_stats(curr, &tot, &elapsed_time);
+    get_stats(curr, &tot, &elapsed_time);
 
-	printf("Op counts by thread:\n");
-	printf("summary: %8s %8s %8s %8s %8s %8s %8s %8s\n",
-	       "thread", "iters",
-	       "put_ins", "put_upd", "put_del",
-	       "puts",
-	       "gets",
-	       "ops");
+    printf("Op counts by thread:\n");
+    printf("summary: %8s %8s %8s %8s %8s %8s %8s %8s\n",
+           "thread", "iters",
+           "put_ins", "put_upd", "put_del",
+           "puts",
+           "gets",
+           "ops");
 
-	for (i = 0; i < opt.test_threads; i++) {
-		s = curr + i;
-		printf("summary: %8d %8lu %8lu %8lu %8lu %8lu %8lu %8lu\n",
-		       i, s->iters,
-		       s->puts, s->upds, s->dels,
-		       s->puts + s->upds + s->dels,
-		       s->gets,
-		       s->puts + s->upds + s->dels + s->gets);
-	}
+    for (i = 0; i < opt.test_threads; i++) {
+        s = curr + i;
+        printf("summary: %8d %8lu %8lu %8lu %8lu %8lu %8lu %8lu\n",
+               i, s->iters,
+               s->puts, s->upds, s->dels,
+               s->puts + s->upds + s->dels,
+               s->gets,
+               s->puts + s->upds + s->dels + s->gets);
+    }
 
-	s = &tot;
-	printf("summary: %8s %8lu %8lu %8lu %8lu %8lu %8lu %8lu\n",
-	       "Total", s->iters,
-	       s->puts, s->upds, s->dels,
-	       s->puts + s->upds + s->dels,
-	       s->gets,
-	       s->puts + s->upds + s->dels + s->gets);
+    s = &tot;
+    printf("summary: %8s %8lu %8lu %8lu %8lu %8lu %8lu %8lu\n",
+           "Total", s->iters,
+           s->puts, s->upds, s->dels,
+           s->puts + s->upds + s->dels,
+           s->gets,
+           s->puts + s->upds + s->dels + s->gets);
 }
 
 
@@ -1995,230 +1994,230 @@ test_summary(
 
 bool
 test_threads_running(
-	void)
+    void)
 {
-	int i;
+    int i;
 
-	for (i = 0; i < opt.test_threads; i++)
-		if (test.ts[i].running)
-			return true;
-	return false;
+    for (i = 0; i < opt.test_threads; i++)
+        if (test.ts[i].running)
+            return true;
+    return false;
 }
 
 int
 test_run(
-	void)
+    void)
 {
-	int             errors;
-	u64             rc;
-	u64             elapsed_time;
-	u64             last_report = 0;
-	unsigned int    idxv;
+    int             errors;
+    u64             rc;
+    u64             elapsed_time;
+    u64             last_report = 0;
+    unsigned int    idxv;
 
-	rc = xkvdb_kvs_open(&test, &idxv, opt.mpool, opt.kvs);
-	if (rc) {
-		fprintf(stderr, "%s: kvs_open(%s,%s) failed\n",
-			progname, opt.mpool, opt.kvs);
-		return -1;
-	}
+    rc = xkvdb_kvs_open(&test, &idxv, opt.mpool, opt.kvs);
+    if (rc) {
+        fprintf(stderr, "%s: kvs_open(%s,%s) failed\n",
+            progname, opt.mpool, opt.kvs);
+        return -1;
+    }
 
-	start_threads();
-	bar_sync();
-	test.start_time = gtod_usec();
+    start_threads();
+    bar_sync();
+    test.start_time = gtod_usec();
 
-	while (test_threads_running()) {
+    while (test_threads_running()) {
 
-		elapsed_time = gtod_usec() - test.start_time;
-		if (opt.duration && elapsed_time > opt.duration*1000*1000)
-			atomic_set(&test.test_complete, 1);
+        elapsed_time = gtod_usec() - test.start_time;
+        if (opt.duration && elapsed_time > opt.duration*1000*1000)
+            atomic_set(&test.test_complete, 1);
 
-		if (opt.stats) {
-			if (!last_report)
-				last_report = elapsed_time;
-			else if (elapsed_time - last_report > 1000*1000) {
-				last_report = elapsed_time;
-				test_stats();
-			}
-		}
+        if (opt.stats) {
+            if (!last_report)
+                last_report = elapsed_time;
+            else if (elapsed_time - last_report > 1000*1000) {
+                last_report = elapsed_time;
+                test_stats();
+            }
+        }
 
-		usleep(10*1000);
-	}
+        usleep(10*1000);
+    }
 
-	join_threads();
+    join_threads();
 
-	if (opt.stats)
-		test_stats();
+    if (opt.stats)
+        test_stats();
 
-	if (opt.verbose)
-		test_summary();
+    if (opt.verbose)
+        test_summary();
 
-	rc = xkvdb_kvs_close(&test);
-	if (rc) {
-		fprintf(stderr, "%s: kvs_close %s/%s failed\n",
-			progname, opt.mpool, opt.kvs);
-	}
+    rc = xkvdb_kvs_close(&test);
+    if (rc) {
+        fprintf(stderr, "%s: kvs_close %s/%s failed\n",
+            progname, opt.mpool, opt.kvs);
+    }
 
-	errors = atomic_read(&test.errors);
-	if (errors)
-		fprintf(stderr, "Error: %d verify errors occurred\n", errors);
+    errors = atomic_read(&test.errors);
+    if (errors)
+        fprintf(stderr, "Error: %d verify errors occurred\n", errors);
 
-	return rc;
+    return rc;
 }
 
 int
 main(int argc, char **argv)
 {
-	int     err = 0;
-	int     i;
+    int     err = 0;
+    int     i;
 
-	setvbuf(stdout, NULL, _IOLBF, 0);
-	progname = strrchr(argv[0], '/');
-	progname = progname ? progname + 1 : argv[0];
+    progname_set(argv[0]);
 
-	opts_set_default(&opt);
-	opts_parse(argc, argv, &opt);
+    setvbuf(stdout, NULL, _IOLBF, 0);
 
-	if (opt.version || opt.help)
-		goto done;
+    opts_set_default(&opt);
+    opts_parse(argc, argv, &opt);
 
-	err = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, NULL);
-	if (err) {
-		fprintf(stderr, "pg_create: rc %d\n", err);
-		goto done;
-	}
+    if (opt.version || opt.help)
+        goto done;
 
-	if (argc - optind < 2)
-		syntax("Missing required parameters");
+    err = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, NULL);
+    if (err) {
+        fprintf(stderr, "pg_create: rc %d\n", err);
+        goto done;
+    }
 
-	opt.mpool = argv[optind++];
-	opt.kvs   = argv[optind++];
+    if (argc - optind < 2)
+        syntax("Missing required parameters");
 
-	if (opt.interactive && opt.test_threads != 1)
-		syntax("Interactive mode only supported with one thread");
+    opt.mpool = argv[optind++];
+    opt.kvs   = argv[optind++];
 
-	/* iters and duration */
-	if (opt.num_iters && opt.duration)
-		syntax("Pick -i or -s but not both");
-	if (!opt.num_iters && !opt.duration)
-		opt.num_iters = 1;
+    if (opt.interactive && opt.test_threads != 1)
+        syntax("Interactive mode only supported with one thread");
 
-	/* threads */
-	if (opt.test_threads == 0 || opt.test_threads > MAX_TEST_THREADS)
-		syntax("Invalid thread count: %u (valid range: 0..%u)",
-		       opt.test_threads, MAX_TEST_THREADS);
-	if (opt.mthread != -1)
-		if (opt.mthread < 0 || opt.mthread >= opt.test_threads)
-			syntax("Invalid mthread value: %d\n", opt.mthread);
+    /* iters and duration */
+    if (opt.num_iters && opt.duration)
+        syntax("Pick -i or -s but not both");
+    if (!opt.num_iters && !opt.duration)
+        opt.num_iters = 1;
 
-	/* key len */
-	if (opt.kmax > MAX_KMAX)
-		syntax("Invalid key len range: %u..%u\n"
-		       "Max key len is %u\n",
-		       opt.kmin, opt.kmax, MAX_KMAX);
-	if (opt.kmin > opt.kmax)
-		opt.kmin = opt.kmax;
+    /* threads */
+    if (opt.test_threads == 0 || opt.test_threads > MAX_TEST_THREADS)
+        syntax("Invalid thread count: %u (valid range: 0..%u)",
+               opt.test_threads, MAX_TEST_THREADS);
+    if (opt.mthread != -1)
+        if (opt.mthread < 0 || opt.mthread >= opt.test_threads)
+            syntax("Invalid mthread value: %d\n", opt.mthread);
 
-	if (opt.cursor) {
-		/* rsgen cannot reliably decode keys longer than 8 bytes */
-		if (opt.kmax > 8)
-			syntax("cursor verify requires kmin <= kmax <= 8");
+    /* key len */
+    if (opt.kmax > MAX_KMAX)
+        syntax("Invalid key len range: %u..%u\n"
+               "Max key len is %u\n",
+               opt.kmin, opt.kmax, MAX_KMAX);
+    if (opt.kmin > opt.kmax)
+        opt.kmin = opt.kmax;
 
-		if (opt.verbose >= 1) {
-			size_t  sz = sizeof(*keystats) * opt.keys;
+    if (opt.cursor) {
+        /* rsgen cannot reliably decode keys longer than 8 bytes */
+        if (opt.kmax > 8)
+            syntax("cursor verify requires kmin <= kmax <= 8");
 
-			keystats = malloc(sz);
-			if (keystats)
-				memset(keystats, 0, sz);
-			else
-				printf("WARNING: per-key stats unavailable\n");
-		}
-	}
+        if (opt.verbose >= 1) {
+            size_t  sz = sizeof(*keystats) * opt.keys;
 
-	/* value len */
-	if (opt.vmax > MAX_VMAX)
-		syntax("Invalid value len range: %u..%u\n"
-		       "Max vlen is %u\n",
-		       opt.vmin, opt.vmax, MAX_VMAX);
-	if (opt.vmin > opt.vmax)
-		opt.vmin = opt.vmax;
+            keystats = malloc(sz);
+            if (keystats)
+                memset(keystats, 0, sz);
+            else
+                printf("WARNING: per-key stats unavailable\n");
+        }
+    }
 
-	/* mpool and kvs */
-	if (!opt.mpool || !opt.kvs)
-		syntax("Must indicate mpool and kvs");
+    /* value len */
+    if (opt.vmax > MAX_VMAX)
+        syntax("Invalid value len range: %u..%u\n"
+               "Max vlen is %u\n",
+               opt.vmin, opt.vmax, MAX_VMAX);
+    if (opt.vmin > opt.vmax)
+        opt.vmin = opt.vmax;
 
-	err = pg_parse_argv(pg, argc, argv, &optind);
-	switch (err) {
-		case 0:
-			if (optind < argc) {
-				fprintf(stderr, "unknown parameter: %s", argv[optind]);
-				exit(EX_USAGE);
-			}
-			break;
-		case EINVAL:
-			fprintf(stderr, "missing group name (e.g. %s) before parameter %s\n",
-				PG_KVDB_OPEN, argv[optind]);
-			exit(EX_USAGE);
-			break;
-		default:
-			fprintf(stderr, "error processing parameter %s\n", argv[optind]);
-			exit(EX_OSERR);
-			break;
-	}
+    /* mpool and kvs */
+    if (!opt.mpool || !opt.kvs)
+        syntax("Must indicate mpool and kvs");
 
-	err = err ?: svec_append_pg(&hse_gparm, pg, PG_HSE_GLOBAL, NULL);
-	err = err ?: svec_append_pg(&db_oparms, pg, PG_KVDB_OPEN, NULL);
-	err = err ?: svec_append_pg(&kv_oparms, pg, PG_KVS_OPEN, NULL);
-	if (err) {
-		fprintf(stderr, "svec_apppend_pg failed: %d\n", err);
-		exit(EX_OSERR);
-	}
+    err = pg_parse_argv(pg, argc, argv, &optind);
+    switch (err) {
+        case 0:
+            if (optind < argc) {
+                fprintf(stderr, "unknown parameter: %s", argv[optind]);
+                exit(EX_USAGE);
+            }
+            break;
+        case EINVAL:
+            fprintf(stderr, "missing group name (e.g. %s) before parameter %s\n",
+                PG_KVDB_OPEN, argv[optind]);
+            exit(EX_USAGE);
+            break;
+        default:
+            fprintf(stderr, "error processing parameter %s\n", argv[optind]);
+            exit(EX_OSERR);
+            break;
+    }
 
-	if (!opt.seed)
-		opt.seed = (u32)gtod_usec();
+    err = err ?: svec_append_pg(&hse_gparm, pg, PG_HSE_GLOBAL, NULL);
+    err = err ?: svec_append_pg(&db_oparms, pg, PG_KVDB_OPEN, NULL);
+    err = err ?: svec_append_pg(&kv_oparms, pg, PG_KVS_OPEN, NULL);
+    if (err) {
+        fprintf(stderr, "svec_apppend_pg failed: %d\n", err);
+        exit(EX_OSERR);
+    }
 
-	if (opt.verbose || opt.show)
-		opts_show(&opt);
+    if (!opt.seed)
+        opt.seed = (u32)gtod_usec();
 
-	err = test_init();
-	if (err)
-		goto done;
+    if (opt.verbose || opt.show)
+        opts_show(&opt);
 
-	/* show each thread's key count */
-	if (opt.verbose || opt.show) {
-		for (i = 0; i < opt.test_threads; i++)
-			printf("T%03d: %8lu keys\n", i, test.ts[i].num_keys);
-		if (opt.show)
-			goto done;
-	}
+    err = test_init();
+    if (err)
+        goto done;
 
-	err = hse_init(opt.config, hse_gparm.strc, hse_gparm.strv);
-	if (err) {
-		fprintf(stderr, "failed to initialize kvdb\n");
-		goto done;
-	}
+    /* show each thread's key count */
+    if (opt.verbose || opt.show) {
+        for (i = 0; i < opt.test_threads; i++)
+            printf("T%03d: %8lu keys\n", i, test.ts[i].num_keys);
+        if (opt.show)
+            goto done;
+    }
 
-	err = test_run();
-	if (err)
-		goto done;
+    err = hse_init(opt.config, hse_gparm.strc, hse_gparm.strv);
+    if (err) {
+        fprintf(stderr, "failed to initialize kvdb\n");
+        goto done;
+    }
 
-	/*
-	 * Hack: if #keys == 0, wait 100ms so we can use longtest with no
-	 * keys to do offline compaction.  Waiting a bit here gives
-	 * queued compaction tasks in CN a chance to get going.  Once
-	 * they get going, the unmount will wait for completion.
-	 */
-	if (opt.keys == 0)
-		usleep(100*1000);
+    err = test_run();
+    if (err)
+        goto done;
+
+    /*
+     * Hack: if #keys == 0, wait 100ms so we can use longtest with no
+     * keys to do offline compaction.  Waiting a bit here gives
+     * queued compaction tasks in CN a chance to get going.  Once
+     * they get going, the unmount will wait for completion.
+     */
+    if (opt.keys == 0)
+        usleep(100*1000);
 
 done:
-	test_fini();
+    test_fini();
 
-	pg_destroy(pg);
-	svec_reset(&hse_gparm);
-	svec_reset(&db_oparms);
-	svec_reset(&kv_oparms);
+    pg_destroy(pg);
+    svec_reset(&hse_gparm);
+    svec_reset(&db_oparms);
+    svec_reset(&kv_oparms);
 
-	hse_fini();
+    hse_fini();
 
-	return err;
+    return err;
 }

--- a/tools/mpool/mblock/mpiotest.c
+++ b/tools/mpool/mblock/mpiotest.c
@@ -29,14 +29,14 @@
 
 #include <bsd/string.h>
 
+#include <hse/cli/program.h>
 #include <hse/error/merr.h>
 #include <hse/hse.h>
+#include <hse/mpool/mpool.h>
+#include <hse/mpool/mcache.h>
 #include <hse/util/err_ctx.h>
 #include <hse/util/minmax.h>
 #include <hse/util/page.h>
-
-#include <hse/mpool/mpool.h>
-#include <hse/mpool/mcache.h>
 
 #define MBLOCK_SIZE_MB_DEFAULT (32 << 20)
 #define WANDERMAX              (1024 * 128)
@@ -82,7 +82,6 @@ struct test {
 };
 
 const char *infile = "/dev/urandom";
-const char *progname;
 
 uint   mballoc_max = 1024 * 1024 * 8;
 size_t wbufsz = MBLOCK_SIZE_MB_DEFAULT;
@@ -1021,8 +1020,7 @@ main(int argc, char **argv)
     FILE    *fp;
     int      fd, rc, i, given[256] = { 0 };
 
-    progname = strrchr(argv[0], '/');
-    progname = (progname ? progname + 1 : argv[0]);
+    progname_set(argv[0]);
 
     seed = time(NULL);
     oflags = O_RDWR;

--- a/tools/mpool/mdc/mdc_tool.c
+++ b/tools/mpool/mdc/mdc_tool.c
@@ -14,17 +14,15 @@
 #include <stdarg.h>
 #include <sysexits.h>
 
-#include <hse/logging/logging.h>
-#include <hse/ikvdb/kvdb_meta.h>
-
+#include <hse/cli/program.h>
 #include <hse/hse.h>
+#include <hse/ikvdb/kvdb_meta.h>
+#include <hse/logging/logging.h>
 #include <hse/mpool/mpool.h>
 
 #include <bsd/string.h>
 
 #define ERROR_BUF_SIZE 256
-
-static const char *progname;
 
 /*
  * MDC logs will never exceed a few MB
@@ -114,7 +112,7 @@ main(int argc, char **argv)
     struct mpool_rparams params = {0};
     struct kvdb_meta     meta;
 
-    progname = basename(argv[0]);
+    progname_set(argv[0]);
 
     wpath = 0;
     ignore = 0;

--- a/tools/mpool/mdc/mdcperf.c
+++ b/tools/mpool/mdc/mdcperf.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 /**
@@ -25,14 +25,14 @@
 
 #include <bsd/string.h>
 
+#include <hse/cli/program.h>
 #include <hse/error/merr.h>
+#include <hse/hse.h>
+#include <hse/mpool/mpool.h>
 #include <hse/util/atomic.h>
 #include <hse/util/err_ctx.h>
 #include <hse/util/platform.h>
 #include <hse/util/parse_num.h>
-
-#include <hse/hse.h>
-#include <hse/mpool/mpool.h>
 
 struct oid_pair {
     u64 oid[2];
@@ -48,7 +48,6 @@ static struct options {
     bool     help;
 } opt;
 
-const char *progname = NULL;
 u8         *pattern;
 u32         pattern_len;
 
@@ -1052,8 +1051,7 @@ main(int argc, char **argv)
     merr_t             err;
     const char        *path;
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
+    progname_set(argv[0]);
 
     options_defaults_set();
     options_parse(argc, argv, &last_arg);

--- a/tools/multicursor/multicursor.c
+++ b/tools/multicursor/multicursor.c
@@ -17,7 +17,6 @@
 #include <endian.h>
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -27,12 +26,12 @@
 #include <sysexits.h>
 #include <unistd.h>
 
+#include <hse/cli/param.h>
+#include <hse/cli/program.h>
 #include <hse/util/arch.h>
 #include <hse/util/atomic.h>
 #include <hse/util/compiler.h>
 #include <hse/util/inttypes.h>
-
-#include <hse/cli/param.h>
 
 #include "kvs_helper.h"
 
@@ -229,8 +228,6 @@ print_stats(void *arg)
     }
 }
 
-char *progname;
-
 void
 usage(void)
 {
@@ -274,7 +271,7 @@ main(int argc, char **argv)
     uint                cur_per_thread;
     int                 rc;
 
-    progname = basename(argv[0]);
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
     if (rc)

--- a/tools/pfx_probe/pfx_probe.c
+++ b/tools/pfx_probe/pfx_probe.c
@@ -1,11 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2018 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2018-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <endian.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <malloc.h>
 #include <pthread.h>
 #include <stdbool.h>
@@ -13,53 +12,50 @@
 #include <sys/time.h>
 #include <sysexits.h>
 
-#include <hse/hse.h>
+#include <hse/cli/param.h>
+#include <hse/cli/program.h>
 #include <hse/experimental.h>
-
+#include <hse/hse.h>
 #include <hse/util/arch.h>
 #include <hse/util/atomic.h>
 #include <hse/util/compiler.h>
 
 #include <xoroshiro.h>
 
-#include <hse/cli/param.h>
-
 #include "kvs_helper.h"
 
-const char *progname;
-
 struct opts {
-	uint npfx;
-	uint ncore;
-	uint nsfx;
-	uint threads;
-	uint duration;
-	bool use_cursors;
-	bool use_gets;
-	bool skip_load;
+    uint npfx;
+    uint ncore;
+    uint nsfx;
+    uint threads;
+    uint duration;
+    bool use_cursors;
+    bool use_gets;
+    bool skip_load;
 } opts = {
-	.npfx = 4,
-	.ncore = 100,
-	.nsfx = 2,
-	.threads = 6,
-	.use_cursors = false,
-	.use_gets = false,
-	.skip_load = false,
-	.duration = 30,
+    .npfx = 4,
+    .ncore = 100,
+    .nsfx = 2,
+    .threads = 6,
+    .use_cursors = false,
+    .use_gets = false,
+    .skip_load = false,
+    .duration = 30,
 };
 
 struct thread_info {
-	uint64_t pfx;
-	uint64_t core;
-	uint64_t sfx;
-	uint64_t seed;
+    uint64_t pfx;
+    uint64_t core;
+    uint64_t sfx;
+    uint64_t seed;
 };
 
 #define VLEN 1024
 
 enum phase {
-	LOAD_PHASE,
-	READ_PHASE,
+    LOAD_PHASE,
+    READ_PHASE,
 };
 enum phase phase;
 uint64_t total_puts;
@@ -72,49 +68,49 @@ static thread_local uint64_t xrand_state[2] HSE_ALIGNED(16);
 static void
 xrand_init(uint64_t seed)
 {
-	xoroshiro128plus_init(xrand_state, seed);
+    xoroshiro128plus_init(xrand_state, seed);
 }
 
 static uint64_t
 xrand(void)
 {
-	return xoroshiro128plus(xrand_state);
+    return xoroshiro128plus(xrand_state);
 }
 
 void
 loader(void *arg)
 {
-	struct kh_thread_arg  *ta = arg;
-	struct thread_info *ti = ta->arg;
-	char key[sizeof(ti->pfx) + sizeof(ti->core) + sizeof(ti->sfx)];
-	char val[VLEN];
-	uint64_t *p, *c, *s;
-	int i, j;
+    struct kh_thread_arg  *ta = arg;
+    struct thread_info *ti = ta->arg;
+    char key[sizeof(ti->pfx) + sizeof(ti->core) + sizeof(ti->sfx)];
+    char val[VLEN];
+    uint64_t *p, *c, *s;
+    int i, j;
     u64 rc;
 
-	rc = hse_kvs_prefix_delete(ta->kvs, 0, NULL, 0, 0);
+    rc = hse_kvs_prefix_delete(ta->kvs, 0, NULL, 0, 0);
         if (err)
             fatal(rc, "prefix delete failed");
 
-	memset(val, 0xa1, sizeof(val));
+    memset(val, 0xa1, sizeof(val));
 
-	p = (void *)key;
-	c = p + 1;
-	s = c + 1;
+    p = (void *)key;
+    c = p + 1;
+    s = c + 1;
 
-	*p = htobe64(ti->pfx);
-	for (i = 0; i < ti->core; i++) {
-		*c = htobe64(i);
-		for (j = 0; j < ti->sfx; j++) {
-			*s = htobe64(j);
-			rc = hse_kvs_put(ta->kvs, 0, NULL, key, sizeof(key),
-				     val, sizeof(val));
-			if (rc)
-				fatal(rc, "put failure");
-		}
+    *p = htobe64(ti->pfx);
+    for (i = 0; i < ti->core; i++) {
+        *c = htobe64(i);
+        for (j = 0; j < ti->sfx; j++) {
+            *s = htobe64(j);
+            rc = hse_kvs_put(ta->kvs, 0, NULL, key, sizeof(key),
+                     val, sizeof(val));
+            if (rc)
+                fatal(rc, "put failure");
+        }
 
         atomic_fetch_add(&completed_puts, ti->sfx);
-	}
+    }
 }
 
 bool killthreads = false;
@@ -124,358 +120,358 @@ atomic_ulong rd_time;
 
 enum hse_kvs_pfx_probe_cnt
 _pfx_probe(
-	struct hse_kvs *kvs,
-	void           *pfx,
-	size_t          pfxlen,
-	void           *kbuf,
-	size_t          kbufsz,
-	void           *vbuf,
-	size_t          vbufsz)
+    struct hse_kvs *kvs,
+    void           *pfx,
+    size_t          pfxlen,
+    void           *kbuf,
+    size_t          kbufsz,
+    void           *vbuf,
+    size_t          vbufsz)
 {
-	size_t      klen, vlen;
-	u64         rc;
-	uint64_t    start, dt;
+    size_t      klen, vlen;
+    u64         rc;
+    uint64_t    start, dt;
 
-	enum hse_kvs_pfx_probe_cnt  pc;
+    enum hse_kvs_pfx_probe_cnt  pc;
 
-	start = get_time_ns();
+    start = get_time_ns();
 
-	if (opts.use_cursors) {
-		struct hse_kvs_cursor *c;
-		const void *k, *v;
-		bool eof;
+    if (opts.use_cursors) {
+        struct hse_kvs_cursor *c;
+        const void *k, *v;
+        bool eof;
 
-		/* cursor over the hard prefix */
-		c = kh_cursor_create(kvs, 0, NULL, pfx, sizeof(uint64_t));
+        /* cursor over the hard prefix */
+        c = kh_cursor_create(kvs, 0, NULL, pfx, sizeof(uint64_t));
 
-		/* seek to soft prefix */
-		kh_cursor_seek(c, pfx, pfxlen);
+        /* seek to soft prefix */
+        kh_cursor_seek(c, pfx, pfxlen);
 
-		eof = kh_cursor_read(c, &k, &klen, &v, &vlen);
-		if (!eof && memcmp(k, pfx, pfxlen))
-			eof = true;
-		if (eof) {
-			pc = HSE_KVS_PFX_FOUND_ZERO;
-			goto done;
-		}
-		eof = kh_cursor_read(c, &k, &klen, &v, &vlen);
-		if (!eof && memcmp(k, pfx, pfxlen))
-			eof = true;
-		if (eof) {
-			pc = HSE_KVS_PFX_FOUND_ONE;
-			goto done;
-		}
+        eof = kh_cursor_read(c, &k, &klen, &v, &vlen);
+        if (!eof && memcmp(k, pfx, pfxlen))
+            eof = true;
+        if (eof) {
+            pc = HSE_KVS_PFX_FOUND_ZERO;
+            goto done;
+        }
+        eof = kh_cursor_read(c, &k, &klen, &v, &vlen);
+        if (!eof && memcmp(k, pfx, pfxlen))
+            eof = true;
+        if (eof) {
+            pc = HSE_KVS_PFX_FOUND_ONE;
+            goto done;
+        }
 
-		pc = HSE_KVS_PFX_FOUND_MUL;
+        pc = HSE_KVS_PFX_FOUND_MUL;
 done:
-		kh_cursor_destroy(c);
-	} else if (opts.use_gets) {
-		bool found;
-		char key[3 * sizeof(uint64_t)] = {0};
+        kh_cursor_destroy(c);
+    } else if (opts.use_gets) {
+        bool found;
+        char key[3 * sizeof(uint64_t)] = {0};
         uint64_t *s;
 
-		memcpy(key, pfx, pfxlen);
+        memcpy(key, pfx, pfxlen);
         s = (uint64_t *)(key + pfxlen);
 
-		pc = HSE_KVS_PFX_FOUND_ZERO;
-		rc = hse_kvs_get(kvs, 0, NULL, key, sizeof(key), &found,
-				 vbuf, vbufsz, &vlen);
-		if (rc)
-			fatal(rc, "get failure");
-		if (found)
-			pc = HSE_KVS_PFX_FOUND_ONE;
+        pc = HSE_KVS_PFX_FOUND_ZERO;
+        rc = hse_kvs_get(kvs, 0, NULL, key, sizeof(key), &found,
+                 vbuf, vbufsz, &vlen);
+        if (rc)
+            fatal(rc, "get failure");
+        if (found)
+            pc = HSE_KVS_PFX_FOUND_ONE;
 
         *s = htobe64(1);
-		rc = hse_kvs_get(kvs, 0, NULL, key, sizeof(key), &found,
-				 vbuf, vbufsz, &vlen);
-		if (rc)
-			fatal(rc, "get failure");
-		if (found)
-			pc = HSE_KVS_PFX_FOUND_MUL;
-	} else {
+        rc = hse_kvs_get(kvs, 0, NULL, key, sizeof(key), &found,
+                 vbuf, vbufsz, &vlen);
+        if (rc)
+            fatal(rc, "get failure");
+        if (found)
+            pc = HSE_KVS_PFX_FOUND_MUL;
+    } else {
 
-		rc = hse_kvs_prefix_probe(kvs, 0, NULL, pfx, pfxlen, &pc,
-					      kbuf, kbufsz, &klen,
-					      vbuf, vbufsz, &vlen);
-		if (rc)
-			fatal(rc, "prefix probe failure");
-	}
+        rc = hse_kvs_prefix_probe(kvs, 0, NULL, pfx, pfxlen, &pc,
+                          kbuf, kbufsz, &klen,
+                          vbuf, vbufsz, &vlen);
+        if (rc)
+            fatal(rc, "prefix probe failure");
+    }
 
-	dt = get_time_ns() - start;
+    dt = get_time_ns() - start;
 
-	atomic_inc(&rd_count);
-	atomic_add(&rd_time, dt);
+    atomic_inc(&rd_count);
+    atomic_add(&rd_time, dt);
 
-	return pc;
+    return pc;
 }
 
 void
 reader(void *arg)
 {
-	struct kh_thread_arg  *ta = arg;
-	char pfxbuf[2 * sizeof(uint64_t)];
-	uint64_t *p, *c;
+    struct kh_thread_arg  *ta = arg;
+    char pfxbuf[2 * sizeof(uint64_t)];
+    uint64_t *p, *c;
 
-	xrand_init(ta->seed);
+    xrand_init(ta->seed);
 
-	p = (void *)pfxbuf;
-	c = p + 1;
+    p = (void *)pfxbuf;
+    c = p + 1;
 
-	while (!killthreads) {
-		char        kbuf[HSE_KVS_KEY_LEN_MAX] = {0};
-		char        vbuf[VLEN];
-		uint64_t    pfx, core;
+    while (!killthreads) {
+        char        kbuf[HSE_KVS_KEY_LEN_MAX] = {0};
+        char        vbuf[VLEN];
+        uint64_t    pfx, core;
 
-		enum hse_kvs_pfx_probe_cnt pc HSE_MAYBE_UNUSED;
+        enum hse_kvs_pfx_probe_cnt pc HSE_MAYBE_UNUSED;
 
-		pfx = xrand() % opts.npfx;
-		core = 0;
-		if (pfx % 5 > 1)
-			core = xrand() % (opts.ncore / 2);
+        pfx = xrand() % opts.npfx;
+        core = 0;
+        if (pfx % 5 > 1)
+            core = xrand() % (opts.ncore / 2);
 
-		*p = htobe64(pfx);
-		*c = htobe64(core);
+        *p = htobe64(pfx);
+        *c = htobe64(core);
 
-		pc = _pfx_probe(ta->kvs, (void *)pfxbuf, sizeof(pfxbuf),
-			       kbuf, sizeof(kbuf), vbuf, sizeof(vbuf));
+        pc = _pfx_probe(ta->kvs, (void *)pfxbuf, sizeof(pfxbuf),
+                   kbuf, sizeof(kbuf), vbuf, sizeof(vbuf));
 
-		if (pfx % 5 == 0 && pc != HSE_KVS_PFX_FOUND_ZERO) {
-			killthreads = true;
-			err = 1;
-			printf("pfx %lu expected %d found %d\n", pfx, 0, pc);
-		} else if (pfx % 5 == 1 && pc != HSE_KVS_PFX_FOUND_ONE) {
-			killthreads = true;
-			err = 1;
-			printf("pfx %lu expected %d found %d\n", pfx, 1, pc);
-		} else if (pfx % 5 > 1 && pc != HSE_KVS_PFX_FOUND_MUL) {
-			killthreads = true;
-			err = 1;
-			printf("pfx %lu expected %d found %d\n", pfx, 2, pc);
-		}
-	}
+        if (pfx % 5 == 0 && pc != HSE_KVS_PFX_FOUND_ZERO) {
+            killthreads = true;
+            err = 1;
+            printf("pfx %lu expected %d found %d\n", pfx, 0, pc);
+        } else if (pfx % 5 == 1 && pc != HSE_KVS_PFX_FOUND_ONE) {
+            killthreads = true;
+            err = 1;
+            printf("pfx %lu expected %d found %d\n", pfx, 1, pc);
+        } else if (pfx % 5 > 1 && pc != HSE_KVS_PFX_FOUND_MUL) {
+            killthreads = true;
+            err = 1;
+            printf("pfx %lu expected %d found %d\n", pfx, 2, pc);
+        }
+    }
 }
 
 void
 syncme(void *arg)
 {
-	struct kh_thread_arg  *ta = arg;
+    struct kh_thread_arg  *ta = arg;
 
-	while (!killthreads) {
-		hse_kvdb_sync(ta->kvdb, 0);
+    while (!killthreads) {
+        hse_kvdb_sync(ta->kvdb, 0);
 
-		usleep(100 * 1000);
-	}
+        usleep(100 * 1000);
+    }
 }
 
 void
 print_stats(void *arg)
 {
-	uint second = 0;
-	uint64_t last_dt = 0;
-	uint64_t last_cnt = 0;
+    uint second = 0;
+    uint64_t last_dt = 0;
+    uint64_t last_cnt = 0;
 
-	usleep(999 * 1000);
+    usleep(999 * 1000);
 
-	while (!killthreads) {
-		uint64_t dt = atomic_read(&rd_time);
-		uint64_t cnt = atomic_read(&rd_count) ?: 1;
-		uint64_t load_pct = 100;
+    while (!killthreads) {
+        uint64_t dt = atomic_read(&rd_time);
+        uint64_t cnt = atomic_read(&rd_count) ?: 1;
+        uint64_t load_pct = 100;
 
-		if (second % 20 == 0)
-			printf("\n%8s %6s %9s %12s\n",
-			       "seconds", "load", "reads", "time/probe");
+        if (second % 20 == 0)
+            printf("\n%8s %6s %9s %12s\n",
+                   "seconds", "load", "reads", "time/probe");
 
-		++second;
-		if (phase == LOAD_PHASE) {
-			load_pct = atomic_read(&completed_puts) * 100;
-			load_pct /= total_puts ?: 1;
-		}
+        ++second;
+        if (phase == LOAD_PHASE) {
+            load_pct = atomic_read(&completed_puts) * 100;
+            load_pct /= total_puts ?: 1;
+        }
 
-		printf("%8u %5lu%% %9lu %12lu\n",
-		       second, load_pct, cnt,
-		       (dt - last_dt)/(1 + cnt - last_cnt));
-		usleep(999 * 1000);
+        printf("%8u %5lu%% %9lu %12lu\n",
+               second, load_pct, cnt,
+               (dt - last_dt)/(1 + cnt - last_cnt));
+        usleep(999 * 1000);
 
-		last_dt = dt;
-		last_cnt = cnt;
-	}
+        last_dt = dt;
+        last_cnt = cnt;
+    }
 }
 
 void
 usage(void)
 {
-	printf(
-		"usage: %s [options] kvdb kvs [param=value]\n"
-		"-c nvar    Number of core (middle portion of key) variations "
-		"per hard prefix\n"
-		"-d secs    Duration of run (in seconds)\n"
-		"-g         Use gets (in addition to -v)\n"
-		"-j jobs    Number of threads\n"
-		"-p npfx    Hard prefixes\n"
-		"-s nsfx    Suffixes per soft prefix\n"
-		"-v         Only verify (default: use hse_kvs_prefix_probe)\n"
-		"-x         Use cursors (in addition to -v)\n"
-		"-Z config  path to global config file\n"
-		, progname);
+    printf(
+        "usage: %s [options] kvdb kvs [param=value]\n"
+        "-c nvar    Number of core (middle portion of key) variations "
+        "per hard prefix\n"
+        "-d secs    Duration of run (in seconds)\n"
+        "-g         Use gets (in addition to -v)\n"
+        "-j jobs    Number of threads\n"
+        "-p npfx    Hard prefixes\n"
+        "-s nsfx    Suffixes per soft prefix\n"
+        "-v         Only verify (default: use hse_kvs_prefix_probe)\n"
+        "-x         Use cursors (in addition to -v)\n"
+        "-Z config  path to global config file\n"
+        , progname);
 
-	printf("\n");
-	exit(0);
+    printf("\n");
+    exit(0);
 }
 
 int
 main(
-	int       argc,
-	char    **argv)
+    int       argc,
+    char    **argv)
 {
-	struct parm_groups *pg = NULL;
-	struct svec         hse_gparms = { 0 };
-	struct svec         db_oparms = { 0 };
-	struct svec         kv_cparms = { 0 };
-	struct svec         kv_oparms = { 0 };
-	const char         *mpool, *kvs, *config = NULL;
-	struct thread_info *ti;
-	int                 c;
-	int                 i;
-	int                 rc;
+    struct parm_groups *pg = NULL;
+    struct svec         hse_gparms = { 0 };
+    struct svec         db_oparms = { 0 };
+    struct svec         kv_cparms = { 0 };
+    struct svec         kv_oparms = { 0 };
+    const char         *mpool, *kvs, *config = NULL;
+    struct thread_info *ti;
+    int                 c;
+    int                 i;
+    int                 rc;
 
-	progname = basename(argv[0]);
-        xrand_init(time(NULL));
+    progname_set(argv[0]);
+    xrand_init(time(NULL));
 
-	rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
-	if (rc)
-		fatal(rc, "pg_create");
+    rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
+    if (rc)
+        fatal(rc, "pg_create");
 
-	while ((c = getopt(argc, argv, "gvxd:j:p:c:s:Z:")) != -1) {
-		errno = 0;
-		switch (c) {
-		case 'p':
-			opts.npfx = strtoul(optarg, 0, 0);
-			break;
-		case 'c':
-			opts.ncore = strtoul(optarg, 0, 0);
-			break;
-		case 's':
-			opts.nsfx = strtoul(optarg, 0, 0);
-			if (opts.nsfx < 3)
-				fatal(EINVAL, "nsfx must be at least 3");
-			break;
-		case 'j':
-			opts.threads = strtoul(optarg, 0, 0);
-			break;
-		case 'x':
-			opts.use_cursors = true;
-			break;
-		case 'g':
-			opts.use_gets = true;
-			break;
-		case 'v':
-			opts.skip_load = true;
-			break;
-		case 'Z':
-			config = optarg;
-			break;
-		case 'd':
-			opts.duration = strtoul(optarg, 0, 0);
-			break;
-		case 'h':
-		default:
-			usage();
-			break;
-		}
-	}
+    while ((c = getopt(argc, argv, "gvxd:j:p:c:s:Z:")) != -1) {
+        errno = 0;
+        switch (c) {
+        case 'p':
+            opts.npfx = strtoul(optarg, 0, 0);
+            break;
+        case 'c':
+            opts.ncore = strtoul(optarg, 0, 0);
+            break;
+        case 's':
+            opts.nsfx = strtoul(optarg, 0, 0);
+            if (opts.nsfx < 3)
+                fatal(EINVAL, "nsfx must be at least 3");
+            break;
+        case 'j':
+            opts.threads = strtoul(optarg, 0, 0);
+            break;
+        case 'x':
+            opts.use_cursors = true;
+            break;
+        case 'g':
+            opts.use_gets = true;
+            break;
+        case 'v':
+            opts.skip_load = true;
+            break;
+        case 'Z':
+            config = optarg;
+            break;
+        case 'd':
+            opts.duration = strtoul(optarg, 0, 0);
+            break;
+        case 'h':
+        default:
+            usage();
+            break;
+        }
+    }
 
 
-	if (argc - optind < 2) {
-		fprintf(stderr, "missing required parameters");
-		exit(EX_USAGE);
-	}
+    if (argc - optind < 2) {
+        fprintf(stderr, "missing required parameters");
+        exit(EX_USAGE);
+    }
 
-	mpool = argv[optind++];
-	kvs   = argv[optind++];
+    mpool = argv[optind++];
+    kvs   = argv[optind++];
 
-	rc = pg_parse_argv(pg, argc, argv, &optind);
-	switch (rc) {
-	case 0:
-		if (optind < argc)
-			fatal(0, "unknown parameter: %s", argv[optind]);
-		break;
-	case EINVAL:
-		fatal(0, "missing group name (e.g. %s) before parameter %s\n",
-			PG_KVDB_OPEN, argv[optind]);
-		break;
-	default:
-		fatal(rc, "error processing parameter %s\n", argv[optind]);
-		break;
-	}
+    rc = pg_parse_argv(pg, argc, argv, &optind);
+    switch (rc) {
+    case 0:
+        if (optind < argc)
+            fatal(0, "unknown parameter: %s", argv[optind]);
+        break;
+    case EINVAL:
+        fatal(0, "missing group name (e.g. %s) before parameter %s\n",
+            PG_KVDB_OPEN, argv[optind]);
+        break;
+    default:
+        fatal(rc, "error processing parameter %s\n", argv[optind]);
+        break;
+    }
 
-	rc = rc ?: svec_append_pg(&hse_gparms, pg, PG_HSE_GLOBAL, NULL);
-	rc = rc ?: svec_append_pg(&db_oparms, pg, PG_KVDB_OPEN, NULL);
-	rc = rc ?: svec_append_pg(&kv_cparms, pg, PG_KVS_CREATE, NULL);
-	rc = rc ?: svec_append_pg(&kv_oparms, pg, PG_KVS_OPEN, NULL);
-	if (rc)
-		fatal(rc, "svec_append_pg failed");
+    rc = rc ?: svec_append_pg(&hse_gparms, pg, PG_HSE_GLOBAL, NULL);
+    rc = rc ?: svec_append_pg(&db_oparms, pg, PG_KVDB_OPEN, NULL);
+    rc = rc ?: svec_append_pg(&kv_cparms, pg, PG_KVS_CREATE, NULL);
+    rc = rc ?: svec_append_pg(&kv_oparms, pg, PG_KVS_OPEN, NULL);
+    if (rc)
+        fatal(rc, "svec_append_pg failed");
 
-	kh_init(config, mpool, &hse_gparms, &db_oparms);
+    kh_init(config, mpool, &hse_gparms, &db_oparms);
 
-	kh_register(KH_FLAG_DETACH, syncme, NULL);
-	kh_register(KH_FLAG_DETACH, print_stats, NULL);
+    kh_register(KH_FLAG_DETACH, syncme, NULL);
+    kh_register(KH_FLAG_DETACH, print_stats, NULL);
 
-	if (opts.skip_load)
-		goto skip_load;
+    if (opts.skip_load)
+        goto skip_load;
 
-	ti = malloc(opts.npfx * sizeof(*ti));
-	if (!ti)
-		fatal(ENOMEM, "no mem");
+    ti = malloc(opts.npfx * sizeof(*ti));
+    if (!ti)
+        fatal(ENOMEM, "no mem");
 
-	printf("Loading %lu keys ...\n", total_puts);
+    printf("Loading %lu keys ...\n", total_puts);
 
-	phase = LOAD_PHASE;
-	for (i = 0; i < opts.npfx; i++) {
-		ti[i].pfx = i;
-		ti[i].core = opts.ncore;
-		ti[i].seed = xrand();
+    phase = LOAD_PHASE;
+    for (i = 0; i < opts.npfx; i++) {
+        ti[i].pfx = i;
+        ti[i].core = opts.ncore;
+        ti[i].seed = xrand();
 
-		switch (i % 5) {
-		case 0:
-			ti[i].sfx = 0;
-			break;
-		case 1:
-			ti[i].sfx = 1;
-			break;
-		default:
-			ti[i].sfx = opts.nsfx;
-			break;
-		}
+        switch (i % 5) {
+        case 0:
+            ti[i].sfx = 0;
+            break;
+        case 1:
+            ti[i].sfx = 1;
+            break;
+        default:
+            ti[i].sfx = opts.nsfx;
+            break;
+        }
 
-		total_puts += ti[i].core * ti[i].sfx;
-	}
+        total_puts += ti[i].core * ti[i].sfx;
+    }
 
-	for (i = 0; i < opts.npfx; i++)
-		kh_register_kvs(kvs, 0, &kv_cparms, &kv_oparms, loader, &ti[i]);
-	kh_wait();
+    for (i = 0; i < opts.npfx; i++)
+        kh_register_kvs(kvs, 0, &kv_cparms, &kv_oparms, loader, &ti[i]);
+    kh_wait();
 
-	free(ti);
+    free(ti);
 
 skip_load:
-	phase = READ_PHASE;
-	for (i = 0; i < opts.threads; i++)
-		kh_register_kvs(kvs, 0, &kv_cparms, &kv_oparms, reader, 0);
+    phase = READ_PHASE;
+    for (i = 0; i < opts.threads; i++)
+        kh_register_kvs(kvs, 0, &kv_cparms, &kv_oparms, reader, 0);
 
-	sleep(opts.duration);
-	killthreads = true;
-	kh_wait();
+    sleep(opts.duration);
+    killthreads = true;
+    kh_wait();
 
-	kh_fini();
+    kh_fini();
 
     svec_reset(&db_oparms);
     svec_reset(&kv_cparms);
     svec_reset(&kv_oparms);
 
-	pg_destroy(pg);
-	svec_reset(&hse_gparms);
-	svec_reset(&db_oparms);
-	svec_reset(&kv_cparms);
-	svec_reset(&kv_oparms);
+    pg_destroy(pg);
+    svec_reset(&hse_gparms);
+    svec_reset(&db_oparms);
+    svec_reset(&kv_cparms);
+    svec_reset(&kv_oparms);
 
-	return err;
+    return err;
 }

--- a/tools/pgd/pgd.c
+++ b/tools/pgd/pgd.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2017 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc. All rights reserved.
  */
 
 /*
@@ -21,14 +21,13 @@
 
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/fmt.h>
 
 #include <tools/common.h>
@@ -73,7 +72,7 @@ do_open(
 }
 
 void
-usage(char *prog)
+usage(void)
 {
     fprintf(
         stderr,
@@ -84,7 +83,7 @@ usage(char *prog)
         "-V         verify puts, fails on first miss\n"
         "-C         show tunable parameters\n"
         "-Z config  path to global config file\n",
-        prog);
+        progname);
 
     exit(1);
 }
@@ -94,7 +93,7 @@ main(int argc, char **argv)
 {
     static char      buf[(HSE_KVS_KEY_LEN_MAX + HSE_KVS_VALUE_LEN_MAX) * 3];
     struct parm_groups *pg = NULL;
-    char *           mpname, *prog;
+    char *           mpname;
     const char *     kvsname;
     struct hse_kvdb *kvdb;
     struct hse_kvs * kvs;
@@ -105,7 +104,8 @@ main(int argc, char **argv)
     struct svec      hse_gparm = { 0 };
     const char *     config = NULL;
 
-    prog = basename(argv[0]);
+    progname_set(argv[0]);
+
     help = 0;
     action = PUT;
 
@@ -141,7 +141,7 @@ main(int argc, char **argv)
     }
 
     if (help == 1)
-        usage(prog);
+        usage();
 
     if (argc - optind < 2)
         fatal(0, "missing required params: kvdb and kvs");

--- a/tools/pscan/pscan.c
+++ b/tools/pscan/pscan.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2017,2019,2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 /*
@@ -13,7 +13,6 @@
 
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <pthread.h>
 #include <signal.h>
 #include <stdarg.h>
@@ -23,11 +22,11 @@
 #include <string.h>
 #include <sysexits.h>
 
-#include <hse/hse.h>
-#include <hse/flags.h>
-
 #include <xxhash.h>
 
+#include <hse/cli/program.h>
+#include <hse/flags.h>
+#include <hse/hse.h>
 #include <hse/util/arch.h>
 #include <hse/util/event_timer.h>
 #include <hse/util/fmt.h>
@@ -36,7 +35,6 @@
 #include <tools/common.h>
 #include <tools/parm_groups.h>
 
-const char * progname;
 int          verbosity;
 bool         headers = true;
 bool         uniq = false;
@@ -60,7 +58,7 @@ struct shr {
     pthread_t    tid;
 };
 
-void
+void HSE_PRINTF(1, 2)
 syntax(const char *fmt, ...)
 {
     char    msg[256];
@@ -74,7 +72,7 @@ syntax(const char *fmt, ...)
 }
 
 void
-usage()
+usage(void)
 {
     printf(
         "usage: %s [options] mp kvdb kvs [param=value ...]\n"
@@ -201,7 +199,6 @@ main(int argc, char **argv)
     EVENT_INIT(tr);
     EVENT_INIT(td);
 
-    progname = basename(argv[0]);
     countem = deletem = stats = false;
     showlen = seeklen = pfxlen = 0;
     cksum = true;
@@ -212,6 +209,8 @@ main(int argc, char **argv)
     Opts.kmax = HSE_KVS_KEY_LEN_MAX;
     Opts.vmax = HSE_KVS_VALUE_LEN_MAX;
     Opts.hexonly = 0;
+
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, NULL);
     if (rc)

--- a/tools/ptree-overload/ptree-overload.c
+++ b/tools/ptree-overload/ptree-overload.c
@@ -5,7 +5,6 @@
 #include <endian.h>
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -14,13 +13,12 @@
 #include <sysexits.h>
 #include <unistd.h>
 
-#include <hse/hse.h>
-
 #include <hse/cli/param.h>
+#include <hse/cli/program.h>
+#include <hse/hse.h>
 
 #include "kvs_helper.h"
 
-char *progname;
 int killthreads = 0;
 
 struct _opts {
@@ -90,11 +88,11 @@ usage(void)
 {
     printf(
         "usage: %s [options] kvdb kvs [param=value ...]\n"
+        "-h         Print this help menu\n"
         "-k nkeys   Number of keys\n"
         "-p nptombs Number of ptombs\n"
-        "-Z config  Path to global config file\n"
-        "-h      Print this help menu\n"
-        , progname);
+        "-Z config  Path to global config file\n",
+        progname);
 
     printf("\nDescription:\n");
     printf("Insert keys and ptombs\n");
@@ -114,7 +112,7 @@ main(int argc, char **argv)
     int                 c;
     int                 rc;
 
-    progname = basename(argv[0]);
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
     if (rc)

--- a/tools/put_flush/put_flush.c
+++ b/tools/put_flush/put_flush.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc. All rights reserved.
  *
  * This test creates several threads that call non-transactional PUTs on a loop.
  * One  thread that calls flush periodically on the KVDB.
@@ -8,7 +8,6 @@
  */
 
 #include <errno.h>
-#include <libgen.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -29,122 +28,122 @@ static bool killthreads;
 void
 flush_kvs(void *arg)
 {
-	struct kh_thread_arg *targ = arg;
+    struct kh_thread_arg *targ = arg;
 
-	while (!killthreads) {
-		hse_kvdb_sync(targ->kvdb, HSE_KVDB_SYNC_ASYNC);
-		usleep(10*1000);
-	}
+    while (!killthreads) {
+        hse_kvdb_sync(targ->kvdb, HSE_KVDB_SYNC_ASYNC);
+        usleep(10*1000);
+    }
 }
 
 void
 put(void *arg)
 {
-	struct kh_thread_arg *targ = arg;
-	uint64_t p = 0;
-	int rc;
+    struct kh_thread_arg *targ = arg;
+    uint64_t p = 0;
+    int rc;
 
-	char key[HSE_KVS_KEY_LEN_MAX];
+    char key[HSE_KVS_KEY_LEN_MAX];
 
-	memset(key, 0xaf, sizeof(key));
-	while (!killthreads) {
-		p++;
-		rc = hse_kvs_put(targ->kvs, 0, NULL, key, sizeof(key), &p, sizeof(p));
-		if (rc) {
-			err = 1;
-			killthreads = true;
-		}
-	}
+    memset(key, 0xaf, sizeof(key));
+    while (!killthreads) {
+        p++;
+        rc = hse_kvs_put(targ->kvs, 0, NULL, key, sizeof(key), &p, sizeof(p));
+        if (rc) {
+            err = 1;
+            killthreads = true;
+        }
+    }
 
 }
 
 void
 seq_inc(void *arg)
 {
-	struct kh_thread_arg  *targ = arg;
-	struct hse_kvdb_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
+    struct kh_thread_arg  *targ = arg;
+    struct hse_kvdb_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
 
-	while (!killthreads) {
+    while (!killthreads) {
 
-		hse_kvdb_txn_begin(targ->kvdb, txn);
-		hse_kvdb_txn_abort(targ->kvdb, txn);
-	}
+        hse_kvdb_txn_begin(targ->kvdb, txn);
+        hse_kvdb_txn_abort(targ->kvdb, txn);
+    }
 
-	hse_kvdb_txn_free(targ->kvdb, txn);
+    hse_kvdb_txn_free(targ->kvdb, txn);
 }
 
 int
 main(int argc, char **argv)
 {
-	struct parm_groups *pg = NULL;
-	struct svec         hse_gparms = { 0 };
-	struct svec         kvdb_oparms = { 0 };
-	struct svec         kvs_cparms = { 0 };
-	struct svec         kvs_oparms = { 0 };
-	const char *        mpool;
-	int i;
-	int rc;
-	int optindex = 0;
+    struct parm_groups *pg = NULL;
+    struct svec         hse_gparms = { 0 };
+    struct svec         kvdb_oparms = { 0 };
+    struct svec         kvs_cparms = { 0 };
+    struct svec         kvs_oparms = { 0 };
+    const char *        mpool;
+    int i;
+    int rc;
+    int optindex = 0;
 
-	rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
-	if (rc)
-		fatal(rc, "pg_create");
+    rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
+    if (rc)
+        fatal(rc, "pg_create");
 
-	if (!argc) {
-		fprintf(stderr, "missing required parameters");
-		exit(EX_USAGE);
-	}
+    if (!argc) {
+        fprintf(stderr, "missing required parameters");
+        exit(EX_USAGE);
+    }
 
-	mpool = argv[optindex++];
+    mpool = argv[optindex++];
 
-	rc = pg_parse_argv(pg, argc, argv, &optind);
-	switch (rc) {
-	case 0:
-		if (optind < argc)
-			fatal(0, "unknown parameter: %s", argv[optind]);
-		break;
-	case EINVAL:
-		fatal(0, "missing group name (e.g. %s) before parameter %s\n",
-			PG_KVDB_OPEN, argv[optind]);
-		break;
-	default:
-		fatal(rc, "error processing parameter %s\n", argv[optind]);
-		break;
-	}
+    rc = pg_parse_argv(pg, argc, argv, &optind);
+    switch (rc) {
+    case 0:
+        if (optind < argc)
+            fatal(0, "unknown parameter: %s", argv[optind]);
+        break;
+    case EINVAL:
+        fatal(0, "missing group name (e.g. %s) before parameter %s\n",
+            PG_KVDB_OPEN, argv[optind]);
+        break;
+    default:
+        fatal(rc, "error processing parameter %s\n", argv[optind]);
+        break;
+    }
 
-	rc = pg_set_parms(pg, PG_KVS_OPEN, "transactions.enabled=true", NULL);
-	if (rc)
-		fatal(rc, "pg_set_parms");
+    rc = pg_set_parms(pg, PG_KVS_OPEN, "transactions.enabled=true", NULL);
+    if (rc)
+        fatal(rc, "pg_set_parms");
 
-	rc = rc ?: svec_append_pg(&hse_gparms, pg, PG_HSE_GLOBAL, NULL);
-	rc = rc ?: svec_append_pg(&kvdb_oparms, pg, PG_KVDB_OPEN, NULL);
-	rc = rc ?: svec_append_pg(&kvs_cparms, pg, PG_KVS_CREATE, NULL);
-	rc = rc ?: svec_append_pg(&kvs_oparms, pg, PG_KVS_OPEN, NULL);
-	if (rc)
-		fatal(rc, "failed to parse params\n");
+    rc = rc ?: svec_append_pg(&hse_gparms, pg, PG_HSE_GLOBAL, NULL);
+    rc = rc ?: svec_append_pg(&kvdb_oparms, pg, PG_KVDB_OPEN, NULL);
+    rc = rc ?: svec_append_pg(&kvs_cparms, pg, PG_KVS_CREATE, NULL);
+    rc = rc ?: svec_append_pg(&kvs_oparms, pg, PG_KVS_OPEN, NULL);
+    if (rc)
+        fatal(rc, "failed to parse params\n");
 
-	kh_init(NULL, mpool, &hse_gparms, &kvdb_oparms);
+    kh_init(NULL, mpool, &hse_gparms, &kvdb_oparms);
 
-	/* frequent flushes */
-	kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &flush_kvs, 0);
+    /* frequent flushes */
+    kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &flush_kvs, 0);
 
-	/* bump up seqno */
-	kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &seq_inc, 0);
+    /* bump up seqno */
+    kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &seq_inc, 0);
 
-	for (i = 0; i < 64; i++)
-		kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &put, 0);
+    for (i = 0; i < 64; i++)
+        kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &put, 0);
 
-	sleep(10);
-	killthreads = true;
-	kh_wait();
+    sleep(10);
+    killthreads = true;
+    kh_wait();
 
-	kh_fini();
+    kh_fini();
 
-	pg_destroy(pg);
-	svec_reset(&hse_gparms);
-	svec_reset(&kvdb_oparms);
-	svec_reset(&kvs_cparms);
-	svec_reset(&kvs_oparms);
+    pg_destroy(pg);
+    svec_reset(&hse_gparms);
+    svec_reset(&kvdb_oparms);
+    svec_reset(&kvs_cparms);
+    svec_reset(&kvs_oparms);
 
-	return err;
+    return err;
 }

--- a/tools/put_txget/put_txget.c
+++ b/tools/put_txget/put_txget.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc. All rights reserved.
  *
  * One  thread calls non-transactional PUTs in a loop. Each time w/ the same
  * key, but a different value.
@@ -9,7 +9,6 @@
  */
 
 #include <errno.h>
-#include <libgen.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -29,122 +28,122 @@ static bool killthreads;
 void
 put(void *arg)
 {
-	struct kh_thread_arg *targ = arg;
-	uint64_t p = 0;
+    struct kh_thread_arg *targ = arg;
+    uint64_t p = 0;
 
-	while (!killthreads) {
-		p++;
-		hse_kvs_put(targ->kvs, 0, NULL, "abc", 3, &p, sizeof(p));
-	}
+    while (!killthreads) {
+        p++;
+        hse_kvs_put(targ->kvs, 0, NULL, "abc", 3, &p, sizeof(p));
+    }
 
 }
 
 void
 txget(void *arg)
 {
-	struct kh_thread_arg  *targ = arg;
-	struct hse_kvdb_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
-	uint64_t            val1, val2;
-	bool                found;
-	size_t              vlen;
+    struct kh_thread_arg  *targ = arg;
+    struct hse_kvdb_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
+    uint64_t            val1, val2;
+    bool                found;
+    size_t              vlen;
 
-	while (!killthreads) {
-		val1 = val2 = 0;
+    while (!killthreads) {
+        val1 = val2 = 0;
 
-		hse_kvdb_txn_begin(targ->kvdb, txn);
-		hse_kvs_get(targ->kvs, 0, txn, "abc", 3, &found, &val1,
-			sizeof(val1), &vlen);
-		if (!found)
-			continue;
-		usleep(1000);
-		hse_kvs_get(targ->kvs, 0, txn, "abc", 3, &found, &val2,
-			sizeof(val2), &vlen);
+        hse_kvdb_txn_begin(targ->kvdb, txn);
+        hse_kvs_get(targ->kvs, 0, txn, "abc", 3, &found, &val1,
+            sizeof(val1), &vlen);
+        if (!found)
+            continue;
+        usleep(1000);
+        hse_kvs_get(targ->kvs, 0, txn, "abc", 3, &found, &val2,
+            sizeof(val2), &vlen);
 
-		if (val1 != val2) {
-			printf("Value mismatch: val1 = %lu, val2 = %lu\n",
-			       val1, val2);
-			killthreads = true;
-			err = 1;
-			return;
-		}
+        if (val1 != val2) {
+            printf("Value mismatch: val1 = %lu, val2 = %lu\n",
+                   val1, val2);
+            killthreads = true;
+            err = 1;
+            return;
+        }
 
-		hse_kvdb_txn_abort(targ->kvdb, txn);
-	}
+        hse_kvdb_txn_abort(targ->kvdb, txn);
+    }
 
-	hse_kvdb_txn_free(targ->kvdb, txn);
+    hse_kvdb_txn_free(targ->kvdb, txn);
 }
 
 int
 main(int argc, char **argv)
 {
-	struct parm_groups *pg = NULL;
-	struct svec         hse_gparms = { 0 };
-	struct svec         kvdb_oparms = { 0 };
-	struct svec         kvs_cparms = { 0 };
-	struct svec         kvs_oparms = { 0 };
-	const char *        mpool;
-	int rc = 0;
+    struct parm_groups *pg = NULL;
+    struct svec         hse_gparms = { 0 };
+    struct svec         kvdb_oparms = { 0 };
+    struct svec         kvs_cparms = { 0 };
+    struct svec         kvs_oparms = { 0 };
+    const char *        mpool;
+    int rc = 0;
 
-	rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
-	if (rc)
-		fatal(rc, "pg_create");
+    rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
+    if (rc)
+        fatal(rc, "pg_create");
 
-	if (argc - optind < 1) {
-		fprintf(stderr, "missing required parameters\n");
-		exit(EX_USAGE);
-	}
+    if (argc - optind < 1) {
+        fprintf(stderr, "missing required parameters\n");
+        exit(EX_USAGE);
+    }
 
-	mpool = argv[optind++];
+    mpool = argv[optind++];
 
-	rc = pg_parse_argv(pg, argc, argv, &optind);
-	switch (rc) {
-	case 0:
-		if (optind < argc)
-			fatal(0, "unknown parameter: %s", argv[optind]);
-		break;
-	case EINVAL:
-		fatal(0, "missing group name (e.g. %s) before parameter %s\n",
-			PG_KVDB_OPEN, argv[optind]);
-		break;
-	default:
-		fatal(rc, "error processing parameter %s\n", argv[optind]);
-		break;
-	}
+    rc = pg_parse_argv(pg, argc, argv, &optind);
+    switch (rc) {
+    case 0:
+        if (optind < argc)
+            fatal(0, "unknown parameter: %s", argv[optind]);
+        break;
+    case EINVAL:
+        fatal(0, "missing group name (e.g. %s) before parameter %s\n",
+            PG_KVDB_OPEN, argv[optind]);
+        break;
+    default:
+        fatal(rc, "error processing parameter %s\n", argv[optind]);
+        break;
+    }
 
-	if (optind < argc) {
-		fprintf(stderr, "extraneous argument: %s", argv[optind]);
-		exit(EX_USAGE);
-	}
+    if (optind < argc) {
+        fprintf(stderr, "extraneous argument: %s", argv[optind]);
+        exit(EX_USAGE);
+    }
 
-	rc = pg_set_parms(pg, PG_KVS_OPEN, "transactions.enabled=true", NULL);
-	if (rc) {
-		fprintf(stderr, "pg_set_parms failed");
-		exit(EX_USAGE);
-	}
+    rc = pg_set_parms(pg, PG_KVS_OPEN, "transactions.enabled=true", NULL);
+    if (rc) {
+        fprintf(stderr, "pg_set_parms failed");
+        exit(EX_USAGE);
+    }
 
-	rc = rc ?: svec_append_pg(&hse_gparms, pg, PG_HSE_GLOBAL, NULL);
-	rc = rc ?: svec_append_pg(&kvdb_oparms, pg, PG_KVDB_OPEN, NULL);
-	rc = rc ?: svec_append_pg(&kvs_cparms, pg, PG_KVS_CREATE, NULL);
-	rc = rc ?: svec_append_pg(&kvs_oparms, pg, PG_KVS_OPEN, NULL);
-	if (rc)
-		fatal(rc, "failed to parse params\n");
+    rc = rc ?: svec_append_pg(&hse_gparms, pg, PG_HSE_GLOBAL, NULL);
+    rc = rc ?: svec_append_pg(&kvdb_oparms, pg, PG_KVDB_OPEN, NULL);
+    rc = rc ?: svec_append_pg(&kvs_cparms, pg, PG_KVS_CREATE, NULL);
+    rc = rc ?: svec_append_pg(&kvs_oparms, pg, PG_KVS_OPEN, NULL);
+    if (rc)
+        fatal(rc, "failed to parse params\n");
 
-	kh_init(NULL, mpool, &hse_gparms, &kvdb_oparms);
+    kh_init(NULL, mpool, &hse_gparms, &kvdb_oparms);
 
-	kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &txget, 0);
-	kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &put, 0);
+    kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &txget, 0);
+    kh_register_kvs("kvs1", 0, &kvs_cparms, &kvs_oparms, &put, 0);
 
-	sleep(10);
-	killthreads = true;
-	kh_wait();
+    sleep(10);
+    killthreads = true;
+    kh_wait();
 
-	kh_fini();
+    kh_fini();
 
-	pg_destroy(pg);
-	svec_reset(&hse_gparms);
-	svec_reset(&kvdb_oparms);
-	svec_reset(&kvs_cparms);
-	svec_reset(&kvs_oparms);
+    pg_destroy(pg);
+    svec_reset(&hse_gparms);
+    svec_reset(&kvdb_oparms);
+    svec_reset(&kvs_cparms);
+    svec_reset(&kvs_oparms);
 
-	return err;
+    return err;
 }

--- a/tools/putbin/putbin.c
+++ b/tools/putbin/putbin.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2017,2021-2022 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc. All rights reserved.
  */
 
 /*
@@ -13,7 +13,6 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <poll.h>
 #include <pthread.h>
 #include <stdlib.h>
@@ -22,8 +21,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/event_timer.h>
 
 #include <tools/common.h>
@@ -211,7 +210,7 @@ do_close(struct hse_kvdb *kvdb, bool sync)
 }
 
 void
-usage(char *prog)
+usage(void)
 {
     fprintf(
         stderr,
@@ -230,7 +229,7 @@ usage(char *prog)
         "-v n       set hse_log_pri to $n\n"
         "-X         exit with sync instead of close\n"
         "-Z config  path to global config file\n",
-        prog);
+        progname);
 
     exit(0);
 }
@@ -239,7 +238,7 @@ int
 main(int argc, char **argv)
 {
     const char *       config = NULL;
-    char *             mpname, *prog;
+    char *             mpname;
     struct parm_groups  *pg = NULL;
     const char *       kvname;
     unsigned char      data[4096];
@@ -254,7 +253,6 @@ main(int argc, char **argv)
     unsigned           opt_sync = 0;
     struct svec        hse_gparm = { 0 };
 
-    prog = basename(argv[0]);
     klen = 4;
     vlen = klen + 4;
     cnt = 1000;
@@ -265,6 +263,8 @@ main(int argc, char **argv)
     paws = 0;
     action = PUT;
     endian = BIG_ENDIAN;
+
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, NULL);
     if (rc)
@@ -314,7 +314,7 @@ main(int argc, char **argv)
                 config = optarg;
                 break;
             case 'h':
-                usage(prog);
+                usage();
                 break;
             case '?': /* fallthru */
             default:

--- a/tools/putgetdel/putgetdel.c
+++ b/tools/putgetdel/putgetdel.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015,2021-2022 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <assert.h>
@@ -17,8 +17,8 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/compiler.h>
 #include <hse/util/inttypes.h>
 #include <hse/util/parse_num.h>
@@ -75,7 +75,6 @@ struct opts opt;
 struct parm_groups *pg;
 
 const char *mode = "";
-const char *progname = NULL;
 struct timeval tv_start;
 int verbose = 0;
 u32 errors = 0;
@@ -1024,10 +1023,9 @@ main(int argc, char **argv)
     hse_err_t         err;
     struct svec       hse_gparm = { 0 };
 
-    gettimeofday(&tv_start, NULL);
+    progname_set(argv[0]);
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
+    gettimeofday(&tv_start, NULL);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, NULL);
     if (rc)

--- a/tools/range_read/range_read.c
+++ b/tools/range_read/range_read.c
@@ -1,33 +1,29 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2018-2019,2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2018-2022 Micron Technology, Inc.  All rights reserved.
  *
  * The user provides the number of prefixes and suffixes to use in the database.
  * Each prefix will get all the suffixes, i.e. the total number of keys in the
  * DB is the product of number of prefixes and suffixes.
  */
 
+#include <endian.h>
+#include <getopt.h>
+#include <sysexits.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+
+#include <hdr/hdr_histogram.h>
+#include <xoroshiro.h>
+
+#include <hse/cli/param.h>
+#include <hse/cli/program.h>
 #include <hse/util/platform.h>
 #include <hse/util/atomic.h>
 #include <hse/util/compiler.h>
 #include <hse/util/inttypes.h>
 
-#include <xoroshiro.h>
-
-#include <endian.h>
-#include <getopt.h>
-#include <libgen.h>
-#include <sysexits.h>
-#include <stdlib.h>
-#include <sys/resource.h>
-
-#include <hse/cli/param.h>
-
 #include "kvs_helper.h"
-
-#include <hdr/hdr_histogram.h>
-
-const char *progname;
 
 struct thread_info {
     uint64_t key_start;
@@ -441,7 +437,7 @@ main(
     void               *tests_base HSE_MAYBE_UNUSED = NULL;
     void               *vsep_base HSE_MAYBE_UNUSED = NULL;
 
-    progname = basename(argv[0]);
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
     if (rc)

--- a/tools/simple_client/simple_client.c
+++ b/tools/simple_client/simple_client.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2018,2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <assert.h>
@@ -12,8 +12,8 @@
 #include <sysexits.h>
 #include <string.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/compiler.h>
 
 const char *kfmt = "k%u";
@@ -22,9 +22,7 @@ uint        kmax = 100;
 struct hse_kvdb *kvdb;
 struct hse_kvs  *kvs;
 
-const char *progname;
-
-void
+void HSE_PRINTF(1, 2)
 syntax(const char *fmt, ...)
 {
     char msg[2048];
@@ -173,8 +171,7 @@ main(int argc, char **argv)
     const char *kvs_name;
     const char *config = NULL;
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
+    progname_set(argv[0]);
 
     while (-1 != (c = getopt(argc, argv, ":c:f:hrvwZ:"))) {
         char *endptr = NULL;

--- a/tools/throttle/throttle.c
+++ b/tools/throttle/throttle.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <assert.h>
@@ -15,8 +15,8 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/arch.h>
 #include <hse/util/atomic.h>
 #include <hse/util/compiler.h>
@@ -66,7 +66,6 @@ char *VAL_PREFIX = "V%016lx_%016u";
 struct opts opt;
 
 const char *mode = "";
-const char *progname = NULL;
 struct timeval tv_start;
 int verbose = 0;
 u32 errors = 0;
@@ -922,10 +921,9 @@ main(int argc, char **argv)
     u64     tot_opsavg = 0;
     u64     tot_time   = 0;
 
-    gettimeofday(&tv_start, NULL);
+    progname_set(argv[0]);
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
+    gettimeofday(&tv_start, NULL);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, NULL);
     if (rc)

--- a/tools/txn_thrash/txn_thrash.c
+++ b/tools/txn_thrash/txn_thrash.c
@@ -1,12 +1,11 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2018-2019 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2018-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <endian.h>
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <malloc.h>
 #include <pthread.h>
 #include <stdbool.h>
@@ -17,11 +16,10 @@
 #include <sys/resource.h>
 #include <sysexits.h>
 
-#include <hse/hse.h>
-
-#include <hse/util/arch.h>
-
 #include <hse/cli/param.h>
+#include <hse/cli/program.h>
+#include <hse/hse.h>
+#include <hse/util/arch.h>
 
 #include "kvs_helper.h"
 
@@ -99,16 +97,14 @@ txn_puts(
     }
 }
 
-char *progname;
-
 void
 usage(void)
 {
     printf(
         "usage: %s [options] kvdb kvs [param=value ...]\n"
         "-c keys   Number of keys per thread\n"
-        "-j jobs   Number threads\n"
-        , progname);
+        "-j jobs   Number threads\n",
+        progname);
 }
 
 int
@@ -125,7 +121,7 @@ main(
     struct thread_info *ti;
     int rc, c;
 
-    progname = basename(argv[0]);
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
     if (rc)

--- a/tools/txput_flush/txput_flush.c
+++ b/tools/txput_flush/txput_flush.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc. All rights reserved.
  *
  * Several threads call transactional PUTs in a loop. For a given thread, each
  * time w/ the same key, but a different value.
@@ -9,7 +9,6 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
-#include <libgen.h>
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>
@@ -28,46 +27,46 @@ static bool killthreads;
 void
 flush_kvs(void *arg)
 {
-	struct kh_thread_arg *targ = arg;
+    struct kh_thread_arg *targ = arg;
 
-	while (!killthreads) {
-		hse_kvdb_sync(targ->kvdb, HSE_KVDB_SYNC_ASYNC);
-		usleep(100*1000);
-	}
+    while (!killthreads) {
+        hse_kvdb_sync(targ->kvdb, HSE_KVDB_SYNC_ASYNC);
+        usleep(100*1000);
+    }
 }
 
 void
 txput(void *arg)
 {
-	struct kh_thread_arg *targ = arg;
-	struct hse_kvdb_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
-	uint idx;
-	uint64_t  vidx;
-	int rc;
+    struct kh_thread_arg *targ = arg;
+    struct hse_kvdb_txn    *txn = hse_kvdb_txn_alloc(targ->kvdb);
+    uint idx;
+    uint64_t  vidx;
+    int rc;
 
-	char val[8];
-	char key[HSE_KVS_KEY_LEN_MAX];
-	uint *v = (uint *)val;
-	uint *k = (uint *)key;
+    char val[8];
+    char key[HSE_KVS_KEY_LEN_MAX];
+    uint *v = (uint *)val;
+    uint *k = (uint *)key;
 
-	idx = *(uint *)targ->arg;
-	*k = htonl(idx);
-	memset(key + sizeof(*k), 0xaf, sizeof(key) - sizeof(*k));
+    idx = *(uint *)targ->arg;
+    *k = htonl(idx);
+    memset(key + sizeof(*k), 0xaf, sizeof(key) - sizeof(*k));
 
-	vidx = 0;
-	while (!killthreads) {
-		hse_kvdb_txn_begin(targ->kvdb, txn);
-		*v = htonl(vidx++);
-		rc = hse_kvs_put(targ->kvs, 0, txn, key, sizeof(key),
-			     val, sizeof(val));
-		if (rc) {
-			err = 1;
-			killthreads = true;
-		}
-		hse_kvdb_txn_commit(targ->kvdb, txn);
-	}
+    vidx = 0;
+    while (!killthreads) {
+        hse_kvdb_txn_begin(targ->kvdb, txn);
+        *v = htonl(vidx++);
+        rc = hse_kvs_put(targ->kvs, 0, txn, key, sizeof(key),
+                 val, sizeof(val));
+        if (rc) {
+            err = 1;
+            killthreads = true;
+        }
+        hse_kvdb_txn_commit(targ->kvdb, txn);
+    }
 
-	hse_kvdb_txn_free(targ->kvdb, txn);
+    hse_kvdb_txn_free(targ->kvdb, txn);
 }
 
 #define NUM_THREADS 64
@@ -75,77 +74,77 @@ txput(void *arg)
 int
 main(int argc, char **argv)
 {
-	struct parm_groups *pg = NULL;
-	struct svec         hse_gparms = { 0 };
-	struct svec         kvdb_oparms = { 0 };
-	struct svec         kvs_cparms = { 0 };
-	struct svec         kvs_oparms = { 0 };
-	const char *mpool, *kvs;
-	uint idx[NUM_THREADS];
-	uint i;
-	int rc;
+    struct parm_groups *pg = NULL;
+    struct svec         hse_gparms = { 0 };
+    struct svec         kvdb_oparms = { 0 };
+    struct svec         kvs_cparms = { 0 };
+    struct svec         kvs_oparms = { 0 };
+    const char *mpool, *kvs;
+    uint idx[NUM_THREADS];
+    uint i;
+    int rc;
 
-	rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
-	if (rc)
-		fatal(rc, "pg_create");
+    rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
+    if (rc)
+        fatal(rc, "pg_create");
 
-	if (argc < 2) {
-		fprintf(stderr, "missing required parameters");
-		exit(EX_USAGE);
-	}
+    if (argc < 2) {
+        fprintf(stderr, "missing required parameters");
+        exit(EX_USAGE);
+    }
 
-	mpool = argv[optind++];
-	kvs   = argv[optind++];
+    mpool = argv[optind++];
+    kvs   = argv[optind++];
 
-	rc = pg_parse_argv(pg, argc, argv, &optind);
-	switch (rc) {
-	case 0:
-		if (optind < argc)
-			fatal(0, "unknown parameter: %s", argv[optind]);
-		break;
-	case EINVAL:
-		fatal(0, "missing group name (e.g. %s) before parameter %s\n",
-			PG_KVDB_OPEN, argv[optind]);
-		break;
-	default:
-		fatal(rc, "error processing parameter %s\n", argv[optind]);
-		break;
-	}
+    rc = pg_parse_argv(pg, argc, argv, &optind);
+    switch (rc) {
+    case 0:
+        if (optind < argc)
+            fatal(0, "unknown parameter: %s", argv[optind]);
+        break;
+    case EINVAL:
+        fatal(0, "missing group name (e.g. %s) before parameter %s\n",
+            PG_KVDB_OPEN, argv[optind]);
+        break;
+    default:
+        fatal(rc, "error processing parameter %s\n", argv[optind]);
+        break;
+    }
 
-	rc = svec_append_pg(&kvs_oparms, pg, PG_KVS_OPEN, "transactions.enabled=true", NULL);
-	if (rc) {
-		fprintf(stderr, "pg_set_parms failed");
-		exit(EX_USAGE);
-	}
+    rc = svec_append_pg(&kvs_oparms, pg, PG_KVS_OPEN, "transactions.enabled=true", NULL);
+    if (rc) {
+        fprintf(stderr, "pg_set_parms failed");
+        exit(EX_USAGE);
+    }
 
-	rc = rc ?: svec_append_pg(&hse_gparms, pg, PG_HSE_GLOBAL, NULL);
-	rc = rc ?: svec_append_pg(&kvdb_oparms, pg, PG_KVDB_OPEN, NULL);
-	rc = rc ?: svec_append_pg(&kvs_cparms, pg, PG_KVS_CREATE, NULL);
-	rc = rc ?: svec_append_pg(&kvs_oparms, pg, PG_KVS_OPEN, NULL);
-	if (rc)
-		fatal(rc, "failed to parse params\n");
+    rc = rc ?: svec_append_pg(&hse_gparms, pg, PG_HSE_GLOBAL, NULL);
+    rc = rc ?: svec_append_pg(&kvdb_oparms, pg, PG_KVDB_OPEN, NULL);
+    rc = rc ?: svec_append_pg(&kvs_cparms, pg, PG_KVS_CREATE, NULL);
+    rc = rc ?: svec_append_pg(&kvs_oparms, pg, PG_KVS_OPEN, NULL);
+    if (rc)
+        fatal(rc, "failed to parse params\n");
 
-	kh_init(NULL, mpool, &hse_gparms, &kvdb_oparms);
+    kh_init(NULL, mpool, &hse_gparms, &kvdb_oparms);
 
-	/* frequent flushes */
-	kh_register_kvs(kvs, 0, &kvs_cparms, &kvs_oparms, &flush_kvs, 0);
+    /* frequent flushes */
+    kh_register_kvs(kvs, 0, &kvs_cparms, &kvs_oparms, &flush_kvs, 0);
 
-	for (i = 0; i < NUM_THREADS; i++) {
-		idx[i] = i;
-		kh_register_kvs(kvs, 0, &kvs_cparms, &kvs_oparms, &txput, &idx[i]);
-	}
+    for (i = 0; i < NUM_THREADS; i++) {
+        idx[i] = i;
+        kh_register_kvs(kvs, 0, &kvs_cparms, &kvs_oparms, &txput, &idx[i]);
+    }
 
-	sleep(15);
-	killthreads = true;
-	kh_wait();
+    sleep(15);
+    killthreads = true;
+    kh_wait();
 
-	kh_fini();
+    kh_fini();
 
-	pg_destroy(pg);
-	svec_reset(&hse_gparms);
-	svec_reset(&kvdb_oparms);
-	svec_reset(&kvs_cparms);
-	svec_reset(&kvs_oparms);
+    pg_destroy(pg);
+    svec_reset(&hse_gparms);
+    svec_reset(&kvdb_oparms);
+    svec_reset(&kvs_cparms);
+    svec_reset(&kvs_oparms);
 
-	return err;
+    return err;
 }

--- a/tools/upsert/upsert.c
+++ b/tools/upsert/upsert.c
@@ -3,9 +3,6 @@
  * Copyright (C) 2022 Micron Technology, Inc.  All rights reserved.
  */
 
-#include <hse/util/atomic.h>
-#include <hse/util/mutex.h>
-
 #include <endian.h>
 #include <errno.h>
 #include <getopt.h>
@@ -19,43 +16,44 @@
 #include <sysexits.h>
 #include <unistd.h>
 
-#include <hse/experimental.h>
-#include <hse/hse.h>
-
 #include <xoroshiro.h>
 
 #include <hse/cli/param.h>
+#include <hse/cli/program.h>
+#include <hse/experimental.h>
+#include <hse/hse.h>
+#include <hse/util/atomic.h>
+#include <hse/util/mutex.h>
 
 #include "kvs_helper.h"
 
 const char *key_suffix = "AA";
 size_t key_sfxlen;
 
-const char *progname;
 volatile bool completed;
 atomic_int completed_cnt;
 
 atomic_long opcnt;
 
 enum run_mode {
-	MODE_PFX_PROBE = 0,
-	MODE_POINT_GET,
-	MODE_CURSOR,
-	MODE_CNT,
+    MODE_PFX_PROBE = 0,
+    MODE_POINT_GET,
+    MODE_CURSOR,
+    MODE_CNT,
 };
 
 struct opts {
-	uint64_t      nkeys;
-	uint64_t      stride;
-	unsigned int  nthreads;
-	unsigned int  laps;
-	enum run_mode mode;
+    uint64_t      nkeys;
+    uint64_t      stride;
+    unsigned int  nthreads;
+    unsigned int  laps;
+    enum run_mode mode;
 } opts = {
-	.nkeys = 1000 * 1000 * 1000,
-	.stride = 100,
-	.nthreads = 32,
-	.laps = 3,
-	.mode = MODE_PFX_PROBE,
+    .nkeys = 1000 * 1000 * 1000,
+    .stride = 100,
+    .nthreads = 32,
+    .laps = 3,
+    .mode = MODE_PFX_PROBE,
 };
 
 struct _test_ctx {
@@ -243,8 +241,8 @@ usage(void)
         "             1: Use point get\n"
         "             2: Use cursor\n"
         "-s stride  Batch size of keys processed by each thread\n"
-        "-Z config  Path to global config file\n"
-        , progname);
+        "-Z config  Path to global config file\n",
+        progname);
 
     printf("\n");
 }
@@ -252,20 +250,20 @@ usage(void)
 int
 main(int argc, char **argv)
 {
-	struct parm_groups *pg = 0;
-	struct svec hse_gparms = { 0 };
-	struct svec kvdb_oparms = { 0 };
-	struct svec kvs_cparms = { 0 };
-	struct svec kvs_oparms = { 0 };
+    struct parm_groups *pg = 0;
+    struct svec hse_gparms = { 0 };
+    struct svec kvdb_oparms = { 0 };
+    struct svec kvs_cparms = { 0 };
+    struct svec kvs_oparms = { 0 };
     const char *kvdbhome, *kvsname, *config = NULL;
     char sfx_param_buf[32];
     int c, rc;
 
-	progname = basename(argv[0]);
+    progname_set(argv[0]);
 
-	rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
-	if (rc)
-		fatal(rc, "pg_create");
+    rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, PG_KVS_CREATE, NULL);
+    if (rc)
+        fatal(rc, "pg_create");
 
     while ((c = getopt(argc, argv, ":c:hj:l:m:s:Z:")) != -1) {
         char *errmsg = NULL, *end = NULL;
@@ -373,5 +371,5 @@ main(int argc, char **argv)
     svec_reset(&kvs_oparms);
     pg_destroy(pg);
 
-	return 0;
+    return 0;
 }

--- a/tools/waltest/waltest.c
+++ b/tools/waltest/waltest.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2017 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2017-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <assert.h>
@@ -14,8 +14,8 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/atomic.h>
 #include <hse/util/compiler.h>
 #include <hse/util/inttypes.h>
@@ -75,7 +75,6 @@ struct parm_groups *pg;
 struct svec kvs_oparms;
 
 const char *mode = "";
-const char *progname = NULL;
 struct timeval tv_start;
 int verbose = 0;
 atomic_ulong errors;
@@ -1393,8 +1392,7 @@ main(int argc, char **argv)
 {
     hse_err_t err;
 
-    progname = strrchr(argv[0], '/');
-    progname = progname ? progname + 1 : argv[0];
+    progname_set(argv[0]);
 
     ingest_mode = false;
     err = waltest_parse(argc, argv);

--- a/tools/wscan/wscan.c
+++ b/tools/wscan/wscan.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2017 Micron Technology, Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc. All rights reserved.
  */
 
 /*
@@ -12,7 +12,6 @@
 #define USE_EVENT_TIMER
 
 #include <getopt.h>
-#include <libgen.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -20,8 +19,8 @@
 #include <string.h>
 #include <strings.h>
 
+#include <hse/cli/program.h>
 #include <hse/hse.h>
-
 #include <hse/util/event_timer.h>
 #include <hse/util/fmt.h>
 #include <hse/util/inttypes.h>
@@ -52,7 +51,7 @@ mk_val(char *buf, u64 val)
 }
 
 void
-usage(const char *prog)
+usage(void)
 {
     fprintf(
         stderr,
@@ -64,7 +63,7 @@ usage(const char *prog)
         "-U         update cursor (vs restart it)\n"
         "-v n       set verbosity to $n\n"
         "-Z config  path to global config file\n",
-        prog);
+        progname);
 
     exit(1);
 }
@@ -83,7 +82,7 @@ main(int argc, char **argv)
     static char kbuf[HSE_KVS_KEY_LEN_MAX];
     static char vbuf[HSE_KVS_VALUE_LEN_MAX];
 
-    const char *           mpname, *dsname, *kvname, *prog, *config = NULL;
+    const char *           mpname, *dsname, *kvname, *config = NULL;
     struct parm_groups *   pg = NULL;
     struct svec            hse_gparm = { 0 };
     struct svec            db_oparm = { 0 };
@@ -119,10 +118,11 @@ main(int argc, char **argv)
     EVENT_INIT(tu);
     EVENT_INIT(cl);
 
-    prog = basename(argv[0]);
     update = 0;
     c0 = 1;
     get = 0;
+
+    progname_set(argv[0]);
 
     rc = pg_create(&pg, PG_HSE_GLOBAL, PG_KVDB_OPEN, PG_KVS_OPEN, NULL);
     if (rc)
@@ -156,7 +156,7 @@ main(int argc, char **argv)
     }
 
     if (opt_help)
-        usage(prog);
+        usage();
 
     if (argc - optind < 3)
         fatal(0, "missing required parameters");


### PR DESCRIPTION
Many of our tools store the name of the program, typically for use in usage statements. All of the programs that store the name did so in custom ways and created repeated code.

The pattern we use fairly often, but not always, in CLIs is output taking the form of `<progname>: <message>`. By storing the program name in libhse-cli, we can more effectively move to a paradigm where we don't create multiple `fatal()`, `syntax()`, etc. functions per program, though this improvement can come at a later time.

Signed-off-by: Tristan Partin <tpartin@micron.com>
