### PR TITLE
Remove unused include

### DIFF
--- a/lib/config/lib/params.c
+++ b/lib/config/lib/params.c
@@ -15,7 +15,6 @@
 
 #include <bsd/string.h>
 #include <cjson/cJSON.h>
-#include <cjson/cJSON_Utils.h>
 
 #include <hse/config/params.h>
 #include <hse/logging/logging.h>


### PR DESCRIPTION
This include was unused and isn't provided by the cjson_dep. This library also doesn't link against the cjson_utils_dep.

Signed-off-by: Tristan Partin <tpartin@micron.com>
