### PR TITLE
Fix clang-format AlignAfterOpenBracket

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@
 
 Language: Cpp
 AccessModifierOffset: -2
-AlignAfterOpenBracket: DontAlign
+AlignAfterOpenBracket: AlwaysBreak
 AlignConsecutiveMacros: Consecutive
 AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: None


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>
