### PR TITLE
Add back --fatal-meson-warnings to asan-ubsan build

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -306,9 +306,9 @@ jobs:
             MESON_ARGS="-Db_lundef=false"
           fi
 
-          meson setup builddir --werror --buildtype=${{ matrix.buildtype }} \
-            -Db_sanitize=address,undefined $MESON_ARGS -Dtools=enabled \
-            -Ddocs=disabled -Dbindings=none
+          meson setup builddir --fatal-meson-warnings --werror \
+            --buildtype=${{ matrix.buildtype }} -Db_sanitize=address,undefined \
+            $MESON_ARGS -Dtools=enabled -Ddocs=disabled -Dbindings=none
 
       - name: Build
         run: |


### PR DESCRIPTION
Now that all the alignment issues are fixed, this is good to go back in.