### PR TITLE
Fix display of errant log message

### DIFF
--- a/lib/binding/diag_kvdb_interface.c
+++ b/lib/binding/diag_kvdb_interface.c
@@ -51,7 +51,7 @@ diag_kvdb_open(
         goto close_mp;
 
     err = kvdb_home_get_config(kvdb_home, &conf);
-    if (err)
+    if (err && merr_errno(err) != ENOENT)
         goto close_mp;
 
     err = kvdb_rparams_from_config(&params, conf);

--- a/lib/config/lib/config.c
+++ b/lib/config/lib/config.c
@@ -32,13 +32,11 @@ config_open(const char *const path, config_validator_t validate, cJSON **const c
     fd = open(path, O_RDONLY);
     if (fd == -1) {
         err = merr(errno);
-        log_errx("Failed to open %s", err, path);
         return err;
     }
 
     if (fstat(fd, &st) == -1) {
         err = merr(errno);
-        log_errx("Failed to get the size of %s", err, path);
         goto out;
     }
 
@@ -50,14 +48,12 @@ config_open(const char *const path, config_validator_t validate, cJSON **const c
 
     if (read(fd, str, st.st_size) == -1) {
         err = merr(errno);
-        log_errx("Failed to read %s", err, path);
         goto out;
     }
 
     impl = cJSON_ParseWithLength(str, st.st_size);
     if (!impl) {
         if (cJSON_GetErrorPtr()) {
-            log_err("%s is not a valid config file: %s", path, cJSON_GetErrorPtr());
             err = merr(EINVAL);
         } else {
             err = merr(ENOMEM);
@@ -66,16 +62,13 @@ config_open(const char *const path, config_validator_t validate, cJSON **const c
     }
 
     if (!cJSON_IsObject(impl)) {
-        log_err("%s is not a valid config file", path);
         err = merr(EINVAL);
         goto out;
     }
 
     err = validate ? validate(impl) : 0;
-    if (err) {
-        log_errx("Failed to validate %s", err, path);
+    if (err)
         goto out;
-    }
 
     *config = impl;
 

--- a/lib/kvdb/kvdb_home.c
+++ b/lib/kvdb/kvdb_home.c
@@ -10,7 +10,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <bsd/string.h>
 


### PR DESCRIPTION
On KVS open, a message would be logged that the kvdb.conf doesn't exist. This is not an actual error that should be logged since kvdb.conf files are optional to have.

Signed-off-by: Tristan Partin <tpartin@micron.com>
