### PR TITLE
Add cast to silence -Wconversion on s390x

### DIFF
--- a/lib/util/include/hse/util/arch.h
+++ b/lib/util/include/hse/util/arch.h
@@ -116,7 +116,7 @@ get_time_ns(void)
 
     /* Convert from fractions of (usecs / 1024) to nsecs.
      */
-    return (cycles * 1000) / 1024;
+    return (uint64_t)((cycles * 1000) / 1024);
 }
 
 #else


### PR DESCRIPTION
I don't understand why this is only now showing up, but this is a pretty obvious truncation, so perform the arithmetic on the 128 bit uint, and then cast.

Signed-off-by: Tristan Partin <tpartin@micron.com>
