### PR TITLE
Cleanup some node/kvset split related code

### DIFF
--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -1772,7 +1772,7 @@ kvset_get_nth_vblock_id(struct kvset *ks, u32 index)
     return (index < ks->ks_st.kst_vblks ? lvx2mbid(ks, index) : 0);
 }
 
-u64
+uint32_t
 kvset_get_nth_vblock_len(struct kvset *ks, u32 index)
 {
     struct vblock_desc *vbd = lvx2vbd(ks, index);
@@ -2581,7 +2581,7 @@ kvset_iter_create(
         iter->reverse = reverse;
     }
 
-    iter->vra_len = min_t(u32, iter->vra_len, 1024 * 1024);
+    iter->vra_len = min_t(u32, iter->vra_len, HSE_KVS_VALUE_LEN_MAX);
     iter->vra_wq = vra_wq;
 
     iter->workq = io_workq;
@@ -2793,7 +2793,8 @@ kvset_iter_seek(struct kv_iterator *handle, const void *key, s32 len, bool *eof)
 
         if (cmp > 0) {
             kvset_iter_mark_eof(handle);
-            *eof = true;
+            if (eof)
+                *eof = true;
             return 0;
         }
     }
@@ -2882,7 +2883,8 @@ kvset_iter_seek(struct kv_iterator *handle, const void *key, s32 len, bool *eof)
 
     iter->last = SRC_NONE;
 
-    *eof = handle->kvi_eof = iter->pti_meta.eof && iter->wbti_meta.eof;
+    if (eof)
+        *eof = handle->kvi_eof = iter->pti_meta.eof && iter->wbti_meta.eof;
 
     wbti_destroy(wbti);
     wbti_destroy(pti);

--- a/lib/cn/kvset.h
+++ b/lib/cn/kvset.h
@@ -353,7 +353,7 @@ kvset_set_rule(struct kvset *ks, enum cn_rule rule);
  * kvset_get_nth_vblock_len() - Get len of useful data in nth vblock
  */
 /* MTF_MOCK */
-u64
+uint32_t
 kvset_get_nth_vblock_len(struct kvset *km, u32 index);
 
 /* MTF_MOCK */

--- a/lib/cn/kvset_split.h
+++ b/lib/cn/kvset_split.h
@@ -6,17 +6,14 @@
 #ifndef HSE_KVS_CN_KVSET_SPLIT_H
 #define HSE_KVS_CN_KVSET_SPLIT_H
 
+#include <stdatomic.h>
+
 #include <hse/error/merr.h>
 #include <hse/ikvdb/blk_list.h>
 #include <hse/util/inttypes.h>
 #include <hse/util/hlog.h>
 #include <hse/util/key_util.h>
-
-#include "kblock_reader.h"
-#include "wbt_reader.h"
-#include "cn_tree.h"
-#include "hblock_reader.h"
-#include "hblock_builder.h"
+#include <hse/util/workqueue.h>
 
 struct kvset;
 

--- a/lib/cn/node_split.c
+++ b/lib/cn/node_split.c
@@ -441,8 +441,23 @@ out:
     return err;
 }
 
-merr_t
-cn_tree_node_get_split_key(
+/**
+ * Return an optimal key to split a node on.
+ *
+ * When a node grows to large, it must be split into two ideally equal size
+ * nodes. This function will look for a key that has equal amounts of data on
+ * either side of it.
+ *
+ * @param node Tree node.
+ * @param key_buf Key buffer in which to copy out the split key.
+ * @param key_buf_sz Size of @p key_buf.
+ *
+ * @remark Caller must take the cN tree read lock before calling this function.
+ *
+ * @returns Error status.
+ */
+static merr_t HSE_NONNULL(1, 2, 4)
+get_split_key(
     const struct cn_tree_node *const node,
     void *const key_buf,
     const size_t key_buf_sz,
@@ -527,8 +542,7 @@ cn_split(struct cn_compaction_work *w)
 
     cndb = cn_tree_get_cndb(w->cw_tree);
 
-    err = cn_tree_node_get_split_key(w->cw_node, w->cw_split.key, HSE_KVS_KEY_LEN_MAX,
-                                     &w->cw_split.klen);
+    err = get_split_key(w->cw_node, w->cw_split.key, HSE_KVS_KEY_LEN_MAX, &w->cw_split.klen);
     if (err)
         return err;
 

--- a/lib/cn/node_split.h
+++ b/lib/cn/node_split.h
@@ -13,29 +13,8 @@
 
 #include "kvset_split.h"
 
+struct cn_compaction_work;
 struct cn_tree_node;
-
-/**
- * Return an optimal key to split a node on.
- *
- * When a node grows to large, it must be split into two ideally equal size
- * nodes. This function will look for a key that has equal amounts of data on
- * either side of it.
- *
- * @param node: Tree node.
- * @param key_buf: Key buffer in which to copy out the split key.
- * @param key_buf_sz: Size of @p key_buf.
- *
- * @remark Caller must take the cN tree read lock before calling this function.
- *
- * @returns Error status.
- */
-merr_t
-cn_tree_node_get_split_key(
-    const struct cn_tree_node *node,
-    void *key_buf,
-    size_t key_buf_sz,
-    unsigned int *key_len) HSE_NONNULL(1);
 
 /**
  * cn_split() - Build kvsets as part of a node split operation

--- a/tests/mocks/repository/lib/mock_kvset.c
+++ b/tests/mocks/repository/lib/mock_kvset.c
@@ -365,7 +365,7 @@ _kvset_get_nth_vblock_id(struct kvset *kvset, u32 index)
     return (index < mk->stats.kst_vblks ? mk->ids[vblk_index_base + index] : 0);
 }
 
-static u64
+static uint32_t
 _kvset_get_nth_vblock_len(struct kvset *kvset, u32 index)
 {
     struct mock_kvset *mk = (void *)kvset;


### PR DESCRIPTION
- Fix some includes
- Make passing eof optional to kvset_iter_create()
- Make function static that no longer needs to be exposed
- Save a split key copy

Signed-off-by: Tristan Partin <tpartin@micron.com>
