### PR TITLE
Handle failure if mbset cannot be created

### DIFF
--- a/lib/cn/kvset.c
+++ b/lib/cn/kvset.c
@@ -729,6 +729,8 @@ kvset_open(struct cn_tree *tree, uint64_t kvsetid, struct kvset_meta *km, struct
     if (idc) {
         err = mbset_create(cn_tree_get_mp(tree), idc, idv, sizeof(struct vblock_desc),
             vblock_udata_init, &vbset);
+        if (ev(err))
+            return err;
         len = 1;
         vbsetc = 1;
     }


### PR DESCRIPTION
For whatever reason this was ignored, but should definitely be bubbled up. Otherwise, you end up in UB territory down the road.

Signed-off-by: Tristan Partin <tpartin@micron.com>
