### PR TITLE
Fix alignment issues in kvdb_rparams

### DIFF
--- a/lib/include/hse/ikvdb/kvdb_rparams.h
+++ b/lib/include/hse/ikvdb/kvdb_rparams.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2015-2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2015-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #ifndef HSE_KVDB_RPARAMS_H
@@ -96,7 +96,7 @@ struct kvdb_rparams {
     uint32_t c0_ingest_threads;
     uint16_t cn_maint_threads;
     uint16_t cn_io_threads;
-    uint32_t cndb_compact_hwm_pct;
+    double cndb_compact_hwm_pct;
 
     uint32_t keylock_tables;
     enum kvdb_open_mode mode;

--- a/lib/kvdb/kvdb_rparams.c
+++ b/lib/kvdb/kvdb_rparams.c
@@ -750,7 +750,7 @@ static const struct param_spec pspecs[] = {
         .ps_stringify = param_default_stringify,
         .ps_jsonify = param_default_jsonify,
         .ps_default_value = {
-            .as_uscalar = HSE_CNDB_COMPACT_HWM_PCT_DEFAULT,
+            .as_double = HSE_CNDB_COMPACT_HWM_PCT_DEFAULT,
         },
         .ps_bounds = {
             .as_double = {

--- a/tests/unit/kvdb/kvdb_rparams_test.c
+++ b/tests/unit/kvdb/kvdb_rparams_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /*
- * Copyright (C) 2021 Micron Technology, Inc.  All rights reserved.
+ * Copyright (C) 2021-2022 Micron Technology, Inc.  All rights reserved.
  */
 
 #include <mtf/framework.h>
@@ -840,6 +840,25 @@ MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, cn_io_threads, test_pre)
     ASSERT_EQ(17, params.cn_io_threads);
     ASSERT_EQ(1, ps->ps_bounds.as_uscalar.ps_min);
     ASSERT_EQ(256, ps->ps_bounds.as_uscalar.ps_max);
+}
+
+MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, cndb_compact_hwm_pct, test_pre)
+{
+    const struct param_spec *ps = ps_get("cndb_compact_hwm_pct");
+
+    ASSERT_NE(NULL, ps);
+    ASSERT_NE(NULL, ps->ps_description);
+    ASSERT_EQ(PARAM_FLAG_EXPERIMENTAL, ps->ps_flags);
+    ASSERT_EQ(PARAM_TYPE_DOUBLE, ps->ps_type);
+    ASSERT_EQ(offsetof(struct kvdb_rparams, cndb_compact_hwm_pct), ps->ps_offset);
+    ASSERT_EQ(sizeof(double), ps->ps_size);
+    ASSERT_EQ((uintptr_t)ps->ps_convert, (uintptr_t)param_default_converter);
+    ASSERT_EQ((uintptr_t)ps->ps_validate, (uintptr_t)param_default_validator);
+    ASSERT_EQ((uintptr_t)ps->ps_stringify, (uintptr_t)param_default_stringify);
+    ASSERT_EQ((uintptr_t)ps->ps_jsonify, (uintptr_t)param_default_jsonify);
+    ASSERT_EQ(HSE_CNDB_COMPACT_HWM_PCT_DEFAULT, params.cndb_compact_hwm_pct);
+    ASSERT_EQ(0, ps->ps_bounds.as_double.ps_min);
+    ASSERT_EQ(100, ps->ps_bounds.as_double.ps_max);
 }
 
 MTF_DEFINE_UTEST_PRE(kvdb_rparams_test, keylock_tables, test_pre)


### PR DESCRIPTION
It seems that when Gaurav reworked cNDB, cndb_compact_hwm_max went through an interation where it was a uint32_t for a bit and was then changed when Alex added support for PARAM_TYPE_DOUBLE.

Signed-off-by: Tristan Partin <tpartin@micron.com>
